### PR TITLE
Test step perfect score tests

### DIFF
--- a/tests/Feature/TestStepCompletionTest.php
+++ b/tests/Feature/TestStepCompletionTest.php
@@ -83,6 +83,7 @@ test('test step cannot be completed if not all questions are correct', function 
         'material_type' => 'test',
         'material_id' => $test->id,
         'retry_step_id' => $reviewStep->id,
+        'require_perfect_score' => true,
     ]);
 
     // Create user entry with one wrong answer
@@ -173,6 +174,7 @@ test('test step can be completed if all questions are correct', function () {
         'slug' => 'test-step',
         'material_type' => 'test',
         'material_id' => $test->id,
+        'require_perfect_score' => true,
     ]);
 
     // Create user entry with all correct answers
@@ -263,6 +265,7 @@ test('test step shows retry link when test fails and retry step is configured', 
         'material_type' => 'test',
         'material_id' => $test->id,
         'retry_step_id' => $reviewStep->id,
+        'require_perfect_score' => true,
     ]);
 
     // Create user entry with wrong answer
@@ -286,6 +289,7 @@ test('test step shows retry link when test fails and retry step is configured', 
     expect($component->get('step')->retryStep)->not->toBeNull();
     expect($component->get('step')->retryStep->id)->toBe($reviewStep->id);
 
-    // Verify the view contains the retry link
-    $component->assertSee('Review Material and Retry');
+    // Verify the view contains the retry buttons
+    $component->assertSee('Review Material');
+    $component->assertSee('Retake Test');
 });


### PR DESCRIPTION
# Details

This PR fixes three bugs in `TestStepCompletionTest.php`:
1.  Ensures tests for the perfect score feature correctly set `require_perfect_score => true` in step factories, activating the feature for proper testing.
2.  Corrects a UI assertion to check for the actual "Review Material" and "Retake Test" button texts instead of a non-existent combined string.
3.  Activates the `require_perfect_score` flag in a test that was silently passing without verifying the intended perfect score behavior.

---

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Updates test coverage for perfect-score behavior and retry UI.
> 
> - Adds `require_perfect_score: true` to `Step` factories so tests actually exercise perfect-score logic
> - Fixes retry UI assertion to expect separate `Review Material` and `Retake Test` buttons
> - Verifies pass/fail and completion states align with rubric answers
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c69a9470af90c6a563f8c3a1fcabe064e66f6ca0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->