### PR TITLE
Course completion and certificates

### DIFF
--- a/src/Livewire/TestStep.php
+++ b/src/Livewire/TestStep.php
@@ -90,6 +90,10 @@ class TestStep extends Component
         if ($this->step->completed_at) {
             $this->step->progress()->delete();
         }
+
+        // Clear course completion so it can be re-evaluated after the retake
+        $course = $this->step->lesson->course;
+        $course->users()->updateExistingPivot(Auth::id(), ['completed_at' => null]);
     }
 
     private function checkTestResults(): void

--- a/src/Models/Course.php
+++ b/src/Models/Course.php
@@ -222,9 +222,13 @@ final class Course extends Model implements HasMedia
         }
 
         if ($this->required_test_percentage !== null) {
-            $overall = $this->getOverallTestPercentageForUser($userId);
-            if ($overall < (float) $this->required_test_percentage) {
-                return;
+            $testSteps = $this->getOrderedTestSteps();
+            // Only apply test percentage requirement if there are test steps
+            if ($testSteps->isNotEmpty()) {
+                $overall = $this->getOverallTestPercentageForUser($userId);
+                if ($overall < (float) $this->required_test_percentage) {
+                    return;
+                }
             }
         }
 

--- a/src/Pages/CourseCompleted.php
+++ b/src/Pages/CourseCompleted.php
@@ -22,8 +22,6 @@ final class CourseCompleted extends Page
 
     public ?int $requiredPercent = null;
 
-    public ?string $urlToFirstStepBelowPerfect = null;
-
     public array $testStepDetails = [];
 
     protected static string|BackedEnum|null $navigationIcon = 'heroicon-o-trophy';
@@ -57,12 +55,15 @@ final class CourseCompleted extends Page
         }
 
         if ($this->course->required_test_percentage !== null) {
-            $overall = $this->course->getOverallTestPercentageForUser(auth()->id());
-            if ($overall < (float) $this->course->required_test_percentage) {
-                $this->qualifiedForCertificate = false;
-                $this->overallPercent = $overall;
-                $this->requiredPercent = (int) $this->course->required_test_percentage;
-                $this->urlToFirstStepBelowPerfect = $this->course->getUrlToFirstTestStepBelowPerfectForUser(auth()->id());
+            $testSteps = $this->course->getOrderedTestSteps();
+            // Only check test percentage if there are test steps
+            if ($testSteps->isNotEmpty()) {
+                $overall = $this->course->getOverallTestPercentageForUser(auth()->id());
+                if ($overall < (float) $this->course->required_test_percentage) {
+                    $this->qualifiedForCertificate = false;
+                    $this->overallPercent = $overall;
+                    $this->requiredPercent = (int) $this->course->required_test_percentage;
+                }
             }
         }
 


### PR DESCRIPTION
# Details

Fixes three bugs:
1.  **Course completion impossible when no test steps exist:** `maybeSetCompletedAtForUser()` now skips the `required_test_percentage` check if no test steps are present, allowing completion. The `CourseCompleted` page also applies this logic.
2.  **Unused property `urlToFirstStepBelowPerfect`:** Removed the unused `$urlToFirstStepBelowPerfect` property and its assignment from `CourseCompleted` to eliminate dead code.
3.  **Certificate download allowed after failing retake tests:** `retakeTest()` now clears the course's `completed_at` timestamp on the user pivot table, ensuring re-evaluation of completion status and preventing certificate download if the user no longer qualifies.

---

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches core course completion/certificate eligibility logic and modifies pivot `completed_at` state on retake, which could affect user progress if edge cases are missed; scope is small and localized.
> 
> **Overview**
> Fixes course completion/certificate eligibility edge cases around test requirements and retakes.
> 
> `Course::maybeSetCompletedAtForUser()` and the `CourseCompleted` page now *skip* the `required_test_percentage` gate when a course has no test steps, preventing users from being blocked from completing a course/certificate due to a missing test set. `TestStep::retakeTest()` now clears the user’s course pivot `completed_at` so completion (and certificate availability) is re-evaluated after a retake, and dead code on `CourseCompleted` (`$urlToFirstStepBelowPerfect`) is removed.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c8724dacc6093ed4e32985e41eb9528f944504e9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->