### PR TITLE
disable top navigation on course pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,7 +225,9 @@ return [
 
 ### top_navigation
 
-Set it to `true` to use top navigation instead of left sidebar on courses page.
+Set it to `true` to enable top navigation on the LMS dashboard (courses list page). 
+
+**Note:** This configuration only affects the dashboard. Course pages (when viewing individual steps) always use sidebar navigation, regardless of this setting.
 
 ### show_exit_lms_link
 

--- a/config/filament-lms.php
+++ b/config/filament-lms.php
@@ -12,6 +12,8 @@ return [
     'awards' => [
         'Default' => 'default',
     ],
+    // Enable top navigation on the LMS dashboard (courses list page).
+    // Note: This only affects the dashboard. Course pages always use sidebar navigation.
     'top_navigation' => false,
     'show_exit_lms_link' => true,
 

--- a/src/LmsPanelProvider.php
+++ b/src/LmsPanelProvider.php
@@ -53,9 +53,27 @@ class LmsPanelProvider extends PanelProvider
             $panel->viteTheme(config('filament-lms.vite_theme'));
         }
 
+        // Enable top navigation for the dashboard (only affects non-course pages)
         if (config('filament-lms.top_navigation')) {
             $panel->topNavigation();
         }
+
+        // Disable top navigation dynamically when on a course page
+        // This needs to happen before the layout is rendered
+        Filament::serving(function () {
+            if (Filament::getCurrentOrDefaultPanel()->getId() !== 'lms') {
+                return;
+            }
+
+            $courseSlug = Route::current()?->parameter('courseSlug')
+                ?? request()->route('courseSlug')
+                ?? request()->route()?->parameter('courseSlug');
+
+            if ($courseSlug) {
+                $panel = Filament::getPanel('lms');
+                $panel->topNavigation(false);
+            }
+        });
 
         if (config('filament-lms.brand_logo')) {
             $panel->brandLogo(asset(config('filament-lms.brand_logo')));
@@ -120,9 +138,12 @@ class LmsPanelProvider extends PanelProvider
 
         $hookedNavigationItems = LmsNavigation::getNavigation('lms');
 
-        if (Route::current()->parameter('courseSlug')) {
-            filament()->getCurrentOrDefaultPanel()->topNavigation(false);
+        // Try multiple methods to get the courseSlug parameter
+        $courseSlug = Route::current()?->parameter('courseSlug')
+            ?? request()->route('courseSlug')
+            ?? request()->route()?->parameter('courseSlug');
 
+        if ($courseSlug) {
             FilamentView::registerRenderHook(
                 PanelsRenderHook::TOPBAR_LOGO_AFTER,
                 function () use ($hookedNavigationItems): View {
@@ -142,7 +163,7 @@ class LmsPanelProvider extends PanelProvider
                 },
             );
 
-            $course = Course::where('slug', Route::current()->parameter('courseSlug'))->firstOrFail();
+            $course = Course::where('slug', $courseSlug)->firstOrFail();
 
             $navigationGroups = $course->lessons->map(function ($lesson) {
                 /** @var Lesson $lesson */
@@ -179,7 +200,6 @@ class LmsPanelProvider extends PanelProvider
 
             return $builder;
         }
-
         return $builder->items([
             ...$hookedNavigationItems,
             NavigationItem::make('Courses')

--- a/src/LmsPanelProvider.php
+++ b/src/LmsPanelProvider.php
@@ -200,6 +200,7 @@ class LmsPanelProvider extends PanelProvider
 
             return $builder;
         }
+
         return $builder->items([
             ...$hookedNavigationItems,
             NavigationItem::make('Courses')


### PR DESCRIPTION
# Details

- disable top navigation on course pages
- clarify that top_navigation config option only affects lms dashboard