### PR TITLE
update slug logic

### DIFF
--- a/database/factories/StepFactory.php
+++ b/database/factories/StepFactory.php
@@ -30,7 +30,7 @@ class StepFactory extends Factory
             'slug' => function (array $attributes) {
                 $lessonId = $attributes['lesson_id'] ?? null;
                 $stepName = $attributes['name'] ?? $this->faker->unique()->word();
-                if (! $lessonId) {
+                if (! $lessonId || ! is_numeric($lessonId)) {
                     return Str::slug($stepName);
                 }
                 $lesson = Lesson::find($lessonId);

--- a/database/factories/StepFactory.php
+++ b/database/factories/StepFactory.php
@@ -23,12 +23,20 @@ class StepFactory extends Factory
     public function definition(): array
     {
         $name = $this->faker->unique()->word();
-        $slug = Str::slug($name);
 
         return [
             'name' => $name,
-            'slug' => $slug,
             'lesson_id' => Lesson::factory()->lazy(),
+            'slug' => function (array $attributes) {
+                $lessonId = $attributes['lesson_id'] ?? null;
+                $stepName = $attributes['name'] ?? $this->faker->unique()->word();
+                if (! $lessonId) {
+                    return Str::slug($stepName);
+                }
+                $lesson = Lesson::find($lessonId);
+
+                return $lesson ? $lesson->slug.'-'.Str::slug($stepName) : Str::slug($stepName);
+            },
             'order' => 1,
             'material_type' => 'video',
             'material_id' => Video::factory()->lazy(),

--- a/src/Resources/StepResource.php
+++ b/src/Resources/StepResource.php
@@ -61,6 +61,20 @@ final class StepResource extends Resource
         return Step::getTenantRelationshipName();
     }
 
+    /**
+     * Generate a slug for a step based on its lesson and name.
+     */
+    private static function generateStepSlug(?int $lessonId, ?string $name): ?string
+    {
+        if (! $lessonId || $name === null || $name === '') {
+            return null;
+        }
+        
+        $lesson = Lesson::find($lessonId);
+        
+        return $lesson ? $lesson->slug.'-'.Str::slug($name) : null;
+    }
+
     public static function form(Schema $schema): Schema
     {
         return $schema
@@ -71,13 +85,9 @@ final class StepResource extends Resource
                         if (isset($livewire->record)) {
                             return;
                         }
-                        $lessonId = $get('lesson_id');
-                        if (! $lessonId || $state === null || $state === '') {
-                            return;
-                        }
-                        $lesson = Lesson::find($lessonId);
-                        if ($lesson) {
-                            $set('slug', $lesson->slug.'-'.Str::slug($state));
+                        $slug = self::generateStepSlug($get('lesson_id'), $state);
+                        if ($slug) {
+                            $set('slug', $slug);
                         }
                     })
                     ->required(),
@@ -105,13 +115,9 @@ final class StepResource extends Resource
                         if (isset($livewire->record)) {
                             return;
                         }
-                        $name = $get('name');
-                        if (! $state || $name === null || $name === '') {
-                            return;
-                        }
-                        $lesson = Lesson::find($state);
-                        if ($lesson) {
-                            $set('slug', $lesson->slug.'-'.Str::slug($name));
+                        $slug = self::generateStepSlug($state, $get('name'));
+                        if ($slug) {
+                            $set('slug', $slug);
                         }
                     }),
                 Checkbox::make('is_optional')

--- a/src/Resources/StepResource.php
+++ b/src/Resources/StepResource.php
@@ -68,7 +68,7 @@ final class StepResource extends Resource
                 TextInput::make('name')
                     ->live(onBlur: true)
                     ->afterStateUpdated(function (Set $set, Get $get, ?string $state, $livewire) {
-                        if (isset($livewire->record) && $livewire->record !== null) {
+                        if (isset($livewire->record)) {
                             return;
                         }
                         $lessonId = $get('lesson_id');
@@ -102,7 +102,7 @@ final class StepResource extends Resource
                                 }
                             }
                         }
-                        if (isset($livewire->record) && $livewire->record !== null) {
+                        if (isset($livewire->record)) {
                             return;
                         }
                         $name = $get('name');

--- a/src/Resources/StepResource.php
+++ b/src/Resources/StepResource.php
@@ -69,9 +69,9 @@ final class StepResource extends Resource
         if (! $lessonId || $name === null || $name === '') {
             return null;
         }
-        
+
         $lesson = Lesson::find($lessonId);
-        
+
         return $lesson ? $lesson->slug.'-'.Str::slug($name) : null;
     }
 

--- a/src/Resources/StepResource.php
+++ b/src/Resources/StepResource.php
@@ -64,8 +64,11 @@ final class StepResource extends Resource
     /**
      * Generate a slug for a step based on its lesson and name.
      */
-    private static function generateStepSlug(?int $lessonId, ?string $name): ?string
+    private static function generateStepSlug(int|string|null $lessonId, ?string $name): ?string
     {
+        // Cast lesson ID to int (Filament forms may pass string values)
+        $lessonId = $lessonId ? (int) $lessonId : null;
+
         if (! $lessonId || $name === null || $name === '') {
             return null;
         }

--- a/src/Resources/StepResource.php
+++ b/src/Resources/StepResource.php
@@ -22,6 +22,7 @@ use Filament\Tables\Table;
 use Illuminate\Support\Str;
 use Tapp\FilamentLms\Concerns\HasLmsSlug;
 use Tapp\FilamentLms\Forms\Components\MorphToSelectWithCreate;
+use Tapp\FilamentLms\Models\Lesson;
 use Tapp\FilamentLms\Models\Step;
 use Tapp\FilamentLms\Resources\StepResource\Pages\CreateStep;
 use Tapp\FilamentLms\Resources\StepResource\Pages\EditStep;
@@ -66,8 +67,18 @@ final class StepResource extends Resource
             ->components([
                 TextInput::make('name')
                     ->live(onBlur: true)
-                    ->afterStateUpdated(function (Set $set, ?string $state) {
-                        $set('slug', Str::slug($state));
+                    ->afterStateUpdated(function (Set $set, Get $get, ?string $state, $livewire) {
+                        if (isset($livewire->record) && $livewire->record !== null) {
+                            return;
+                        }
+                        $lessonId = $get('lesson_id');
+                        if (! $lessonId || $state === null || $state === '') {
+                            return;
+                        }
+                        $lesson = Lesson::find($lessonId);
+                        if ($lesson) {
+                            $set('slug', $lesson->slug.'-'.Str::slug($state));
+                        }
                     })
                     ->required(),
                 TextInput::make('slug')
@@ -79,10 +90,9 @@ final class StepResource extends Resource
                     ->preload()
                     ->required()
                     ->live()
-                    ->afterStateUpdated(function (Set $set, ?string $state, $livewire) {
-                        // Clear retry_step_id if the lesson changes to a different course
+                    ->afterStateUpdated(function (Set $set, Get $get, $state, $livewire) {
                         if ($state) {
-                            $newLesson = \Tapp\FilamentLms\Models\Lesson::find($state);
+                            $newLesson = Lesson::find($state);
                             $currentRetryStepId = $livewire->data['retry_step_id'] ?? null;
 
                             if ($currentRetryStepId && $newLesson) {
@@ -91,6 +101,17 @@ final class StepResource extends Resource
                                     $set('retry_step_id', null);
                                 }
                             }
+                        }
+                        if (isset($livewire->record) && $livewire->record !== null) {
+                            return;
+                        }
+                        $name = $get('name');
+                        if (! $state || $name === null || $name === '') {
+                            return;
+                        }
+                        $lesson = Lesson::find($state);
+                        if ($lesson) {
+                            $set('slug', $lesson->slug.'-'.Str::slug($name));
                         }
                     }),
                 Checkbox::make('is_optional')

--- a/tests/Feature/StepTest.php
+++ b/tests/Feature/StepTest.php
@@ -24,6 +24,17 @@ test('step can be created with required fields', function () {
     expect($step->lesson_id)->toBe($lesson->id);
 });
 
+test('step factory generates composite slug when slug not passed', function () {
+    $course = Course::factory()->create();
+    $lesson = Lesson::factory()->create(['course_id' => $course->id, 'slug' => 'intro-lesson']);
+    $step = Step::factory()->create([
+        'lesson_id' => $lesson->id,
+        'name' => 'Watch the video',
+    ]);
+
+    expect($step->slug)->toBe('intro-lesson-watch-the-video');
+});
+
 test('step belongs to lesson', function () {
     $course = Course::factory()->create();
     $lesson = Lesson::factory()->create(['course_id' => $course->id]);


### PR DESCRIPTION
# Details

* Step Slug should not auto-change on edit
* Step slug should concatenate the lesson slug on the step on creation

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to slug generation in the Step factory and admin form; low impact outside creation flows, with minor risk of unexpected slug formats in tests/seed data and new step creation UX.
> 
> **Overview**
> **Step slug generation is updated to be lesson-aware on creation and no longer auto-mutates on edits.**
> 
> `StepFactory` now defaults `slug` to `${lesson.slug}-${step-name}` when a valid `lesson_id` is present (falling back to `Str::slug(name)` otherwise), and a new feature test asserts this composite behavior.
> 
> In `StepResource`, slug auto-fill is refactored into `generateStepSlug()` and is only applied during create (guarded by `isset($livewire->record)`), updating the slug when either `name` or `lesson_id` changes while creating a step.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 96a5778cf36bd7778db439a68941f6173ec752a8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->