### PR TITLE
Add placeholder to MorphToSelectWithCreate component

### DIFF
--- a/src/Forms/Components/MorphToSelectWithCreate.php
+++ b/src/Forms/Components/MorphToSelectWithCreate.php
@@ -31,6 +31,7 @@ class MorphToSelectWithCreate
                     'test' => 'Test',
                 ])
                 ->live()
+                ->placeholder('Select a material type if needed')
                 ->nullable()
                 ->afterStateUpdated(function (Set $set) {
                     $set('material_id', null);


### PR DESCRIPTION
This allows to unselect the select dropdown if already set

# Details

Details of the feature / fix this PR addresses.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only change to form behavior/UX with no data model or business-logic changes.
> 
> **Overview**
> Adds a placeholder to the `material_type` `Select` in `MorphToSelectWithCreate`, allowing the dropdown to be cleared/unselected when no material type is desired.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9d300840b56aa1f73781433613c76e8fe9b256b3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->