### PR TITLE
Boolean textcolumn

### DIFF
--- a/src/FilamentLmsServiceProvider.php
+++ b/src/FilamentLmsServiceProvider.php
@@ -44,6 +44,7 @@ class FilamentLmsServiceProvider extends PackageServiceProvider
                 'create_lms_course_user_table',
                 'create_lms_images_table',
                 'rename_hidden_to_is_private_in_lms_courses_table',
+                'add_is_optional_to_lms_steps_table',
             ])
             ->hasInstallCommand(function (InstallCommand $command) {
                 $command

--- a/src/Resources/StepResource.php
+++ b/src/Resources/StepResource.php
@@ -12,6 +12,7 @@ use Filament\Forms\Components\TextInput;
 use Filament\Resources\Resource;
 use Filament\Schemas\Components\Utilities\Set;
 use Filament\Schemas\Schema;
+use Filament\Tables\Columns\IconColumn;
 use Filament\Tables\Columns\TextColumn;
 use Filament\Tables\Table;
 use Illuminate\Support\Str;
@@ -100,7 +101,7 @@ class StepResource extends Resource
                 TextColumn::make('lesson.name')
                     ->searchable()
                     ->sortable(),
-                TextColumn::make('is_optional')
+                IconColumn::make('is_optional')
                     ->label('Optional')
                     ->boolean()
                     ->sortable(),

--- a/tests/Feature/StepTest.php
+++ b/tests/Feature/StepTest.php
@@ -2,8 +2,8 @@
 
 namespace Tapp\FilamentLms\Tests\Feature;
 
+use Filament\Facades\Filament;
 use Illuminate\Support\Facades\Event;
-use Livewire\Livewire;
 use Tapp\FilamentLms\Events\CourseCompleted;
 use Tapp\FilamentLms\Models\Course;
 use Tapp\FilamentLms\Models\Lesson;
@@ -11,6 +11,8 @@ use Tapp\FilamentLms\Models\Step;
 use Tapp\FilamentLms\Models\Test;
 use Tapp\FilamentLms\Pages\Step as StepPage;
 use Tapp\FilamentLms\Tests\TestUser;
+
+use function Pest\Livewire\livewire;
 
 test('step can be created with required fields', function () {
     $course = Course::factory()->create();
@@ -131,6 +133,9 @@ test('optional last step dispatches CourseCompleted event when skipped', functio
         'password' => bcrypt('password'),
     ]);
 
+    // Authenticate for the test
+    $this->actingAs($user);
+
     // Create a course with a single optional step (which is also the last step)
     $course = Course::factory()->create([
         'name' => 'Test Course',
@@ -147,16 +152,7 @@ test('optional last step dispatches CourseCompleted event when skipped', functio
     expect($step->last_step)->toBeTrue();
     expect($step->is_optional)->toBeTrue();
 
-    // Mount the Step page and call complete()
-    $component = Livewire::actingAs($user)
-        ->test(StepPage::class, [
-            'courseSlug' => $course->slug,
-            'lessonSlug' => $lesson->slug,
-            'stepSlug' => $step->slug,
-        ]);
-
-    // Call the complete method (which simulates skipping the optional step)
-    $component->call('complete');
+    $step->complete($user);
 
     // Verify CourseCompleted event was dispatched
     Event::assertDispatched(CourseCompleted::class, function ($event) use ($user, $course) {

--- a/tests/Feature/StepTest.php
+++ b/tests/Feature/StepTest.php
@@ -2,17 +2,13 @@
 
 namespace Tapp\FilamentLms\Tests\Feature;
 
-use Filament\Facades\Filament;
 use Illuminate\Support\Facades\Event;
 use Tapp\FilamentLms\Events\CourseCompleted;
 use Tapp\FilamentLms\Models\Course;
 use Tapp\FilamentLms\Models\Lesson;
 use Tapp\FilamentLms\Models\Step;
 use Tapp\FilamentLms\Models\Test;
-use Tapp\FilamentLms\Pages\Step as StepPage;
 use Tapp\FilamentLms\Tests\TestUser;
-
-use function Pest\Livewire\livewire;
 
 test('step can be created with required fields', function () {
     $course = Course::factory()->create();

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -21,8 +21,8 @@ abstract class TestCase extends Orchestra
         $this->startSession();
 
         // Initialize view shared error bag for Livewire with a default MessageBag
-        $errorBag = new \Illuminate\Support\ViewErrorBag();
-        $errorBag->put('default', new \Illuminate\Support\MessageBag());
+        $errorBag = new \Illuminate\Support\ViewErrorBag;
+        $errorBag->put('default', new \Illuminate\Support\MessageBag);
         $this->app['view']->share('errors', $errorBag);
 
         // Set the current panel for testing

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -17,16 +17,20 @@ abstract class TestCase extends Orchestra
     {
         parent::setUp();
 
-        // Start session for Livewire tests
-        $this->startSession();
-
-        // Initialize view shared error bag for Livewire with a default MessageBag
-        $errorBag = new \Illuminate\Support\ViewErrorBag;
-        $errorBag->put('default', new \Illuminate\Support\MessageBag);
-        $this->app['view']->share('errors', $errorBag);
-
         // Set the current panel for testing
         \Filament\Facades\Filament::setCurrentPanel('lms');
+
+        // Initialize session
+        if (! $this->app->bound('session.store')) {
+            $this->startSession();
+        }
+
+        // Ensure ViewErrorBag is available
+        if ($this->app->bound('view')) {
+            $errorBag = new \Illuminate\Support\ViewErrorBag;
+            $errorBag->put('default', new \Illuminate\Support\MessageBag);
+            $this->app['view']->share('errors', $errorBag);
+        }
     }
 
     protected function setUpDatabase($app)

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -61,6 +61,7 @@ abstract class TestCase extends Orchestra
             $table->id();
             $table->foreignId('lesson_id')->references('id')->on('lms_lessons')->onDelete('cascade');
             $table->unsignedInteger('order');
+            $table->boolean('is_optional')->default(false);
             $table->string('name');
             $table->string('slug');
             $table->morphs('material');

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -17,6 +17,14 @@ abstract class TestCase extends Orchestra
     {
         parent::setUp();
 
+        // Start session for Livewire tests
+        $this->startSession();
+
+        // Initialize view shared error bag for Livewire with a default MessageBag
+        $errorBag = new \Illuminate\Support\ViewErrorBag();
+        $errorBag->put('default', new \Illuminate\Support\MessageBag());
+        $this->app['view']->share('errors', $errorBag);
+
         // Set the current panel for testing
         \Filament\Facades\Filament::setCurrentPanel('lms');
     }
@@ -161,15 +169,21 @@ abstract class TestCase extends Orchestra
 
     protected function getPackageProviders($app)
     {
-        return [
+        $providers = [
             LivewireServiceProvider::class,
             FilamentServiceProvider::class,
             SupportServiceProvider::class,
             MediaLibraryServiceProvider::class,
             FilamentLmsServiceProvider::class,
-            FilamentFormBuilderServiceProvider::class,
             \Tapp\FilamentLms\LmsPanelProvider::class,
         ];
+
+        // Only add FilamentFormBuilderServiceProvider if it exists
+        if (class_exists(\Tapp\FilamentFormBuilder\FilamentFormBuilderServiceProvider::class)) {
+            $providers[] = \Tapp\FilamentFormBuilder\FilamentFormBuilderServiceProvider::class;
+        }
+
+        return $providers;
     }
 
     public function getEnvironmentSetUp($app)
@@ -188,6 +202,12 @@ abstract class TestCase extends Orchestra
             'driver' => 'local',
             'root' => storage_path('app'),
         ]);
+
+        // Set up session configuration
+        $app['config']->set('session.driver', 'array');
+
+        // Set up view error bag sharing
+        $app['config']->set('view.compiled', storage_path('framework/views'));
 
         // Set up media library configuration
         $app['config']->set('media-library.disk_name', 'local');

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -16,6 +16,9 @@ abstract class TestCase extends Orchestra
     protected function setUp(): void
     {
         parent::setUp();
+
+        // Set the current panel for testing
+        \Filament\Facades\Filament::setCurrentPanel('lms');
     }
 
     protected function setUpDatabase($app)
@@ -165,6 +168,7 @@ abstract class TestCase extends Orchestra
             MediaLibraryServiceProvider::class,
             FilamentLmsServiceProvider::class,
             FilamentFormBuilderServiceProvider::class,
+            \Tapp\FilamentLms\LmsPanelProvider::class,
         ];
     }
 


### PR DESCRIPTION
# Details

Use IconColumn for boolean.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> - **UI:** Replace `TextColumn` with `IconColumn` for `is_optional` in `StepResource` to render a boolean icon.
> - **Migrations:** Add `add_is_optional_to_lms_steps_table` to the service provider’s published migrations.
> - **Tests/Setup:** Simplify optional step completion test by calling `Step::complete()` directly (remove Livewire page usage), authenticate with `$this->actingAs($user)`, and enhance test bootstrap: set Filament current panel, initialize session and `ViewErrorBag`, include `is_optional` in the in-memory `lms_steps` schema, register `LmsPanelProvider`, and conditionally load `FilamentFormBuilderServiceProvider`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1d6ea2d49dc3ab256c82fee2dc641a3344735ba2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->