### PR TITLE
Step URL and retry issues

### DIFF
--- a/resources/views/livewire/test-step.blade.php
+++ b/resources/views/livewire/test-step.blade.php
@@ -26,16 +26,9 @@
                                 </div>
                                 <div class="mt-4 flex gap-3">
                                     @if($step->retryStep)
-                                        @php
-                                            $retryStep = $step->retryStep;
-                                            if (!$retryStep->relationLoaded('lesson')) {
-                                                $retryStep->load('lesson.course');
-                                            }
-                                            $retryStepUrl = '/lms/courses/' . $retryStep->lesson->course->slug . '/' . $retryStep->lesson->slug . '/' . $retryStep->slug;
-                                        @endphp
                                         <x-filament::button
                                             tag="a"
-                                            :href="$retryStepUrl"
+                                            :href="$step->retryStep->url"
                                             color="danger"
                                             outlined
                                         >

--- a/src/Resources/StepResource.php
+++ b/src/Resources/StepResource.php
@@ -73,7 +73,22 @@ class StepResource extends Resource
                 Select::make('lesson_id')
                     ->relationship(name: 'lesson', titleAttribute: 'name')
                     ->preload()
-                    ->required(),
+                    ->required()
+                    ->live()
+                    ->afterStateUpdated(function (Set $set, ?string $state, $livewire) {
+                        // Clear retry_step_id if the lesson changes to a different course
+                        if ($state) {
+                            $newLesson = \Tapp\FilamentLms\Models\Lesson::find($state);
+                            $currentRetryStepId = $livewire->data['retry_step_id'] ?? null;
+
+                            if ($currentRetryStepId && $newLesson) {
+                                $retryStep = \Tapp\FilamentLms\Models\Step::find($currentRetryStepId);
+                                if ($retryStep && $retryStep->lesson->course_id !== $newLesson->course_id) {
+                                    $set('retry_step_id', null);
+                                }
+                            }
+                        }
+                    }),
                 Checkbox::make('is_optional')
                     ->label('Optional Step')
                     ->helperText('Optional steps can be skipped without completing them. Users can proceed to the next step without finishing optional steps.'),


### PR DESCRIPTION
# Details

This PR addresses two bugs related to URL generation and data integrity in the LMS module:

1.  **Hardcoded URL ignores tenancy and panel configuration**: The "Review Material" button in `test-step.blade.php` now uses the `Step` model's `url` attribute instead of a hardcoded path. This ensures URLs correctly respect multi-tenancy and custom Filament panel configurations.
2.  **Retry step can reference step in different course**: An `afterStateUpdated` hook has been added to the `lesson_id` field in `StepResource.php`. This hook clears the `retry_step_id` if the selected lesson changes to one belonging to a different course, preventing invalid cross-course step references.

---

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Improves URL correctness and enforces course consistency for retry steps.
> 
> - In `resources/views/livewire/test-step.blade.php`, "Review Material" now links to `{$step->retryStep->url}` instead of a hardcoded path, respecting tenancy and panel routing.
> - In `StepResource.php`, `Select('lesson_id')` is now `->live()` with an `afterStateUpdated` hook that clears `retry_step_id` when the selected lesson switches to a different course, preventing cross-course references.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bb6801a51fd439095c41de18ab4641ad6c4f6e0c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->