### PR TITLE
User entry ownership check

### DIFF
--- a/src/Livewire/TestStep.php
+++ b/src/Livewire/TestStep.php
@@ -52,6 +52,11 @@ class TestStep extends Component
 
     public function entrySaved(FilamentFormUser $entry)
     {
+        // Verify the entry belongs to the current user
+        if ($entry->user_id !== Auth::id()) {
+            return;
+        }
+
         $this->entry = $entry;
         $this->checkTestResults();
 


### PR DESCRIPTION
# Details

Addresses a security vulnerability where an attacker could potentially delete another user's test submission. The `entrySaved` event listener now verifies that the provided `FilamentFormUser` entry belongs to the current authenticated user before processing it, preventing unauthorized actions.

---

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds an authorization guard to ensure test submissions are only processed for the authenticated user.
> 
> - In `TestStep::entrySaved`, early-returns if `FilamentFormUser::$user_id` does not match `Auth::id()`, preventing actions (e.g., completion or deletion via retake) on another user's entry
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b8877d9f52f0ee73a7d35957155b0d58c2f80122. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->