### PR TITLE
fix course dashboard on mobile

### DIFF
--- a/resources/views/pages/dashboard.blade.php
+++ b/resources/views/pages/dashboard.blade.php
@@ -1,5 +1,5 @@
 <x-filament-panels::page>
-    <div class="grid grid-cols-3 gap-y-4 sm:grid-cols-2 sm:gap-x-6 sm:gap-y-10 lg:grid-cols-3 lg:gap-x-8">
+    <div class="grid grid-cols-1 gap-y-4 sm:grid-cols-2 sm:gap-x-6 sm:gap-y-10 lg:grid-cols-3 lg:gap-x-8">
         @foreach ($courses as $course)
             <x-filament-lms::course-card :course="$course"/>
         @endforeach


### PR DESCRIPTION
sets default col-span to 1 to prevent crazy bunching on mobile.