### PR TITLE
Store course completed_at on pivot and improve test step UI

### DIFF
--- a/database/migrations/add_completed_at_to_lms_course_user_table.php.stub
+++ b/database/migrations/add_completed_at_to_lms_course_user_table.php.stub
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('lms_course_user', function (Blueprint $table): void {
+            $table->timestamp('completed_at')->nullable()->after('updated_at');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('lms_course_user', function (Blueprint $table): void {
+            $table->dropColumn('completed_at');
+        });
+    }
+};

--- a/database/migrations/add_is_optional_to_lms_steps_table.php.stub
+++ b/database/migrations/add_is_optional_to_lms_steps_table.php.stub
@@ -11,7 +11,11 @@ return new class extends Migration
      */
     public function up(): void
     {
-        Schema::table('lms_steps', function (Blueprint $table) {
+        if (Schema::hasColumn('lms_steps', 'is_optional')) {
+            return;
+        }
+
+        Schema::table('lms_steps', function (Blueprint $table): void {
             $table->boolean('is_optional')->default(false)->after('order');
         });
     }
@@ -21,7 +25,11 @@ return new class extends Migration
      */
     public function down(): void
     {
-        Schema::table('lms_steps', function (Blueprint $table) {
+        if (! Schema::hasColumn('lms_steps', 'is_optional')) {
+            return;
+        }
+
+        Schema::table('lms_steps', function (Blueprint $table): void {
             $table->dropColumn('is_optional');
         });
     }

--- a/database/migrations/add_required_test_percentage_to_lms_courses_table.php.stub
+++ b/database/migrations/add_required_test_percentage_to_lms_courses_table.php.stub
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('lms_courses', function (Blueprint $table): void {
+            $table->unsignedTinyInteger('required_test_percentage')->nullable()->after('description');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('lms_courses', function (Blueprint $table): void {
+            $table->dropColumn('required_test_percentage');
+        });
+    }
+};

--- a/resources/views/livewire/test-step.blade.php
+++ b/resources/views/livewire/test-step.blade.php
@@ -4,8 +4,8 @@
             @livewire('view-graded-entry', ['test' => $test, 'entry' => $entry])
         </div>
         
-        @if(!$testPassed && $step->require_perfect_score)
-            <x-filament::section class="mt-8">
+        @if($testGrade !== null && $testGrade < 100.0 && $step->require_perfect_score)
+            <x-filament::section class="mt-6">
                 <div class="space-y-4">
                     <div class="rounded-lg bg-danger-50 dark:bg-danger-900/20 p-4">
                         <div class="flex">
@@ -22,6 +22,10 @@
                                 <div class="mt-2 text-sm text-danger-700 dark:text-danger-300">
                                     <p>
                                         You must answer all questions correctly to proceed. Please review the material and try again.
+                                        @if($step->lesson->course->required_test_percentage !== null)
+                                            <br><br>
+                                            <strong>Note:</strong> This course requires an overall test average of at least {{ $step->lesson->course->required_test_percentage }}% to receive your certificate.
+                                        @endif
                                     </p>
                                 </div>
                                 <div class="mt-4 flex gap-3">
@@ -44,6 +48,36 @@
                                 </div>
                             </div>
                         </div>
+                    </div>
+                </div>
+            </x-filament::section>
+        @elseif($testGrade !== null && $testGrade < 100.0)
+            <x-filament::section class="mt-6">
+                <div class="rounded-lg bg-gray-50 dark:bg-gray-800/50 p-4">
+                    <p class="text-sm text-gray-700 dark:text-gray-300">
+                        You didn't get a perfect score. You can continue or retake the test.
+                        @if($step->lesson->course->required_test_percentage !== null)
+                            <br><br>
+                            <strong>Note:</strong> This course requires an overall test average of at least {{ $step->lesson->course->required_test_percentage }}% to receive your certificate. Retaking this test now may help you meet that requirement.
+                        @endif
+                    </p>
+                    <div class="mt-3 flex gap-3">
+                        @if($step->retryStep)
+                            <x-filament::button
+                                tag="a"
+                                :href="$step->retryStep->url"
+                                color="gray"
+                                outlined
+                            >
+                                Review Material
+                            </x-filament::button>
+                        @endif
+                        <x-filament::button
+                            wire:click="retakeTest"
+                            color="primary"
+                        >
+                            Retake Test
+                        </x-filament::button>
                     </div>
                 </div>
             </x-filament::section>

--- a/resources/views/pages/course-completed.blade.php
+++ b/resources/views/pages/course-completed.blade.php
@@ -1,22 +1,84 @@
 <x-filament::section class="m-8">
-    <x-slot name="heading">
-    Congratulations! You have completed "{{ $course->name }}"
-    </x-slot>
+    @if($qualifiedForCertificate)
+        <x-slot name="heading">
+            Congratulations! You have completed "{{ $course->name }}"
+        </x-slot>
 
-    <x-slot name="headerEnd">
-    </x-slot>
+        <x-slot name="headerEnd">
+        </x-slot>
 
-    Download your certificate below.
+        Download your certificate below.
 
-    <div class="mt-4">
-    <a href="{{\Tapp\FilamentLms\Pages\Dashboard::getUrl()}}">
-        <x-filament::button color="gray">
-            View All Courses
-        </x-filament::button>
-    </a>
+        <div class="mt-4 flex gap-3">
+            <a href="{{ \Tapp\FilamentLms\Pages\Dashboard::getUrl() }}">
+                <x-filament::button color="gray">
+                    View All Courses
+                </x-filament::button>
+            </a>
+            <x-filament::button tag="a" href="{{ route('filament-lms::certificates.download', [$course->id]) }}">
+                Download Certificate
+            </x-filament::button>
+        </div>
+    @else
+        <x-slot name="heading">
+            You have completed all steps in "{{ $course->name }}"
+        </x-slot>
 
-    <x-filament::button tag="a" href="{{route('filament-lms::certificates.download', [$this->course->id])}}">
-        Download Certificate
-    </x-filament::button>
-    </div>
+        <x-slot name="headerEnd">
+        </x-slot>
+
+        <p class="text-gray-700 dark:text-gray-300 mb-4">
+            Your combined test score is {{ number_format($overallPercent ?? 0, 1) }}%. You need at least {{ $requiredPercent ?? 0 }}% to receive the certificate.
+        </p>
+
+        @if(!empty($testStepDetails))
+            <div class="mt-4 fi-infolist-ctn divide-y divide-gray-200 overflow-hidden rounded-xl bg-white shadow-sm ring-1 ring-gray-950/5 dark:divide-white/5 dark:bg-gray-900 dark:ring-white/10">
+                <dl class="divide-y divide-gray-200 dark:divide-white/5">
+                    @foreach($testStepDetails as $detail)
+                        <div class="fi-infolist-record px-4 py-6 sm:grid sm:grid-cols-3 sm:gap-4 sm:px-6">
+                            <dt class="text-sm font-medium leading-6 text-gray-950 dark:text-white">
+                                <a href="{{ $detail['url'] }}" class="text-primary-600 hover:text-primary-800 dark:text-primary-400 dark:hover:text-primary-300">
+                                    {{ $detail['name'] }}
+                                </a>
+                            </dt>
+                            <dd class="mt-1 flex items-center justify-between gap-x-4 text-sm leading-6 text-gray-500 dark:text-gray-400 sm:col-span-2 sm:mt-0">
+                                <div class="flex items-center gap-x-4">
+                                    <span class="font-medium text-gray-900 dark:text-white">{{ number_format($detail['percentage'], 1) }}%</span>
+                                </div>
+                                <div>
+                                    @if($detail['percentage'] < 100)
+                                        <a href="{{ $detail['url'] }}" class="fi-btn fi-btn-size-sm fi-btn-color-primary inline-flex items-center justify-center gap-x-1.5 rounded-lg px-2.5 py-1.5 text-sm font-semibold shadow-sm ring-1 transition duration-75 fi-color-primary bg-primary-600 text-white ring-primary-600 hover:bg-primary-700 dark:bg-primary-600 dark:text-white dark:ring-primary-500 dark:hover:bg-primary-700">
+                                            Retake
+                                        </a>
+                                    @else
+                                        <span class="text-gray-400 dark:text-gray-500">—</span>
+                                    @endif
+                                </div>
+                            </dd>
+                        </div>
+                    @endforeach
+                    <div class="fi-infolist-record px-4 py-6 sm:grid sm:grid-cols-3 sm:gap-4 sm:px-6 bg-gray-50 dark:bg-white/5">
+                        <dt class="text-sm font-semibold leading-6 text-gray-950 dark:text-white">
+                            Total
+                        </dt>
+                        <dd class="mt-1 flex items-center justify-between gap-x-4 text-sm leading-6 text-gray-500 dark:text-gray-400 sm:col-span-2 sm:mt-0">
+                            <div class="flex items-center gap-x-4">
+                                <span class="font-semibold text-gray-900 dark:text-white">{{ number_format($overallPercent ?? 0, 1) }}%</span>
+                            </div>
+                            <div>
+                                <span class="text-gray-400 dark:text-gray-500">—</span>
+                            </div>
+                        </dd>
+                    </div>
+                </dl>
+            </div>
+        @endif
+        <div class="mt-4">
+            <a href="{{ \Tapp\FilamentLms\Pages\Dashboard::getUrl() }}">
+                <x-filament::button color="gray">
+                    View All Courses
+                </x-filament::button>
+            </a>
+        </div>
+    @endif
 </x-filament::section>

--- a/src/FilamentLmsServiceProvider.php
+++ b/src/FilamentLmsServiceProvider.php
@@ -45,6 +45,8 @@ class FilamentLmsServiceProvider extends PackageServiceProvider
                 'rename_hidden_to_is_private_in_lms_courses_table',
                 'add_is_optional_to_lms_steps_table',
                 'add_test_step_features_to_lms_steps_table',
+                'add_required_test_percentage_to_lms_courses_table',
+                'add_completed_at_to_lms_course_user_table',
             ])
             ->hasInstallCommand(function (InstallCommand $command) {
                 $command

--- a/src/Livewire/TestStep.php
+++ b/src/Livewire/TestStep.php
@@ -18,6 +18,8 @@ class TestStep extends Component
 
     public bool $testPassed = false;
 
+    public ?float $testGrade = null;
+
     public ?FilamentFormUser $entry = null;
 
     protected $listeners = ['entrySaved'];
@@ -25,7 +27,7 @@ class TestStep extends Component
     public function mount($step)
     {
         $this->step = $step;
-        $this->step->load(['retryStep.lesson.course']);
+        $this->step->load(['retryStep.lesson.course', 'lesson.course']);
         $this->test = $step->material;
         $this->testCompleted = (bool) $step->completed_at;
 
@@ -81,6 +83,7 @@ class TestStep extends Component
         // Reset entry and completion status
         $this->entry = null;
         $this->testPassed = false;
+        $this->testGrade = null;
         $this->testCompleted = false;
 
         // Reset step completion if it was marked as completed
@@ -93,6 +96,7 @@ class TestStep extends Component
     {
         if (! $this->entry) {
             $this->testPassed = false;
+            $this->testGrade = null;
 
             return;
         }
@@ -102,9 +106,13 @@ class TestStep extends Component
         // Check if grade is an Exception (error)
         if ($grade instanceof \Exception) {
             $this->testPassed = false;
+            $this->testGrade = null;
 
             return;
         }
+
+        // Store the actual grade percentage
+        $this->testGrade = $grade;
 
         // If require_perfect_score is enabled, test passes only if 100% correct
         // Otherwise, any score passes

--- a/src/Livewire/TestStep.php
+++ b/src/Livewire/TestStep.php
@@ -90,6 +90,10 @@ class TestStep extends Component
         if ($this->step->completed_at) {
             $this->step->progress()->delete();
         }
+
+        // Clear course completion so it can be re-evaluated after the retake
+        $course = $this->step->lesson->course;
+        $course->users()->updateExistingPivot(Auth::id(), ['completed_at' => null]);
     }
 
     private function checkTestResults(): void

--- a/src/Livewire/ViewGradedEntry.php
+++ b/src/Livewire/ViewGradedEntry.php
@@ -100,8 +100,7 @@ class ViewGradedEntry extends Component implements HasForms, HasInfolists
                     })
                     ->collapsible()
                     ->collapsed()
-                    ->description('Click to view detailed question-by-question results')
-                    ->extraAttributes(['class' => 'mb-8']),
+                    ->description('Click to view detailed question-by-question results'),
             ]);
     }
 }

--- a/src/Models/Course.php
+++ b/src/Models/Course.php
@@ -223,12 +223,11 @@ final class Course extends Model implements HasMedia
 
         if ($this->required_test_percentage !== null) {
             $testSteps = $this->getOrderedTestSteps();
-            if ($testSteps->isEmpty()) {
-                return;
-            }
-            $overall = $this->getOverallTestPercentageForUser($userId);
-            if ($overall < (float) $this->required_test_percentage) {
-                return;
+            if ($testSteps->isNotEmpty()) {
+                $overall = $this->getOverallTestPercentageForUser($userId);
+                if ($overall < (float) $this->required_test_percentage) {
+                    return;
+                }
             }
         }
 

--- a/src/Models/Course.php
+++ b/src/Models/Course.php
@@ -222,9 +222,13 @@ final class Course extends Model implements HasMedia
         }
 
         if ($this->required_test_percentage !== null) {
-            $overall = $this->getOverallTestPercentageForUser($userId);
-            if ($overall < (float) $this->required_test_percentage) {
-                return;
+            $testSteps = $this->getOrderedTestSteps();
+            // Only apply test percentage requirement if there are test steps
+            if ($testSteps->isNotEmpty()) {
+                $overall = $this->getOverallTestPercentageForUser($userId);
+                if ($overall < (float) $this->required_test_percentage) {
+                    return;
+                }
             }
         }
 

--- a/src/Models/Course.php
+++ b/src/Models/Course.php
@@ -223,12 +223,12 @@ final class Course extends Model implements HasMedia
 
         if ($this->required_test_percentage !== null) {
             $testSteps = $this->getOrderedTestSteps();
-            // Only apply test percentage requirement if there are test steps
-            if ($testSteps->isNotEmpty()) {
-                $overall = $this->getOverallTestPercentageForUser($userId);
-                if ($overall < (float) $this->required_test_percentage) {
-                    return;
-                }
+            if ($testSteps->isEmpty()) {
+                return;
+            }
+            $overall = $this->getOverallTestPercentageForUser($userId);
+            if ($overall < (float) $this->required_test_percentage) {
+                return;
             }
         }
 

--- a/src/Models/Course.php
+++ b/src/Models/Course.php
@@ -1,7 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Tapp\FilamentLms\Models;
 
+use DateTimeInterface;
+use Exception;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
@@ -11,6 +15,7 @@ use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Support\Facades\Auth;
 use Spatie\MediaLibrary\HasMedia;
 use Spatie\MediaLibrary\InteractsWithMedia;
+use Tapp\FilamentFormBuilder\Models\FilamentFormUser;
 use Tapp\FilamentLms\Contracts\FilamentLmsUserInterface;
 use Tapp\FilamentLms\Database\Factories\CourseFactory;
 use Tapp\FilamentLms\Models\Traits\BelongsToTenant;
@@ -28,13 +33,14 @@ use Tapp\FilamentLms\Traits\HasMediaUrl;
  * @property string|null $award
  * @property array $award_content
  * @property string|null $description
+ * @property int|null $required_test_percentage
  * @property bool $is_private
  * @property \Carbon\Carbon $created_at
  * @property \Carbon\Carbon $updated_at
  * @property-read \Illuminate\Database\Eloquent\Collection|Lesson[] $lessons
  * @property-read \Illuminate\Database\Eloquent\Collection|Step[] $steps
  */
-class Course extends Model implements HasMedia
+final class Course extends Model implements HasMedia
 {
     use BelongsToTenant;
     use HasFactory;
@@ -90,11 +96,6 @@ class Course extends Model implements HasMedia
         })
         // Only include courses that have at least one step
             ->whereHas('steps');
-    }
-
-    protected static function newFactory()
-    {
-        return CourseFactory::new();
     }
 
     public function lessons(): HasMany
@@ -187,26 +188,47 @@ class Course extends Model implements HasMedia
             ->min('created_at');
     }
 
+    /**
+     * When the user completed this course (all steps + passing grade if required).
+     * Stored on lms_course_user.completed_at; set when they first qualify (including after retakes).
+     */
     public function completedByUserAt($userId): ?string
     {
-        $steps = $this->steps()->get();
+        $pivot = $this->users()->where('user_id', $userId)->first()?->pivot;
 
-        if ($steps->isEmpty()) {
+        if (! $pivot || $pivot->completed_at === null) {
             return null;
         }
 
-        // Get all completed steps for this specific user
-        $completedStepUsers = StepUser::whereIn('step_id', $steps->pluck('id'))
-            ->where('user_id', $userId)
-            ->whereNotNull('completed_at')
-            ->get();
+        $at = $pivot->completed_at;
 
-        // Check if all steps are completed (including optional steps)
-        if ($completedStepUsers->count() === $steps->count()) {
-            return $completedStepUsers->max('completed_at');
+        return $at instanceof DateTimeInterface ? $at->format('Y-m-d H:i:s') : (string) $at;
+    }
+
+    /**
+     * Set course completed_at for the user on the pivot when they have completed all steps
+     * and (if required) met the test percentage. Called after any step completion so that
+     * retaking a test and passing will set completed_at.
+     */
+    public function maybeSetCompletedAtForUser(int $userId): void
+    {
+        $existing = $this->users()->where('user_id', $userId)->first()?->pivot?->completed_at;
+        if ($existing !== null) {
+            return;
         }
 
-        return null;
+        if (! $this->allStepsCompletedByUser($userId)) {
+            return;
+        }
+
+        if ($this->required_test_percentage !== null) {
+            $overall = $this->getOverallTestPercentageForUser($userId);
+            if ($overall < (float) $this->required_test_percentage) {
+                return;
+            }
+        }
+
+        $this->users()->syncWithoutDetaching([$userId => ['completed_at' => now()]]);
     }
 
     public function getCompletedAtAttribute()
@@ -281,7 +303,29 @@ class Course extends Model implements HasMedia
     {
         $userModel = config('filament-lms.user_model');
 
-        return $this->belongsToMany($userModel, 'lms_course_user', 'course_id', 'user_id')->withTimestamps();
+        return $this->belongsToMany($userModel, 'lms_course_user', 'course_id', 'user_id')
+            ->withPivot('completed_at')
+            ->withTimestamps();
+    }
+
+    /**
+     * Check if all steps are completed by the user (regardless of test percentage requirement).
+     * This is useful for determining if a user has finished all steps but may not have met the test percentage requirement.
+     */
+    public function allStepsCompletedByUser(int $userId): bool
+    {
+        $steps = $this->steps()->get();
+
+        if ($steps->isEmpty()) {
+            return false;
+        }
+
+        $completedStepUsers = StepUser::whereIn('step_id', $steps->pluck('id'))
+            ->where('user_id', $userId)
+            ->whereNotNull('completed_at')
+            ->get();
+
+        return $completedStepUsers->count() === $steps->count();
     }
 
     /**
@@ -305,5 +349,102 @@ class Course extends Model implements HasMedia
 
         // Check if user is assigned to this course
         return $this->users()->where('user_id', $user->id)->exists();
+    }
+
+    /**
+     * Overall test percentage for the user across all test steps in this course (0–100).
+     * Steps with no entry or grading errors count as 0. Returns 0 if there are no test steps.
+     */
+    public function getOverallTestPercentageForUser(int $userId): float
+    {
+        $testSteps = $this->getOrderedTestSteps();
+
+        if ($testSteps->isEmpty()) {
+            return 0.0;
+        }
+
+        $sum = 0.0;
+        foreach ($testSteps as $step) {
+            $sum += $this->getTestStepPercentageForUser($step, $userId);
+        }
+
+        return round($sum / $testSteps->count(), 2);
+    }
+
+    /**
+     * First test step (in course order) where the user scored below 100%, or null if all are 100%.
+     */
+    public function getFirstTestStepBelowPerfectForUser(int $userId): ?Step
+    {
+        $testSteps = $this->getOrderedTestSteps();
+
+        foreach ($testSteps as $step) {
+            $pct = $this->getTestStepPercentageForUser($step, $userId);
+            if ($pct < 100) {
+                return $step;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * URL to the first test step below 100% for the user, or the dashboard URL if none.
+     */
+    public function getUrlToFirstTestStepBelowPerfectForUser(int $userId): string
+    {
+        $step = $this->getFirstTestStepBelowPerfectForUser($userId);
+
+        return $step ? StepPage::getUrlForStep($step) : Dashboard::getUrl();
+    }
+
+    /**
+     * Get all test steps for this course in lesson/step order.
+     *
+     * @return \Illuminate\Support\Collection<int, Step>
+     */
+    public function getOrderedTestSteps(): \Illuminate\Support\Collection
+    {
+        return $this->lessons()
+            ->with(['steps' => fn ($q) => $q->where('material_type', 'test')->orderBy('order')])
+            ->orderBy('order')
+            ->get()
+            ->pluck('steps')
+            ->flatten();
+    }
+
+    protected static function newFactory()
+    {
+        return CourseFactory::new();
+    }
+
+    /**
+     * Get the percentage score for a single test step for a user (0–100), or 0 if no entry or on error.
+     */
+    protected function getTestStepPercentageForUser(Step $step, int $userId): float
+    {
+        $step->load('material');
+        $test = $step->material;
+
+        if (! $test instanceof Test) {
+            return 0.0;
+        }
+
+        $entry = FilamentFormUser::where('filament_form_id', $test->filament_form_id)
+            ->where('user_id', $userId)
+            ->when($test->filament_form_user_id, fn ($q) => $q->where('id', '!=', $test->filament_form_user_id))
+            ->first();
+
+        if (! $entry) {
+            return 0.0;
+        }
+
+        $grade = $test->gradeEntry($entry);
+
+        if ($grade instanceof Exception) {
+            return 0.0;
+        }
+
+        return (float) $grade;
     }
 }

--- a/src/Models/Step.php
+++ b/src/Models/Step.php
@@ -118,9 +118,12 @@ class Step extends Model implements Sortable
                 'step_id' => $nextStep->id,
             ]);
 
+            $this->lesson->course->maybeSetCompletedAtForUser($user->id);
+
             return $nextStep;
         } else {
             CourseCompleted::dispatch($user, $this->lesson->course);
+            $this->lesson->course->maybeSetCompletedAtForUser($user->id);
         }
     }
 
@@ -155,7 +158,24 @@ class Step extends Model implements Sortable
 
     public function isActive()
     {
-        return request()->is('*'.$this->lesson->course->slug.'/'.$this->lesson->slug.'/'.$this->slug.'*');
+        $route = request()->route();
+        
+        if (! $route) {
+            return false;
+        }
+        
+        $courseSlug = $route->parameter('courseSlug');
+        $lessonSlug = $route->parameter('lessonSlug');
+        $stepSlug = $route->parameter('stepSlug');
+        
+        // Only check if we're on a step page (has these parameters)
+        if ($courseSlug === null || $lessonSlug === null || $stepSlug === null) {
+            return false;
+        }
+        
+        return $courseSlug === $this->lesson->course->slug
+            && $lessonSlug === $this->lesson->slug
+            && $stepSlug === $this->slug;
     }
 
     public function getUrlAttribute()

--- a/src/Models/Step.php
+++ b/src/Models/Step.php
@@ -159,20 +159,20 @@ class Step extends Model implements Sortable
     public function isActive()
     {
         $route = request()->route();
-        
+
         if (! $route) {
             return false;
         }
-        
+
         $courseSlug = $route->parameter('courseSlug');
         $lessonSlug = $route->parameter('lessonSlug');
         $stepSlug = $route->parameter('stepSlug');
-        
+
         // Only check if we're on a step page (has these parameters)
         if ($courseSlug === null || $lessonSlug === null || $stepSlug === null) {
             return false;
         }
-        
+
         return $courseSlug === $this->lesson->course->slug
             && $lessonSlug === $this->lesson->slug
             && $stepSlug === $this->slug;

--- a/src/Models/Test.php
+++ b/src/Models/Test.php
@@ -10,6 +10,10 @@ use Tapp\FilamentFormBuilder\Models\FilamentForm;
 use Tapp\FilamentFormBuilder\Models\FilamentFormUser;
 use Tapp\FilamentLms\Models\Traits\BelongsToTenant;
 
+/**
+ * @property int|null $filament_form_id
+ * @property int|null $filament_form_user_id
+ */
 class Test extends Model
 {
     use BelongsToTenant;

--- a/src/Pages/CourseCompleted.php
+++ b/src/Pages/CourseCompleted.php
@@ -22,8 +22,6 @@ final class CourseCompleted extends Page
 
     public ?int $requiredPercent = null;
 
-    public ?string $urlToFirstStepBelowPerfect = null;
-
     public array $testStepDetails = [];
 
     protected static string|BackedEnum|null $navigationIcon = 'heroicon-o-trophy';
@@ -57,12 +55,15 @@ final class CourseCompleted extends Page
         }
 
         if ($this->course->required_test_percentage !== null) {
-            $overall = $this->course->getOverallTestPercentageForUser(auth()->id());
-            if ($overall < (float) $this->course->required_test_percentage) {
-                $this->qualifiedForCertificate = false;
-                $this->overallPercent = $overall;
-                $this->requiredPercent = (int) $this->course->required_test_percentage;
-                $this->urlToFirstStepBelowPerfect = $this->course->getUrlToFirstTestStepBelowPerfectForUser(auth()->id());
+            $testSteps = $this->course->getOrderedTestSteps();
+            // Only check test percentage if there are test steps
+            if ($testSteps->isNotEmpty()) {
+                $overall = $this->course->getOverallTestPercentageForUser(auth()->id());
+                if ($overall < (float) $this->course->required_test_percentage) {
+                    $this->qualifiedForCertificate = false;
+                    $this->overallPercent = $overall;
+                    $this->requiredPercent = (int) $this->course->required_test_percentage;
+                }
             }
         }
 

--- a/src/Pages/CourseCompleted.php
+++ b/src/Pages/CourseCompleted.php
@@ -100,7 +100,7 @@ final class CourseCompleted extends Page
             $test->load('rubric');
             $rubric = $test->rubric;
 
-            if (! $rubric) {
+            if (! $rubric instanceof \Tapp\FilamentFormBuilder\Models\FilamentFormUser) {
                 continue;
             }
 

--- a/src/Pages/CourseCompleted.php
+++ b/src/Pages/CourseCompleted.php
@@ -1,16 +1,32 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Tapp\FilamentLms\Pages;
 
+use BackedEnum;
+use Exception;
 use Filament\Pages\Page;
 use Tapp\FilamentLms\Concerns\CourseLayout;
 use Tapp\FilamentLms\Models\Course;
 
-class CourseCompleted extends Page
+final class CourseCompleted extends Page
 {
     use CourseLayout;
 
-    protected static string|\BackedEnum|null $navigationIcon = 'heroicon-o-trophy';
+    public $course;
+
+    public bool $qualifiedForCertificate = true;
+
+    public ?float $overallPercent = null;
+
+    public ?int $requiredPercent = null;
+
+    public ?string $urlToFirstStepBelowPerfect = null;
+
+    public array $testStepDetails = [];
+
+    protected static string|BackedEnum|null $navigationIcon = 'heroicon-o-trophy';
 
     protected string $view = 'filament-lms::pages.course-completed';
 
@@ -19,8 +35,6 @@ class CourseCompleted extends Page
     protected static ?string $slug = '{courseSlug}/completed';
 
     protected static ?string $title = 'Course Completed';
-
-    public $course;
 
     public function mount($courseSlug)
     {
@@ -31,9 +45,10 @@ class CourseCompleted extends Page
             return redirect()->to(Dashboard::getUrl());
         }
 
-        if (! $this->course->completed_at) {
+        // Only redirect when the user has not completed all steps. Allow viewing this page when all steps
+        // are done even if required_test_percentage is not met (we show retake/certificate state below).
+        if (! $this->course->allStepsCompletedByUser(auth()->id())) {
             $currentStepUrl = $this->course->linkToCurrentStep();
-            // If linkToCurrentStep returns empty (no steps), redirect to dashboard
             if (empty($currentStepUrl)) {
                 return redirect()->to(Dashboard::getUrl());
             }
@@ -41,11 +56,98 @@ class CourseCompleted extends Page
             return redirect()->to($currentStepUrl);
         }
 
+        if ($this->course->required_test_percentage !== null) {
+            $overall = $this->course->getOverallTestPercentageForUser(auth()->id());
+            if ($overall < (float) $this->course->required_test_percentage) {
+                $this->qualifiedForCertificate = false;
+                $this->overallPercent = $overall;
+                $this->requiredPercent = (int) $this->course->required_test_percentage;
+                $this->urlToFirstStepBelowPerfect = $this->course->getUrlToFirstTestStepBelowPerfectForUser(auth()->id());
+            }
+        }
+
+        // Collect test step details for the table
+        $this->testStepDetails = $this->getTestStepDetails();
+
         $this->registerCourseLayout();
     }
 
     public function downloadCertificate()
     {
         return response()->download(route('certificates.download', [auth()->user()->id, $this->course->id]));
+    }
+
+    /**
+     * Get test step details for display in the table.
+     *
+     * @return array<int, array{name: string, total_questions: int, correct_questions: int, percentage: float, url: string}>
+     */
+    protected function getTestStepDetails(): array
+    {
+        $testSteps = $this->course->getOrderedTestSteps();
+        $userId = auth()->id();
+        $details = [];
+
+        foreach ($testSteps as $step) {
+            $step->load('material');
+            $test = $step->material;
+
+            if (! $test instanceof \Tapp\FilamentLms\Models\Test) {
+                continue;
+            }
+
+            $test->load('rubric');
+            $rubric = $test->rubric;
+
+            if (! $rubric) {
+                continue;
+            }
+
+            $totalQuestions = count($rubric->entry);
+
+            $entry = \Tapp\FilamentFormBuilder\Models\FilamentFormUser::where('filament_form_id', $test->filament_form_id)
+                ->where('user_id', $userId)
+                ->when($test->filament_form_user_id, fn ($q) => $q->where('id', '!=', $test->filament_form_user_id))
+                ->first();
+
+            if (! $entry) {
+                $details[] = [
+                    'name' => $step->name,
+                    'total_questions' => $totalQuestions,
+                    'correct_questions' => 0,
+                    'percentage' => 0.0,
+                    'url' => Step::getUrlForStep($step),
+                ];
+
+                continue;
+            }
+
+            $grade = $test->gradeEntry($entry);
+
+            if ($grade instanceof Exception) {
+                $details[] = [
+                    'name' => $step->name,
+                    'total_questions' => $totalQuestions,
+                    'correct_questions' => 0,
+                    'percentage' => 0.0,
+                    'url' => Step::getUrlForStep($step),
+                ];
+
+                continue;
+            }
+
+            $percentage = (float) $grade;
+            $correctQuestions = (int) round(($percentage / 100) * $totalQuestions);
+
+            $details[] = [
+                'name' => $step->name,
+                'total_questions' => $totalQuestions,
+                'correct_questions' => $correctQuestions,
+                'percentage' => $percentage,
+                'url' => Step::getUrlForStep($step),
+            ];
+        }
+
+        return $details;
     }
 }

--- a/src/Pages/CourseCompleted.php
+++ b/src/Pages/CourseCompleted.php
@@ -70,6 +70,15 @@ final class CourseCompleted extends Page
         // Collect test step details for the table
         $this->testStepDetails = $this->getTestStepDetails();
 
+        // Backfill completed_at if user qualifies but it was never set (e.g. course had required_test_percentage but no test steps).
+        $this->course->maybeSetCompletedAtForUser(auth()->id());
+
+        // Only show certificate UI when the user has actually completed the course (completed_at set).
+        // Prevents 403 on download when e.g. required_test_percentage is set but course has no test steps.
+        if ($this->course->completedByUserAt(auth()->id()) === null) {
+            $this->qualifiedForCertificate = false;
+        }
+
         $this->registerCourseLayout();
     }
 

--- a/src/Pages/Reporting.php
+++ b/src/Pages/Reporting.php
@@ -136,11 +136,11 @@ class Reporting extends Page implements HasTable
                         return $query
                             ->when(
                                 $data['completed_from'],
-                                fn (Builder $query, $date): Builder => $query->whereDate('lms_step_user.completed_at', '>=', $date),
+                                fn (Builder $q, $date): Builder => $q->whereDate('lms_course_user.completed_at', '>=', $date),
                             )
                             ->when(
                                 $data['completed_until'],
-                                fn (Builder $query, $date): Builder => $query->whereDate('lms_step_user.completed_at', '<=', $date),
+                                fn (Builder $q, $date): Builder => $q->whereDate('lms_course_user.completed_at', '<=', $date),
                             );
                     })
                     ->indicateUsing(function (array $data): array {
@@ -163,36 +163,10 @@ class Reporting extends Page implements HasTable
                         'In Progress' => 'In Progress',
                     ])
                     ->query(function (Builder $query, array $data): Builder {
-                        return $query->when($data['value'], function ($query, $status) {
-                            if ($status === 'Completed') {
-                                return $query->whereRaw('(SELECT COUNT(DISTINCT s2.step_id) FROM lms_step_user s2
-                                    WHERE s2.user_id = lms_step_user.user_id
-                                    AND s2.completed_at IS NOT NULL
-                                    AND s2.step_id IN (
-                                        SELECT s3.id FROM lms_steps s3
-                                        JOIN lms_lessons l3 ON s3.lesson_id = l3.id
-                                        WHERE l3.course_id = lms_courses.id
-                                    )) = (
-                                    SELECT COUNT(DISTINCT s4.id)
-                                    FROM lms_steps s4
-                                    JOIN lms_lessons l4 ON s4.lesson_id = l4.id
-                                    WHERE l4.course_id = lms_courses.id
-                                )');
-                            } else {
-                                return $query->whereRaw('(SELECT COUNT(DISTINCT s2.step_id) FROM lms_step_user s2
-                                    WHERE s2.user_id = lms_step_user.user_id
-                                    AND s2.completed_at IS NOT NULL
-                                    AND s2.step_id IN (
-                                        SELECT s3.id FROM lms_steps s3
-                                        JOIN lms_lessons l3 ON s3.lesson_id = l3.id
-                                        WHERE l3.course_id = lms_courses.id
-                                    )) < (
-                                    SELECT COUNT(DISTINCT s4.id)
-                                    FROM lms_steps s4
-                                    JOIN lms_lessons l4 ON s4.lesson_id = l4.id
-                                    WHERE l4.course_id = lms_courses.id
-                                )');
-                            }
+                        return $query->when($data['value'], function ($q, $status) {
+                            return $status === 'Completed'
+                                ? $q->whereNotNull('lms_course_user.completed_at')
+                                : $q->whereNull('lms_course_user.completed_at');
                         });
                     }),
 

--- a/src/Resources/CourseResource.php
+++ b/src/Resources/CourseResource.php
@@ -94,6 +94,14 @@ class CourseResource extends Resource
                     ->collection('courses')
                     ->image(),
                 Textarea::make('description'),
+                TextInput::make('required_test_percentage')
+                    ->label('Required Average Test Score (percentage)')
+                    ->helperText('User will not be able to complete the course until they have met this requirement.')
+                    ->numeric()
+                    ->minValue(0)
+                    ->maxValue(100)
+                    ->default(0)
+                    ->nullable(),
                 Select::make('award')
                     ->options(config('filament-lms.awards'))
                     ->required()

--- a/src/Resources/StepResource.php
+++ b/src/Resources/StepResource.php
@@ -1,7 +1,10 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Tapp\FilamentLms\Resources;
 
+use BackedEnum;
 use Filament\Actions\BulkActionGroup;
 use Filament\Actions\DeleteBulkAction;
 use Filament\Actions\EditAction;
@@ -23,16 +26,17 @@ use Tapp\FilamentLms\Models\Step;
 use Tapp\FilamentLms\Resources\StepResource\Pages\CreateStep;
 use Tapp\FilamentLms\Resources\StepResource\Pages\EditStep;
 use Tapp\FilamentLms\Resources\StepResource\Pages\ListSteps;
+use UnitEnum;
 
-class StepResource extends Resource
+final class StepResource extends Resource
 {
     use HasLmsSlug;
 
     protected static ?string $model = Step::class;
 
-    protected static string|\BackedEnum|null $navigationIcon = 'heroicon-o-check-circle';
+    protected static string|BackedEnum|null $navigationIcon = 'heroicon-o-check-circle';
 
-    protected static string|\UnitEnum|null $navigationGroup = 'LMS';
+    protected static string|UnitEnum|null $navigationGroup = 'LMS';
 
     /**
      * Disable Filament's automatic tenant scoping.
@@ -82,7 +86,7 @@ class StepResource extends Resource
                             $currentRetryStepId = $livewire->data['retry_step_id'] ?? null;
 
                             if ($currentRetryStepId && $newLesson) {
-                                $retryStep = \Tapp\FilamentLms\Models\Step::find($currentRetryStepId);
+                                $retryStep = Step::find($currentRetryStepId);
                                 if ($retryStep && $retryStep->lesson->course_id !== $newLesson->course_id) {
                                     $set('retry_step_id', null);
                                 }
@@ -144,14 +148,13 @@ class StepResource extends Resource
                     ->searchable()
                     ->preload()
                     ->visible(function (Get $get, $livewire) {
-                        // Only show if require_perfect_score is checked
-                        $requirePerfect = $get('require_perfect_score');
-                        if ($requirePerfect) {
+                        // Show for test steps regardless of require_perfect_score
+                        $materialType = $get('material_type');
+                        if ($materialType === 'test') {
                             return true;
                         }
-                        // Check record when editing existing step
                         if (isset($livewire->record) && $livewire->record) {
-                            return $livewire->record->require_perfect_score === true;
+                            return $livewire->record->material_type === 'test';
                         }
 
                         return false;

--- a/src/Services/CourseProgressQueryService.php
+++ b/src/Services/CourseProgressQueryService.php
@@ -3,18 +3,28 @@
 namespace Tapp\FilamentLms\Services;
 
 use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Query\Builder as QueryBuilder;
 use Illuminate\Support\Facades\DB;
-use Tapp\FilamentLms\Models\StepUser;
 
 class CourseProgressQueryService
 {
-    public static function buildQuery(): Builder
+    /**
+     * Build query for course progress reporting. Uses lms_course_user.completed_at as the source
+     * of truth for completion (not step-derived calculation).
+     *
+     * @return Builder|QueryBuilder
+     */
+    public static function buildQuery()
     {
-        return StepUser::query()
-            ->join('users', 'lms_step_user.user_id', '=', 'users.id')
-            ->join('lms_steps', 'lms_step_user.step_id', '=', 'lms_steps.id')
-            ->join('lms_lessons', 'lms_steps.lesson_id', '=', 'lms_lessons.id')
-            ->join('lms_courses', 'lms_lessons.course_id', '=', 'lms_courses.id')
+        return DB::table('lms_course_user')
+            ->join('users', 'users.id', '=', 'lms_course_user.user_id')
+            ->join('lms_courses', 'lms_courses.id', '=', 'lms_course_user.course_id')
+            ->leftJoin('lms_lessons', 'lms_lessons.course_id', '=', 'lms_courses.id')
+            ->leftJoin('lms_steps', 'lms_steps.lesson_id', '=', 'lms_lessons.id')
+            ->leftJoin('lms_step_user', function ($join): void {
+                $join->on('lms_step_user.step_id', '=', 'lms_steps.id')
+                    ->on('lms_step_user.user_id', '=', 'lms_course_user.user_id');
+            })
             ->select([
                 'users.id as user_id',
                 'users.first_name as user_first_name',
@@ -23,47 +33,34 @@ class CourseProgressQueryService
                 'lms_courses.id as course_id',
                 'lms_courses.name as course_name',
                 DB::raw('MIN(lms_step_user.created_at) as started_at'),
-                DB::raw('CASE
-                        WHEN COUNT(DISTINCT CASE WHEN lms_step_user.completed_at IS NOT NULL THEN lms_step_user.step_id END) =
-                        (SELECT COUNT(DISTINCT s.id) FROM lms_steps s JOIN lms_lessons l ON s.lesson_id = l.id WHERE l.course_id = lms_courses.id)
-                        THEN MAX(lms_step_user.completed_at)
-                        ELSE NULL
-                    END as completed_at'),
-                DB::raw('CASE
-                        WHEN COUNT(DISTINCT CASE WHEN lms_step_user.completed_at IS NOT NULL THEN lms_step_user.step_id END) =
-                        (SELECT COUNT(DISTINCT s.id) FROM lms_steps s JOIN lms_lessons l ON s.lesson_id = l.id WHERE l.course_id = lms_courses.id)
-                        THEN MAX(lms_step_user.completed_at)
-                        ELSE NULL
-                    END as completion_date'),
+                'lms_course_user.completed_at as completed_at',
+                'lms_course_user.completed_at as completion_date',
                 DB::raw('COUNT(DISTINCT CASE WHEN lms_step_user.completed_at IS NOT NULL THEN lms_step_user.step_id END) as steps_completed'),
                 DB::raw('(SELECT COUNT(DISTINCT s.id) FROM lms_steps s JOIN lms_lessons l ON s.lesson_id = l.id WHERE l.course_id = lms_courses.id) as total_steps'),
-                DB::raw('CASE
-                        WHEN COUNT(DISTINCT CASE WHEN lms_step_user.completed_at IS NOT NULL THEN lms_step_user.step_id END) =
-                        (SELECT COUNT(DISTINCT s.id) FROM lms_steps s JOIN lms_lessons l ON s.lesson_id = l.id WHERE l.course_id = lms_courses.id)
-                        THEN \'Completed\'
-                        ELSE \'In Progress\'
-                    END as status'),
+                DB::raw("CASE WHEN lms_course_user.completed_at IS NOT NULL THEN 'Completed' ELSE 'In Progress' END as status"),
             ])
-            ->groupBy('users.id', 'users.first_name', 'users.last_name', 'users.email', 'lms_courses.id', 'lms_courses.name')
+            ->groupBy('lms_course_user.user_id', 'lms_course_user.course_id', 'lms_course_user.completed_at', 'users.id', 'users.first_name', 'users.last_name', 'users.email', 'lms_courses.id', 'lms_courses.name')
             ->orderBy('users.id', 'asc')
             ->orderBy('lms_courses.id', 'asc');
     }
 
-    public static function sortByStatus($query, $direction): Builder
+    /**
+     * @param  Builder|QueryBuilder  $query
+     * @return Builder|QueryBuilder
+     */
+    public static function sortByStatus($query, $direction)
     {
-        // Sort by completion status: Completed first when DESC, In Progress first when ASC
         return $query->reorder()
-            ->orderByRaw("CASE
-                WHEN COUNT(DISTINCT CASE WHEN lms_step_user.completed_at IS NOT NULL THEN lms_step_user.step_id END) =
-                (SELECT COUNT(DISTINCT s.id) FROM lms_steps s JOIN lms_lessons l ON s.lesson_id = l.id WHERE l.course_id = lms_courses.id)
-                THEN 1
-                ELSE 0
-            END {$direction}")
+            ->orderByRaw("CASE WHEN lms_course_user.completed_at IS NOT NULL THEN 1 ELSE 0 END {$direction}")
             ->orderBy('users.id', 'asc')
             ->orderBy('lms_courses.id', 'asc');
     }
 
-    public static function sortByFirstName($query, $direction): Builder
+    /**
+     * @param  Builder|QueryBuilder  $query
+     * @return Builder|QueryBuilder
+     */
+    public static function sortByFirstName($query, $direction)
     {
         return $query->reorder()
             ->orderBy('users.first_name', $direction)
@@ -71,7 +68,11 @@ class CourseProgressQueryService
             ->orderBy('lms_courses.id', 'asc');
     }
 
-    public static function sortByLastName($query, $direction): Builder
+    /**
+     * @param  Builder|QueryBuilder  $query
+     * @return Builder|QueryBuilder
+     */
+    public static function sortByLastName($query, $direction)
     {
         return $query->reorder()
             ->orderBy('users.last_name', $direction)
@@ -79,7 +80,11 @@ class CourseProgressQueryService
             ->orderBy('lms_courses.id', 'asc');
     }
 
-    public static function sortByEmail($query, $direction): Builder
+    /**
+     * @param  Builder|QueryBuilder  $query
+     * @return Builder|QueryBuilder
+     */
+    public static function sortByEmail($query, $direction)
     {
         return $query->reorder()
             ->orderBy('users.email', $direction)
@@ -87,7 +92,11 @@ class CourseProgressQueryService
             ->orderBy('lms_courses.id', 'asc');
     }
 
-    public static function sortByCourseName($query, $direction): Builder
+    /**
+     * @param  Builder|QueryBuilder  $query
+     * @return Builder|QueryBuilder
+     */
+    public static function sortByCourseName($query, $direction)
     {
         return $query->reorder()
             ->orderBy('lms_courses.name', $direction)
@@ -95,27 +104,38 @@ class CourseProgressQueryService
             ->orderBy('lms_courses.id', 'asc');
     }
 
-    public static function sortByStepsCompleted($query, $direction): Builder
+    /**
+     * @param  Builder|QueryBuilder  $query
+     * @return Builder|QueryBuilder
+     */
+    public static function sortByStepsCompleted($query, $direction)
     {
-        // Sort by the number of completed steps
         return $query->reorder()
-            ->orderByRaw("COUNT(DISTINCT CASE WHEN lms_step_user.completed_at IS NOT NULL THEN lms_step_user.step_id END) {$direction}")
+            ->orderBy('steps_completed', $direction)
             ->orderBy('users.id', 'asc')
             ->orderBy('lms_courses.id', 'asc');
     }
 
-    public static function sortByStartedAt($query, $direction): Builder
+    /**
+     * @param  Builder|QueryBuilder  $query
+     * @return Builder|QueryBuilder
+     */
+    public static function sortByStartedAt($query, $direction)
     {
         return $query->reorder()
-            ->orderByRaw("MIN(lms_step_user.created_at) {$direction}")
+            ->orderBy('started_at', $direction)
             ->orderBy('users.id', 'asc')
             ->orderBy('lms_courses.id', 'asc');
     }
 
-    public static function sortByCompletedAt($query, $direction): Builder
+    /**
+     * @param  Builder|QueryBuilder  $query
+     * @return Builder|QueryBuilder
+     */
+    public static function sortByCompletedAt($query, $direction)
     {
         return $query->reorder()
-            ->orderByRaw("MAX(lms_step_user.completed_at) {$direction}")
+            ->orderBy('lms_course_user.completed_at', $direction)
             ->orderBy('users.id', 'asc')
             ->orderBy('lms_courses.id', 'asc');
     }

--- a/src/Services/CourseProgressQueryService.php
+++ b/src/Services/CourseProgressQueryService.php
@@ -9,21 +9,34 @@ use Illuminate\Support\Facades\DB;
 class CourseProgressQueryService
 {
     /**
-     * Build query for course progress reporting. Uses lms_course_user.completed_at as the source
-     * of truth for completion (not step-derived calculation).
+     * Build query for course progress reporting. Starts from step activity (lms_step_user) so
+     * in-progress users appear even when they are not yet in lms_course_user. Completion comes
+     * from lms_course_user.completed_at when present.
      *
      * @return Builder|QueryBuilder
      */
     public static function buildQuery()
     {
-        return DB::table('lms_course_user')
-            ->join('users', 'users.id', '=', 'lms_course_user.user_id')
-            ->join('lms_courses', 'lms_courses.id', '=', 'lms_course_user.course_id')
-            ->leftJoin('lms_lessons', 'lms_lessons.course_id', '=', 'lms_courses.id')
+        $participants = DB::table('lms_step_user')
+            ->select('lms_step_user.user_id')
+            ->selectRaw('l.course_id')
+            ->join('lms_steps as s', 's.id', '=', 'lms_step_user.step_id')
+            ->join('lms_lessons as l', 'l.id', '=', 's.lesson_id')
+            ->distinct();
+
+        return DB::table(DB::raw('('.$participants->toSql().') as participants'))
+            ->mergeBindings($participants)
+            ->leftJoin('lms_course_user', function ($join): void {
+                $join->on('lms_course_user.user_id', '=', 'participants.user_id')
+                    ->on('lms_course_user.course_id', '=', 'participants.course_id');
+            })
+            ->join('users', 'users.id', '=', 'participants.user_id')
+            ->join('lms_courses', 'lms_courses.id', '=', 'participants.course_id')
+            ->leftJoin('lms_lessons', 'lms_lessons.course_id', '=', 'participants.course_id')
             ->leftJoin('lms_steps', 'lms_steps.lesson_id', '=', 'lms_lessons.id')
             ->leftJoin('lms_step_user', function ($join): void {
                 $join->on('lms_step_user.step_id', '=', 'lms_steps.id')
-                    ->on('lms_step_user.user_id', '=', 'lms_course_user.user_id');
+                    ->on('lms_step_user.user_id', '=', 'participants.user_id');
             })
             ->select([
                 'users.id as user_id',
@@ -36,10 +49,10 @@ class CourseProgressQueryService
                 'lms_course_user.completed_at as completed_at',
                 'lms_course_user.completed_at as completion_date',
                 DB::raw('COUNT(DISTINCT CASE WHEN lms_step_user.completed_at IS NOT NULL THEN lms_step_user.step_id END) as steps_completed'),
-                DB::raw('(SELECT COUNT(DISTINCT s.id) FROM lms_steps s JOIN lms_lessons l ON s.lesson_id = l.id WHERE l.course_id = lms_courses.id) as total_steps'),
+                DB::raw('(SELECT COUNT(DISTINCT s2.id) FROM lms_steps s2 JOIN lms_lessons l2 ON s2.lesson_id = l2.id WHERE l2.course_id = lms_courses.id) as total_steps'),
                 DB::raw("CASE WHEN lms_course_user.completed_at IS NOT NULL THEN 'Completed' ELSE 'In Progress' END as status"),
             ])
-            ->groupBy('lms_course_user.user_id', 'lms_course_user.course_id', 'lms_course_user.completed_at', 'users.id', 'users.first_name', 'users.last_name', 'users.email', 'lms_courses.id', 'lms_courses.name')
+            ->groupBy('participants.user_id', 'participants.course_id', 'lms_course_user.completed_at', 'users.id', 'users.first_name', 'users.last_name', 'users.email', 'lms_courses.id', 'lms_courses.name')
             ->orderBy('users.id', 'asc')
             ->orderBy('lms_courses.id', 'asc');
     }

--- a/src/Traits/FilamentLmsUser.php
+++ b/src/Traits/FilamentLmsUser.php
@@ -27,10 +27,13 @@ trait FilamentLmsUser
 {
     /**
      * Get all courses the user is assigned to (via lms_course_user).
+     * Pivot includes completed_at so integrations (e.g. HubSpot) can read completion from the column.
      */
     public function courses(): BelongsToMany
     {
-        return $this->belongsToMany(Course::class, 'lms_course_user', 'user_id', 'course_id')->withTimestamps();
+        return $this->belongsToMany(Course::class, 'lms_course_user', 'user_id', 'course_id')
+            ->withPivot('completed_at')
+            ->withTimestamps();
     }
 
     /**

--- a/tests/Feature/CourseOverallGradeTest.php
+++ b/tests/Feature/CourseOverallGradeTest.php
@@ -1,0 +1,306 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tapp\FilamentLms\Tests\Feature;
+
+use Tapp\FilamentFormBuilder\Models\FilamentForm;
+use Tapp\FilamentFormBuilder\Models\FilamentFormField;
+use Tapp\FilamentFormBuilder\Models\FilamentFormUser;
+use Tapp\FilamentLms\Models\Course;
+use Tapp\FilamentLms\Models\Lesson;
+use Tapp\FilamentLms\Models\Step;
+use Tapp\FilamentLms\Models\Test;
+use Tapp\FilamentLms\Pages\Dashboard;
+use Tapp\FilamentLms\Tests\TestUser;
+
+beforeEach(function () {
+    config(['filament-lms.user_model' => TestUser::class]);
+});
+
+test('getOverallTestPercentageForUser returns 0 when course has no test steps', function () {
+    $user = TestUser::create([
+        'name' => 'Test User',
+        'email' => 'test@example.com',
+        'password' => bcrypt('password'),
+    ]);
+
+    $course = Course::factory()->create();
+    $lesson = Lesson::factory()->create(['course_id' => $course->id]);
+    Step::factory()->create([
+        'lesson_id' => $lesson->id,
+        'order' => 1,
+        'material_type' => 'document',
+    ]);
+
+    expect($course->getOverallTestPercentageForUser($user->id))->toBe(0.0);
+});
+
+test('getOverallTestPercentageForUser returns average of test step scores', function () {
+    $user = TestUser::create([
+        'name' => 'Test User',
+        'email' => 'test@example.com',
+        'password' => bcrypt('password'),
+    ]);
+
+    $course = Course::factory()->create();
+    $lesson = Lesson::factory()->create(['course_id' => $course->id, 'order' => 1]);
+
+    $form1 = FilamentForm::create(['name' => 'Form 1', 'slug' => 'form-1']);
+    FilamentFormField::create([
+        'filament_form_id' => $form1->id,
+        'field' => 'q1',
+        'label' => 'Q1',
+        'type' => 'TEXT',
+        'required' => true,
+        'order' => 1,
+    ]);
+    $rubric1 = FilamentFormUser::create([
+        'filament_form_id' => $form1->id,
+        'user_id' => $user->id,
+        'entry' => [['field' => 'q1', 'type' => 'Text', 'answer' => 'A']],
+    ]);
+    $test1 = Test::create(['name' => 'Test 1', 'filament_form_id' => $form1->id, 'filament_form_user_id' => $rubric1->id]);
+
+    $form2 = FilamentForm::create(['name' => 'Form 2', 'slug' => 'form-2']);
+    FilamentFormField::create([
+        'filament_form_id' => $form2->id,
+        'field' => 'q1',
+        'label' => 'Q1',
+        'type' => 'TEXT',
+        'required' => true,
+        'order' => 1,
+    ]);
+    $rubric2 = FilamentFormUser::create([
+        'filament_form_id' => $form2->id,
+        'user_id' => $user->id,
+        'entry' => [['field' => 'q1', 'type' => 'Text', 'answer' => 'B']],
+    ]);
+    $test2 = Test::create(['name' => 'Test 2', 'filament_form_id' => $form2->id, 'filament_form_user_id' => $rubric2->id]);
+
+    Step::factory()->create([
+        'lesson_id' => $lesson->id,
+        'order' => 1,
+        'material_type' => 'test',
+        'material_id' => $test1->id,
+    ]);
+    Step::factory()->create([
+        'lesson_id' => $lesson->id,
+        'order' => 2,
+        'material_type' => 'test',
+        'material_id' => $test2->id,
+    ]);
+
+    FilamentFormUser::create([
+        'filament_form_id' => $form1->id,
+        'user_id' => $user->id,
+        'entry' => [['field' => 'q1', 'type' => 'Text', 'answer' => 'A']],
+    ]);
+    FilamentFormUser::create([
+        'filament_form_id' => $form2->id,
+        'user_id' => $user->id,
+        'entry' => [['field' => 'q1', 'type' => 'Text', 'answer' => 'X']],
+    ]);
+
+    $overall = $course->getOverallTestPercentageForUser($user->id);
+    expect($overall)->toBe(50.0);
+});
+
+test('getFirstTestStepBelowPerfectForUser returns first step below 100 or null', function () {
+    $user = TestUser::create([
+        'name' => 'Test User',
+        'email' => 'test@example.com',
+        'password' => bcrypt('password'),
+    ]);
+
+    $course = Course::factory()->create();
+    $lesson = Lesson::factory()->create(['course_id' => $course->id, 'order' => 1]);
+
+    $form1 = FilamentForm::create(['name' => 'Form 1', 'slug' => 'form-1']);
+    FilamentFormField::create([
+        'filament_form_id' => $form1->id,
+        'field' => 'q1',
+        'label' => 'Q1',
+        'type' => 'TEXT',
+        'required' => true,
+        'order' => 1,
+    ]);
+    $rubric1 = FilamentFormUser::create([
+        'filament_form_id' => $form1->id,
+        'user_id' => $user->id,
+        'entry' => [['field' => 'q1', 'type' => 'Text', 'answer' => 'A']],
+    ]);
+    $test1 = Test::create(['name' => 'Test 1', 'filament_form_id' => $form1->id, 'filament_form_user_id' => $rubric1->id]);
+
+    $form2 = FilamentForm::create(['name' => 'Form 2', 'slug' => 'form-2']);
+    FilamentFormField::create([
+        'filament_form_id' => $form2->id,
+        'field' => 'q1',
+        'label' => 'Q1',
+        'type' => 'TEXT',
+        'required' => true,
+        'order' => 1,
+    ]);
+    $rubric2 = FilamentFormUser::create([
+        'filament_form_id' => $form2->id,
+        'user_id' => $user->id,
+        'entry' => [['field' => 'q1', 'type' => 'Text', 'answer' => 'B']],
+    ]);
+    $test2 = Test::create(['name' => 'Test 2', 'filament_form_id' => $form2->id, 'filament_form_user_id' => $rubric2->id]);
+
+    $step1 = Step::factory()->create([
+        'lesson_id' => $lesson->id,
+        'order' => 1,
+        'material_type' => 'test',
+        'material_id' => $test1->id,
+    ]);
+    $step2 = Step::factory()->create([
+        'lesson_id' => $lesson->id,
+        'order' => 2,
+        'material_type' => 'test',
+        'material_id' => $test2->id,
+    ]);
+
+    FilamentFormUser::create([
+        'filament_form_id' => $form1->id,
+        'user_id' => $user->id,
+        'entry' => [['field' => 'q1', 'type' => 'Text', 'answer' => 'A']],
+    ]);
+    $firstBelow = $course->getFirstTestStepBelowPerfectForUser($user->id);
+    expect($firstBelow)->not->toBeNull();
+    expect($firstBelow->id)->toBe($step2->id);
+
+    FilamentFormUser::create([
+        'filament_form_id' => $form2->id,
+        'user_id' => $user->id,
+        'entry' => [['field' => 'q1', 'type' => 'Text', 'answer' => 'Wrong']],
+    ]);
+    $firstBelow = $course->getFirstTestStepBelowPerfectForUser($user->id);
+    expect($firstBelow)->not->toBeNull();
+    expect($firstBelow->id)->toBe($step2->id);
+});
+
+test('getUrlToFirstTestStepBelowPerfectForUser returns dashboard when all perfect', function () {
+    $user = TestUser::create([
+        'name' => 'Test User',
+        'email' => 'test@example.com',
+        'password' => bcrypt('password'),
+    ]);
+
+    $course = Course::factory()->create();
+    $lesson = Lesson::factory()->create(['course_id' => $course->id, 'order' => 1]);
+    $form = FilamentForm::create(['name' => 'Form', 'slug' => 'form']);
+    FilamentFormField::create([
+        'filament_form_id' => $form->id,
+        'field' => 'q1',
+        'label' => 'Q1',
+        'type' => 'TEXT',
+        'required' => true,
+        'order' => 1,
+    ]);
+    $rubric = FilamentFormUser::create([
+        'filament_form_id' => $form->id,
+        'user_id' => $user->id,
+        'entry' => [['field' => 'q1', 'type' => 'Text', 'answer' => 'A']],
+    ]);
+    $test = Test::create(['name' => 'Test', 'filament_form_id' => $form->id, 'filament_form_user_id' => $rubric->id]);
+    Step::factory()->create([
+        'lesson_id' => $lesson->id,
+        'order' => 1,
+        'material_type' => 'test',
+        'material_id' => $test->id,
+    ]);
+    FilamentFormUser::create([
+        'filament_form_id' => $form->id,
+        'user_id' => $user->id,
+        'entry' => [['field' => 'q1', 'type' => 'Text', 'answer' => 'A']],
+    ]);
+
+    $url = $course->getUrlToFirstTestStepBelowPerfectForUser($user->id);
+    expect($url)->toBe(Dashboard::getUrl());
+});
+
+test('course certificate gate: overall below required sets qualified false', function () {
+    $user = TestUser::create([
+        'name' => 'Test User',
+        'email' => 'test@example.com',
+        'password' => bcrypt('password'),
+    ]);
+
+    $course = Course::factory()->create(['required_test_percentage' => 80]);
+    $lesson = Lesson::factory()->create(['course_id' => $course->id, 'order' => 1]);
+
+    $form1 = FilamentForm::create(['name' => 'Form 1', 'slug' => 'form-1']);
+    FilamentFormField::create([
+        'filament_form_id' => $form1->id,
+        'field' => 'q1',
+        'label' => 'Q1',
+        'type' => 'TEXT',
+        'required' => true,
+        'order' => 1,
+    ]);
+    $rubric1 = FilamentFormUser::create([
+        'filament_form_id' => $form1->id,
+        'user_id' => $user->id,
+        'entry' => [['field' => 'q1', 'type' => 'Text', 'answer' => 'A']],
+    ]);
+    $test1 = Test::create(['name' => 'Test 1', 'filament_form_id' => $form1->id, 'filament_form_user_id' => $rubric1->id]);
+    $form2 = FilamentForm::create(['name' => 'Form 2', 'slug' => 'form-2']);
+    FilamentFormField::create([
+        'filament_form_id' => $form2->id,
+        'field' => 'q1',
+        'label' => 'Q1',
+        'type' => 'TEXT',
+        'required' => true,
+        'order' => 1,
+    ]);
+    $rubric2 = FilamentFormUser::create([
+        'filament_form_id' => $form2->id,
+        'user_id' => $user->id,
+        'entry' => [['field' => 'q1', 'type' => 'Text', 'answer' => 'B']],
+    ]);
+    $test2 = Test::create(['name' => 'Test 2', 'filament_form_id' => $form2->id, 'filament_form_user_id' => $rubric2->id]);
+
+    Step::factory()->create([
+        'lesson_id' => $lesson->id,
+        'order' => 1,
+        'material_type' => 'test',
+        'material_id' => $test1->id,
+    ]);
+    Step::factory()->create([
+        'lesson_id' => $lesson->id,
+        'order' => 2,
+        'material_type' => 'test',
+        'material_id' => $test2->id,
+    ]);
+
+    FilamentFormUser::create([
+        'filament_form_id' => $form1->id,
+        'user_id' => $user->id,
+        'entry' => [['field' => 'q1', 'type' => 'Text', 'answer' => 'A']],
+    ]);
+    FilamentFormUser::create([
+        'filament_form_id' => $form2->id,
+        'user_id' => $user->id,
+        'entry' => [['field' => 'q1', 'type' => 'Text', 'answer' => 'Wrong']],
+    ]);
+
+    $overall = $course->getOverallTestPercentageForUser($user->id);
+    expect($overall)->toBe(50.0);
+    expect($overall < (float) $course->required_test_percentage)->toBeTrue();
+    expect($course->getUrlToFirstTestStepBelowPerfectForUser($user->id))->not->toBe(Dashboard::getUrl());
+});
+
+test('course certificate gate: required_test_percentage null implies no percent check', function () {
+    $user = TestUser::create([
+        'name' => 'Test User',
+        'email' => 'test@example.com',
+        'password' => bcrypt('password'),
+    ]);
+
+    $course = Course::factory()->create(['required_test_percentage' => null]);
+    $lesson = Lesson::factory()->create(['course_id' => $course->id, 'order' => 1]);
+    Step::factory()->create(['lesson_id' => $lesson->id, 'order' => 1, 'material_type' => 'document']);
+
+    expect($course->required_test_percentage)->toBeNull();
+});

--- a/tests/Feature/CourseProgressQueryServiceTest.php
+++ b/tests/Feature/CourseProgressQueryServiceTest.php
@@ -1,0 +1,94 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tapp\FilamentLms\Tests\Feature;
+
+use Tapp\FilamentLms\Models\Course;
+use Tapp\FilamentLms\Models\Document;
+use Tapp\FilamentLms\Models\Lesson;
+use Tapp\FilamentLms\Models\Step;
+use Tapp\FilamentLms\Services\CourseProgressQueryService;
+use Tapp\FilamentLms\Tests\TestUser;
+
+beforeEach(function (): void {
+    config(['filament-lms.user_model' => TestUser::class]);
+});
+
+test('course progress query includes in-progress users who are not yet in lms_course_user', function (): void {
+    $user = TestUser::create([
+        'name' => 'In Progress User',
+        'first_name' => 'In Progress',
+        'last_name' => 'User',
+        'email' => 'inprogress@example.com',
+        'password' => bcrypt('password'),
+    ]);
+
+    $document = Document::create(['name' => 'Doc', 'file_path' => '/tmp/doc.pdf']);
+    $course = Course::factory()->create([
+        'name' => 'Public Course',
+        'slug' => 'public-course',
+        'external_id' => 'public-course',
+    ]);
+    $lesson = Lesson::factory()->create(['course_id' => $course->id, 'order' => 1]);
+    $step1 = Step::factory()->create([
+        'lesson_id' => $lesson->id,
+        'order' => 1,
+        'material_type' => 'document',
+        'material_id' => $document->id,
+    ]);
+    $step2 = Step::factory()->create([
+        'lesson_id' => $lesson->id,
+        'order' => 2,
+        'material_type' => 'document',
+        'material_id' => $document->id,
+    ]);
+
+    $step1->complete($user);
+
+    $rows = CourseProgressQueryService::buildQuery()->get();
+
+    expect($rows)->toHaveCount(1);
+    expect((int) $rows->first()->user_id)->toBe($user->id);
+    expect((int) $rows->first()->course_id)->toBe($course->id);
+    expect($rows->first()->status)->toBe('In Progress');
+    expect($rows->first()->completed_at)->toBeNull();
+    expect($rows->first()->steps_completed)->toBe(1);
+    expect($rows->first()->total_steps)->toBe(2);
+});
+
+test('course progress query includes completed users with completed_at from pivot', function (): void {
+    $user = TestUser::create([
+        'name' => 'Completed User',
+        'first_name' => 'Completed',
+        'last_name' => 'User',
+        'email' => 'completed@example.com',
+        'password' => bcrypt('password'),
+    ]);
+
+    $document = Document::create(['name' => 'Doc', 'file_path' => '/tmp/doc.pdf']);
+    $course = Course::factory()->create([
+        'name' => 'Short Course',
+        'slug' => 'short-course',
+        'external_id' => 'short-course',
+    ]);
+    $lesson = Lesson::factory()->create(['course_id' => $course->id, 'order' => 1]);
+    $step = Step::factory()->create([
+        'lesson_id' => $lesson->id,
+        'order' => 1,
+        'material_type' => 'document',
+        'material_id' => $document->id,
+    ]);
+
+    $step->complete($user);
+
+    $rows = CourseProgressQueryService::buildQuery()->get();
+
+    expect($rows)->toHaveCount(1);
+    expect((int) $rows->first()->user_id)->toBe($user->id);
+    expect((int) $rows->first()->course_id)->toBe($course->id);
+    expect($rows->first()->status)->toBe('Completed');
+    expect($rows->first()->completed_at)->not->toBeNull();
+    expect($rows->first()->steps_completed)->toBe(1);
+    expect($rows->first()->total_steps)->toBe(1);
+});

--- a/tests/Feature/CourseRedirectTest.php
+++ b/tests/Feature/CourseRedirectTest.php
@@ -139,6 +139,38 @@ test('course completed page does not redirect when course has steps and is compl
     }
 });
 
+test('course completed page does not redirect when all steps are done but required test percentage is not met', function () {
+    // User has completed all steps but scored below required_test_percentage; they should see the completed page
+    // (with retake/certificate messaging), not get redirected in a loop.
+    $user = TestUser::create([
+        'name' => 'Test User',
+        'email' => 'test@example.com',
+        'password' => bcrypt('password'),
+    ]);
+
+    Auth::login($user);
+
+    $course = Course::factory()->create([
+        'name' => 'Course With Required Percent',
+        'slug' => 'course-required-percent',
+        'required_test_percentage' => 80,
+    ]);
+    $lesson = Lesson::factory()->create(['course_id' => $course->id]);
+    $step = Step::factory()->create(['lesson_id' => $lesson->id]);
+
+    $step->complete($user);
+
+    expect($course->allStepsCompletedByUser($user->id))->toBeTrue();
+    expect($course->completedByUserAt($user->id))->toBeNull();
+
+    try {
+        $component = Livewire::test(CourseCompleted::class, ['courseSlug' => $course->slug]);
+        $component->assertSuccessful();
+    } catch (\Exception $e) {
+        expect($course->allStepsCompletedByUser($user->id))->toBeTrue();
+    }
+});
+
 test('course completed page redirects to current step when course has steps but is not completed', function () {
     // Create a user and authenticate
     $user = TestUser::create([
@@ -159,10 +191,10 @@ test('course completed page redirects to current step when course has steps but 
 
     // Verify the conditions that trigger redirect in CourseCompleted::mount()
     expect($course->steps()->exists())->toBeTrue();
-    expect($course->completed_at)->toBeNull();
+    expect($course->allStepsCompletedByUser($user->id))->toBeFalse();
 
-    // The mount method checks: if (!$this->course->completed_at)
-    // Since the course is not completed, it should redirect to current step
+    // The mount method checks: if (!$this->course->allStepsCompletedByUser(auth()->id()))
+    // Since not all steps are completed, it should redirect to current step
     // We verify the logic without testing the actual URL generation
     $allSteps = $course->steps()->ordered()->get();
     expect($allSteps->isEmpty())->toBeFalse();

--- a/tests/Feature/CourseRedirectTest.php
+++ b/tests/Feature/CourseRedirectTest.php
@@ -4,9 +4,14 @@ namespace Tapp\FilamentLms\Tests\Feature;
 
 use Illuminate\Support\Facades\Auth;
 use Livewire\Livewire;
+use Tapp\FilamentFormBuilder\Models\FilamentForm;
+use Tapp\FilamentFormBuilder\Models\FilamentFormField;
+use Tapp\FilamentFormBuilder\Models\FilamentFormUser;
 use Tapp\FilamentLms\Models\Course;
+use Tapp\FilamentLms\Models\Document;
 use Tapp\FilamentLms\Models\Lesson;
 use Tapp\FilamentLms\Models\Step;
+use Tapp\FilamentLms\Models\Test;
 use Tapp\FilamentLms\Pages\CourseCompleted;
 use Tapp\FilamentLms\Pages\Dashboard;
 use Tapp\FilamentLms\Tests\TestUser;
@@ -140,8 +145,9 @@ test('course completed page does not redirect when course has steps and is compl
 });
 
 test('course completed page does not redirect when all steps are done but required test percentage is not met', function () {
-    // User has completed all steps but scored below required_test_percentage; they should see the completed page
-    // (with retake/certificate messaging), not get redirected in a loop.
+    // User has completed all steps but scored below required_test_percentage (80%); they should see the completed page
+    // (with retake/certificate messaging), not get redirected in a loop. Course has one document step and one test
+    // step; user completes both but scores 60% on the test, so course completed_at stays null.
     $user = TestUser::create([
         'name' => 'Test User',
         'email' => 'test@example.com',
@@ -155,12 +161,72 @@ test('course completed page does not redirect when all steps are done but requir
         'slug' => 'course-required-percent',
         'required_test_percentage' => 80,
     ]);
-    $lesson = Lesson::factory()->create(['course_id' => $course->id]);
-    $step = Step::factory()->create(['lesson_id' => $lesson->id]);
+    $course->users()->attach($user->id);
+    $lesson = Lesson::factory()->create(['course_id' => $course->id, 'order' => 1]);
 
-    $step->complete($user);
+    $document = Document::create(['name' => 'Doc', 'file_path' => '/tmp/test.pdf']);
+    $docStep = Step::factory()->create([
+        'lesson_id' => $lesson->id,
+        'order' => 1,
+        'name' => 'Doc Step',
+        'slug' => 'doc-step',
+        'material_type' => 'document',
+        'material_id' => $document->id,
+    ]);
+
+    $form = FilamentForm::create(['name' => 'Test Form', 'slug' => 'test-form']);
+    foreach (['q1', 'q2', 'q3', 'q4', 'q5'] as $i => $field) {
+        FilamentFormField::create([
+            'filament_form_id' => $form->id,
+            'field' => $field,
+            'label' => "Question {$field}",
+            'type' => 'TEXT',
+            'required' => true,
+            'order' => $i + 1,
+        ]);
+    }
+    $rubric = FilamentFormUser::create([
+        'filament_form_id' => $form->id,
+        'user_id' => $user->id,
+        'entry' => [
+            ['field' => 'q1', 'type' => 'Text', 'answer' => 'A1'],
+            ['field' => 'q2', 'type' => 'Text', 'answer' => 'A2'],
+            ['field' => 'q3', 'type' => 'Text', 'answer' => 'A3'],
+            ['field' => 'q4', 'type' => 'Text', 'answer' => 'A4'],
+            ['field' => 'q5', 'type' => 'Text', 'answer' => 'A5'],
+        ],
+    ]);
+    $test = Test::create([
+        'name' => 'Test Quiz',
+        'filament_form_id' => $form->id,
+        'filament_form_user_id' => $rubric->id,
+    ]);
+    $testStep = Step::factory()->create([
+        'lesson_id' => $lesson->id,
+        'order' => 2,
+        'name' => 'Test Step',
+        'slug' => 'test-step',
+        'material_type' => 'test',
+        'material_id' => $test->id,
+    ]);
+
+    FilamentFormUser::create([
+        'filament_form_id' => $form->id,
+        'user_id' => $user->id,
+        'entry' => [
+            ['field' => 'q1', 'type' => 'Text', 'answer' => 'A1'],
+            ['field' => 'q2', 'type' => 'Text', 'answer' => 'A2'],
+            ['field' => 'q3', 'type' => 'Text', 'answer' => 'A3'],
+            ['field' => 'q4', 'type' => 'Text', 'answer' => 'Wrong4'],
+            ['field' => 'q5', 'type' => 'Text', 'answer' => 'Wrong5'],
+        ],
+    ]);
+
+    $docStep->complete($user);
+    $testStep->complete($user);
 
     expect($course->allStepsCompletedByUser($user->id))->toBeTrue();
+    expect($course->getOverallTestPercentageForUser($user->id))->toBe(60.0);
     expect($course->completedByUserAt($user->id))->toBeNull();
 
     try {

--- a/tests/Feature/CourseTest.php
+++ b/tests/Feature/CourseTest.php
@@ -3,6 +3,7 @@
 namespace Tapp\FilamentLms\Tests\Feature;
 
 use Tapp\FilamentLms\Models\Course;
+use Tapp\FilamentLms\Models\Document;
 use Tapp\FilamentLms\Models\Lesson;
 use Tapp\FilamentLms\Models\Step;
 use Tapp\FilamentLms\Tests\TestUser;
@@ -71,6 +72,29 @@ test('course can check if completed by user', function () {
     // Now check if course is completed
     $completedAt = $course->completedByUserAt($userId);
     expect($completedAt)->not->toBeNull();
+});
+
+test('course with required_test_percentage but no test steps sets completed_at when all steps completed', function () {
+    $course = Course::factory()->create(['required_test_percentage' => 80]);
+    $lesson = Lesson::factory()->create(['course_id' => $course->id]);
+    $document = Document::create(['name' => 'Test Doc', 'file_path' => '/tmp/test.pdf']);
+    $step = Step::factory()->create([
+        'lesson_id' => $lesson->id,
+        'material_type' => 'document',
+        'material_id' => $document->id,
+    ]);
+
+    $user = TestUser::create([
+        'name' => 'Test User',
+        'email' => 'test@example.com',
+        'password' => bcrypt('password'),
+    ]);
+
+    expect($course->completedByUserAt($user->id))->toBeNull();
+
+    $step->complete($user);
+
+    expect($course->completedByUserAt($user->id))->not->toBeNull();
 });
 
 test('course can calculate completion percentage', function () {

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Tapp\FilamentLms\Tests;
 
 use Filament\FilamentServiceProvider;
@@ -33,6 +35,43 @@ abstract class TestCase extends Orchestra
         }
     }
 
+    final public function getEnvironmentSetUp($app)
+    {
+        // Set up the database connection for testing
+        $app['config']->set('database.default', 'testbench');
+        $app['config']->set('database.connections.testbench', [
+            'driver' => 'sqlite',
+            'database' => ':memory:',
+            'prefix' => '',
+        ]);
+
+        // Set up filesystem for testing
+        $app['config']->set('filesystems.default', 'local');
+        $app['config']->set('filesystems.disks.local', [
+            'driver' => 'local',
+            'root' => storage_path('app'),
+        ]);
+
+        // Set up session configuration
+        $app['config']->set('session.driver', 'array');
+
+        // Set up view error bag sharing
+        $app['config']->set('view.compiled', storage_path('framework/views'));
+
+        // Set up media library configuration
+        $app['config']->set('media-library.disk_name', 'local');
+        $app['config']->set('media-library.media_model', \Spatie\MediaLibrary\MediaCollections\Models\Media::class);
+
+        // Set up app key for testing
+        $app['config']->set('app.key', 'base64:'.base64_encode(random_bytes(32)));
+
+        // Set up filament-lms user model for testing
+        $app['config']->set('filament-lms.user_model', TestUser::class);
+
+        // Set up database tables
+        $this->setUpDatabase($app);
+    }
+
     protected function setUpDatabase($app)
     {
         // Create users table
@@ -55,6 +94,7 @@ abstract class TestCase extends Orchestra
             $table->text('image')->nullable();
             $table->string('award')->nullable();
             $table->text('description')->nullable();
+            $table->unsignedTinyInteger('required_test_percentage')->nullable();
             $table->boolean('is_private')->default(false);
             $table->timestamps();
             $table->softDeletes();
@@ -221,47 +261,10 @@ abstract class TestCase extends Orchestra
         ];
 
         // Only add FilamentFormBuilderServiceProvider if it exists
-        if (class_exists(\Tapp\FilamentFormBuilder\FilamentFormBuilderServiceProvider::class)) {
-            $providers[] = \Tapp\FilamentFormBuilder\FilamentFormBuilderServiceProvider::class;
+        if (class_exists(FilamentFormBuilderServiceProvider::class)) {
+            $providers[] = FilamentFormBuilderServiceProvider::class;
         }
 
         return $providers;
-    }
-
-    public function getEnvironmentSetUp($app)
-    {
-        // Set up the database connection for testing
-        $app['config']->set('database.default', 'testbench');
-        $app['config']->set('database.connections.testbench', [
-            'driver' => 'sqlite',
-            'database' => ':memory:',
-            'prefix' => '',
-        ]);
-
-        // Set up filesystem for testing
-        $app['config']->set('filesystems.default', 'local');
-        $app['config']->set('filesystems.disks.local', [
-            'driver' => 'local',
-            'root' => storage_path('app'),
-        ]);
-
-        // Set up session configuration
-        $app['config']->set('session.driver', 'array');
-
-        // Set up view error bag sharing
-        $app['config']->set('view.compiled', storage_path('framework/views'));
-
-        // Set up media library configuration
-        $app['config']->set('media-library.disk_name', 'local');
-        $app['config']->set('media-library.media_model', \Spatie\MediaLibrary\MediaCollections\Models\Media::class);
-
-        // Set up app key for testing
-        $app['config']->set('app.key', 'base64:'.base64_encode(random_bytes(32)));
-
-        // Set up filament-lms user model for testing
-        $app['config']->set('filament-lms.user_model', \Tapp\FilamentLms\Tests\TestUser::class);
-
-        // Set up database tables
-        $this->setUpDatabase($app);
     }
 }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -74,10 +74,12 @@ abstract class TestCase extends Orchestra
 
     protected function setUpDatabase($app)
     {
-        // Create users table
+        // Create users table (first_name/last_name for course progress reporting query)
         $app['db']->connection()->getSchemaBuilder()->create('users', function (Blueprint $table) {
             $table->id();
             $table->string('name');
+            $table->string('first_name')->nullable();
+            $table->string('last_name')->nullable();
             $table->string('email')->unique();
             $table->timestamp('email_verified_at')->nullable();
             $table->string('password');


### PR DESCRIPTION
## Changes

- Add `completed_at` column to `lms_course_user` pivot table
- Store course completion timestamp when user meets all requirements (including after retakes)
- Fix redirect loop by checking `allStepsCompletedByUser` for page access instead of `completedByUserAt`
- Update `Course::completedByUserAt()` to read from pivot instead of calculating
- Add `maybeSetCompletedAtForUser()` to set completion when requirements met
- Call completion check after each step completion (supports retakes)
- Improve test step spacing consistency
- Update CourseResource label to 'Required Average Test Score (percentage)' and simplify help text
- Set default `required_test_percentage` to 0

## Testing

All course-related tests pass, including CourseRedirectTest, CourseTest, and CourseOverallGradeTest.

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches completion/certification state and reporting queries, so incorrect pivot updates or edge cases (retakes, courses with/without tests) could mislabel completion or block certificate download, though changes are localized and covered by new feature tests.
> 
> **Overview**
> Course completion is now **persisted on `lms_course_user.completed_at`** (new migration + pivot relationship updates) rather than being derived from step progress, with `Course::maybeSetCompletedAtForUser()` setting the timestamp once a user has finished all steps and (optionally) met a course-level `required_test_percentage` average across test steps.
> 
> The certificate flow is updated to avoid redirect loops and to clearly handle “all steps done but not certificate-qualified”: `CourseCompleted` now allows entry once all steps are complete, shows per-test/overall grade details and retake links when below the required average, and only enables certificate download when the pivot `completed_at` is set; retaking a test clears the pivot completion so it can be re-evaluated.
> 
> Reporting and progress queries are simplified to rely on the pivot completion timestamp for status/date filtering/sorting, and the admin UI adds `required_test_percentage` to course settings plus improved test-step messaging (including non-perfect-score guidance and optional review-step selection for all test steps).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3cecf8c2b2a4abc93afddf56655ca08ed1fc4631. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->