### PR TITLE
Remove extra navigation from config

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,11 +138,6 @@ return [
     ],
     'top_navigation' => false,
     'show_exit_lms_link' => true,
-    'extra_navigation_items' => [
-        NavigationItem::make('Home')
-            ->icon('heroicon-o-home')
-            ->url(fn (): string => '/'),
-    ],
 ];
 
 ```
@@ -155,23 +150,22 @@ Set it to `true` to use top navigation instead of left sidebar on courses page.
 
 Use to display or not the `Exit LMS` link on top bar.
 
-### extra_navigation_items
+## Adding extra navigation items
 
-By default the `Home` extra navigation item is added:
+To register new navigation items in the LMS panel, use the `boot()` method of your `AppPanelProvider.php` file:
 
 ```php
-    'extra_navigation_items' => [
+use Tapp\FilamentLms\LmsNavigation;
+use Filament\Navigation\NavigationItem;
+
+public function boot(): void
+{
+    LmsNavigation::addNavigation('lms',
         NavigationItem::make('Home')
             ->icon('heroicon-o-home')
             ->url(fn (): string => '/'),
-    ],
-```
-
-More navigation items can be added using this config if needed.
-If you don't want to display extra menu items, set this config as an empty array:
-
-```php
-'extra_navigation_items' => [],
+    );
+}
 ```
 
 ## Authorization

--- a/config/filament-lms.php
+++ b/config/filament-lms.php
@@ -16,11 +16,7 @@ return [
     ],
     'top_navigation' => false,
     'show_exit_lms_link' => true,
-    'extra_navigation_items' => [
-        NavigationItem::make('Home')
-            ->icon('heroicon-o-home')
-            ->url(fn (): string => '/'),
-    ],
+
     // If true, users only see courses they are assigned to via lms_course_user. If false, all courses are visible.
     'restrict_course_visibility' => false,
 ];

--- a/config/filament-lms.php
+++ b/config/filament-lms.php
@@ -1,7 +1,5 @@
 <?php
 
-use Filament\Navigation\NavigationItem;
-
 return [
     'theme' => 'default',
     'font' => 'Poppins',

--- a/src/LmsNavigation.php
+++ b/src/LmsNavigation.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Tapp\FilamentLms;
+
+use Filament\Navigation\NavigationItem;
+
+class LmsNavigation
+{
+    protected static array $extraNavigation = [];
+
+    public static function addNavigation(string $panelId, NavigationItem|callable $item): void
+    {
+        static::$extraNavigation[$panelId][] = $item;
+    }
+
+    public static function getNavigation(string $panelId): array
+    {
+        return collect(static::$extraNavigation[$panelId] ?? [])
+            ->map(fn ($item) => is_callable($item) ? $item() : $item)
+            ->all();
+    }
+}

--- a/src/LmsPanelProvider.php
+++ b/src/LmsPanelProvider.php
@@ -110,16 +110,16 @@ class LmsPanelProvider extends PanelProvider
 
     public function navigationItems(NavigationBuilder $builder): NavigationBuilder
     {
-        $extraNavigationItems = config('filament-lms.extra_navigation_items');
+        $hookedNavigationItems = LmsNavigation::getNavigation('lms');
 
         if (Route::current()->parameter('courseSlug')) {
             filament()->getCurrentPanel()->topNavigation(false);
 
             FilamentView::registerRenderHook(
                 PanelsRenderHook::TOPBAR_START,
-                function () use ($extraNavigationItems): View {
+                function () use ($hookedNavigationItems): View {
                     $topNavigation = [
-                        ...$extraNavigationItems,
+                        ...$hookedNavigationItems,
                         NavigationItem::make('Courses')
                             ->icon('heroicon-o-academic-cap')
                             ->isActiveWhen(fn (): bool => request()->routeIs(Dashboard::getRouteName()))
@@ -164,7 +164,7 @@ class LmsPanelProvider extends PanelProvider
         }
 
         return $builder->items([
-            ...$extraNavigationItems,
+            ...$hookedNavigationItems,
             NavigationItem::make('Courses')
                 ->icon('heroicon-o-academic-cap')
                 ->isActiveWhen(fn (): bool => request()->routeIs(Dashboard::getRouteName()))

--- a/src/LmsPanelProvider.php
+++ b/src/LmsPanelProvider.php
@@ -140,7 +140,7 @@ class LmsPanelProvider extends PanelProvider
                 /** @var \Tapp\FilamentLms\Models\Lesson $lesson */
                 return NavigationGroup::make($lesson->name)
                     ->collapsed(fn (): bool => ! $lesson->isActive())
-                    //->collapsible(true)
+                    // ->collapsible(true)
                     ->items($lesson->steps->map(function ($step) {
                         /** @var \Tapp\FilamentLms\Models\Step $step */
                         return NavigationItem::make($step->name)

--- a/src/LmsPanelProvider.php
+++ b/src/LmsPanelProvider.php
@@ -139,9 +139,8 @@ class LmsPanelProvider extends PanelProvider
             $navigationGroups = $course->lessons->map(function ($lesson) {
                 /** @var \Tapp\FilamentLms\Models\Lesson $lesson */
                 return NavigationGroup::make($lesson->name)
-                    // TODO collapsed is not working
-                    // ->collapsed(fn (): bool => ! $lesson->isActive())
-                    // ->collapsible(true)
+                    ->collapsed(fn (): bool => ! $lesson->isActive())
+                    //->collapsible(true)
                     ->items($lesson->steps->map(function ($step) {
                         /** @var \Tapp\FilamentLms\Models\Step $step */
                         return NavigationItem::make($step->name)
@@ -151,12 +150,15 @@ class LmsPanelProvider extends PanelProvider
                     })->toArray());
             })->toArray();
 
-            $navigationGroups[] = NavigationGroup::make('Course Completed')->items([
-                NavigationItem::make('Certificate')
-                    ->icon('heroicon-o-trophy')
-                    ->url(fn (): string => CourseCompleted::getUrl([$course->slug]))
-                    ->isActiveWhen(fn (): bool => request()->routeIs(CourseCompleted::getRouteName())),
-            ]);
+            $navigationGroups[] = NavigationGroup::make('Course Completed')
+                ->collapsed(fn (): bool => ! request()->routeIs(CourseCompleted::getRouteName()))
+                ->collapsible(true)
+                ->items([
+                    NavigationItem::make('Certificate')
+                        ->icon('heroicon-o-trophy')
+                        ->url(fn (): string => CourseCompleted::getUrl([$course->slug]))
+                        ->isActiveWhen(fn (): bool => request()->routeIs(CourseCompleted::getRouteName())),
+                ]);
 
             $builder->groups($navigationGroups);
 

--- a/src/Models/Lesson.php
+++ b/src/Models/Lesson.php
@@ -43,7 +43,7 @@ class Lesson extends Model implements Sortable
         if (request()->is('*/'.$this->course->slug.'/'.$this->slug.'*')) {
             return true;
         }
-        
+
         // Then check if any step in this lesson is currently active
         return $this->steps->contains(function ($step) {
             return $step->isActive();

--- a/src/Models/Lesson.php
+++ b/src/Models/Lesson.php
@@ -39,7 +39,15 @@ class Lesson extends Model implements Sortable
 
     public function isActive()
     {
-        return request()->is('*'.$this->slug.'*');
+        // First check if we're on a lesson URL pattern
+        if (request()->is('*/'.$this->course->slug.'/'.$this->slug.'*')) {
+            return true;
+        }
+        
+        // Then check if any step in this lesson is currently active
+        return $this->steps->contains(function ($step) {
+            return $step->isActive();
+        });
     }
 
     public function getCompletedAtAttribute()


### PR DESCRIPTION
Remove extra navigation from config file to avoid serialization errors when using config:cache.

To register new navigation items in the LMS panel, use the boot() method of your AppPanelProvider.php file:

```php
use Tapp\FilamentLms\LmsNavigation;
use Filament\Navigation\NavigationItem;

public function boot(): void
{
    LmsNavigation::addNavigation('lms',
        NavigationItem::make('Home')
            ->icon('heroicon-o-home')
            ->url(fn (): string => '/'),
    );
}
```

- [x] Remove extra navigation from config
- [x] Collapsible lessons