### PR TITLE
Step material consistency

### DIFF
--- a/resources/views/pages/step.blade.php
+++ b/resources/views/pages/step.blade.php
@@ -111,23 +111,21 @@
     }
     </style>
 
-    @if (is_null($step->material))
-        @if(!$step->text)
-            {{-- No material and no text: show error --}}
-            <div class="flex items-center justify-center min-h-[60vh]">
-                <x-filament::card class="py-12 w-full max-w-md">
-                    <div class="flex flex-col justify-center items-center text-center">
-                        <div class="mb-4 text-lg font-semibold text-red-600">
-                            The material for this step is missing or has been deleted.
-                        </div>
-                        <x-filament-lms::next-button :fixed="false" />
+    @if (is_null($step->material_type))
+        {{-- Intentionally text-only step: show the next button --}}
+        <x-filament-lms::next-button />
+    @elseif (is_null($step->material))
+        {{-- Material type is set but material is missing (deleted): show error --}}
+        <div class="flex items-center justify-center min-h-[60vh]">
+            <x-filament::card class="py-12 w-full max-w-md">
+                <div class="flex flex-col justify-center items-center text-center">
+                    <div class="mb-4 text-lg font-semibold text-red-600">
+                        The material for this step is missing or has been deleted.
                     </div>
-                </x-filament::card>
-            </div>
-        @else
-            {{-- Text-only step: show the next button --}}
-            <x-filament-lms::next-button />
-        @endif
+                    <x-filament-lms::next-button :fixed="false" />
+                </div>
+            </x-filament::card>
+        </div>
     @elseif ($step->material_type == 'video')
         <livewire:video-step :step="$step"/>
     @elseif ($step->material_type == 'form')

--- a/src/Forms/Components/MorphToSelectWithCreate.php
+++ b/src/Forms/Components/MorphToSelectWithCreate.php
@@ -62,7 +62,7 @@ class MorphToSelectWithCreate
                     return $className::query()->pluck('name', 'id');
                 })
                 ->searchable()
-                ->nullable()
+                ->requiredWith('material_type')
                 ->suffixActions([
                     Action::make('create_video')
                         ->label('New')


### PR DESCRIPTION
# Details

This PR addresses two issues related to material handling in steps:

1.  **Correctly displays missing material errors**: The `step.blade.php` view now distinguishes between intentionally text-only steps (where `material_type` is null) and steps where material was deleted (where `material_type` is set but the material record is missing). An error message is now displayed when material is missing but a `material_type` was specified.
2.  **Enforces material selection in form**: The `MorphToSelectWithCreate` component now uses `requiredWith('material_type')` for the `material_id` field. This prevents users from selecting a `material_type` without also selecting an actual material item, ensuring data consistency.

---

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: view logic and form validation tweaks to prevent inconsistent step/material states; main risk is stricter validation blocking previously-saved partial entries.
> 
> **Overview**
> Improves step material consistency by treating `material_type = null` as an intentionally text-only step (shows only the next button) while showing an explicit error state when `material_type` is set but the linked material record is missing.
> 
> Tightens the step material form by making `material_id` `requiredWith('material_type')`, preventing users from selecting a material type without choosing an actual material.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d2b7e39a1ce027cdf9f17e601db7e6f4c2b9cbf2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->