### PR TITLE
Fix reporting page: Eloquent wrapper, configurable user name, filters

### DIFF
--- a/config/filament-lms.php
+++ b/config/filament-lms.php
@@ -41,6 +41,10 @@ return [
         'email',
     ],
 
+    // User name columns for the course progress report. Use ['first_name', 'last_name'] when the
+    // users table has first_name and last_name, or ['name'] when it has a single name column.
+    'report_user_name_columns' => ['first_name', 'last_name'],
+
     // Media URL configuration
     'media' => [
         // If true, generates signed URLs for private storage (S3, etc.)

--- a/src/Models/CourseProgressReportRow.php
+++ b/src/Models/CourseProgressReportRow.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tapp\FilamentLms\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+/**
+ * Dummy model used only to wrap the course progress report query in an
+ * Eloquent Builder so Filament Tables accept it (they require Builder|Closure|null, not Query\Builder).
+ */
+class CourseProgressReportRow extends Model
+{
+    protected $table = 'report';
+
+    public $timestamps = false;
+
+    protected $keyType = 'string';
+
+    public $incrementing = false;
+}

--- a/src/Pages/Reporting.php
+++ b/src/Pages/Reporting.php
@@ -20,6 +20,7 @@ use Illuminate\Support\Facades\Gate;
 use Maatwebsite\Excel\Facades\Excel;
 use Tapp\FilamentLms\Exports\CourseProgressExport;
 use Tapp\FilamentLms\Models\Course;
+use Tapp\FilamentLms\Models\CourseProgressReportRow;
 use Tapp\FilamentLms\Services\CourseProgressQueryService;
 
 class Reporting extends Page implements HasTable
@@ -59,8 +60,11 @@ class Reporting extends Page implements HasTable
 
     public function table(Table $table): Table
     {
+        $rawQuery = CourseProgressQueryService::buildQuery();
+        $query = CourseProgressReportRow::query()->fromSub($rawQuery, 'report');
+
         return $table
-            ->query(CourseProgressQueryService::buildQuery())
+            ->query($query)
             ->columns([
                 TextColumn::make('user_first_name')
                     ->label('First Name')
@@ -136,11 +140,11 @@ class Reporting extends Page implements HasTable
                         return $query
                             ->when(
                                 $data['completed_from'],
-                                fn (Builder $q, $date): Builder => $q->whereDate('lms_course_user.completed_at', '>=', $date),
+                                fn (Builder $q, $date): Builder => $q->whereDate('completed_at', '>=', $date),
                             )
                             ->when(
                                 $data['completed_until'],
-                                fn (Builder $q, $date): Builder => $q->whereDate('lms_course_user.completed_at', '<=', $date),
+                                fn (Builder $q, $date): Builder => $q->whereDate('completed_at', '<=', $date),
                             );
                     })
                     ->indicateUsing(function (array $data): array {
@@ -163,10 +167,10 @@ class Reporting extends Page implements HasTable
                         'In Progress' => 'In Progress',
                     ])
                     ->query(function (Builder $query, array $data): Builder {
-                        return $query->when($data['value'], function ($q, $status) {
+                        return $query->when($data['value'], function (Builder $q, $status): Builder {
                             return $status === 'Completed'
-                                ? $q->whereNotNull('lms_course_user.completed_at')
-                                : $q->whereNull('lms_course_user.completed_at');
+                                ? $q->whereNotNull('completed_at')
+                                : $q->whereNull('completed_at');
                         });
                     }),
 

--- a/src/Services/CourseProgressQueryService.php
+++ b/src/Services/CourseProgressQueryService.php
@@ -4,6 +4,7 @@ namespace Tapp\FilamentLms\Services;
 
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Query\Builder as QueryBuilder;
+use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\DB;
 
 class CourseProgressQueryService
@@ -13,16 +14,53 @@ class CourseProgressQueryService
      * in-progress users appear even when they are not yet in lms_course_user. Completion comes
      * from lms_course_user.completed_at when present.
      *
+     * User name columns come from config 'report_user_name_columns': ['first_name', 'last_name']
+     * or ['name'] for a single name column (exposed as first name, last name empty).
+     *
      * @return Builder|QueryBuilder
      */
     public static function buildQuery()
     {
+        $nameColumns = Config::get('filament-lms.report_user_name_columns', ['first_name', 'last_name']);
+        $isSingleName = $nameColumns === ['name'] || (count($nameColumns) === 1 && $nameColumns[0] === 'name');
+
+        $userNameSelect = $isSingleName
+            ? ['users.name as user_first_name', DB::raw("'' as user_last_name")]
+            : ['users.first_name as user_first_name', 'users.last_name as user_last_name'];
+
+        $userNameGroupBy = $isSingleName
+            ? ['users.id', 'users.name', 'users.email']
+            : ['users.id', 'users.first_name', 'users.last_name', 'users.email'];
+
         $participants = DB::table('lms_step_user')
             ->select('lms_step_user.user_id')
             ->selectRaw('l.course_id')
             ->join('lms_steps as s', 's.id', '=', 'lms_step_user.step_id')
             ->join('lms_lessons as l', 'l.id', '=', 's.lesson_id')
             ->distinct();
+
+        $select = array_merge(
+            [
+                DB::raw("CONCAT(participants.user_id, '-', participants.course_id) as id"),
+                'users.id as user_id',
+                'users.email as user_email',
+                'lms_courses.id as course_id',
+                'lms_courses.name as course_name',
+                DB::raw('MIN(lms_step_user.created_at) as started_at'),
+                'lms_course_user.completed_at as completed_at',
+                'lms_course_user.completed_at as completion_date',
+                DB::raw('COUNT(DISTINCT CASE WHEN lms_step_user.completed_at IS NOT NULL THEN lms_step_user.step_id END) as steps_completed'),
+                DB::raw('(SELECT COUNT(DISTINCT s2.id) FROM lms_steps s2 JOIN lms_lessons l2 ON s2.lesson_id = l2.id WHERE l2.course_id = lms_courses.id) as total_steps'),
+                DB::raw("CASE WHEN lms_course_user.completed_at IS NOT NULL THEN 'Completed' ELSE 'In Progress' END as status"),
+            ],
+            $userNameSelect
+        );
+
+        $groupBy = array_merge(
+            ['participants.user_id', 'participants.course_id', 'lms_course_user.completed_at'],
+            $userNameGroupBy,
+            ['lms_courses.id', 'lms_courses.name']
+        );
 
         return DB::table(DB::raw('('.$participants->toSql().') as participants'))
             ->mergeBindings($participants)
@@ -38,21 +76,8 @@ class CourseProgressQueryService
                 $join->on('lms_step_user.step_id', '=', 'lms_steps.id')
                     ->on('lms_step_user.user_id', '=', 'participants.user_id');
             })
-            ->select([
-                'users.id as user_id',
-                'users.first_name as user_first_name',
-                'users.last_name as user_last_name',
-                'users.email as user_email',
-                'lms_courses.id as course_id',
-                'lms_courses.name as course_name',
-                DB::raw('MIN(lms_step_user.created_at) as started_at'),
-                'lms_course_user.completed_at as completed_at',
-                'lms_course_user.completed_at as completion_date',
-                DB::raw('COUNT(DISTINCT CASE WHEN lms_step_user.completed_at IS NOT NULL THEN lms_step_user.step_id END) as steps_completed'),
-                DB::raw('(SELECT COUNT(DISTINCT s2.id) FROM lms_steps s2 JOIN lms_lessons l2 ON s2.lesson_id = l2.id WHERE l2.course_id = lms_courses.id) as total_steps'),
-                DB::raw("CASE WHEN lms_course_user.completed_at IS NOT NULL THEN 'Completed' ELSE 'In Progress' END as status"),
-            ])
-            ->groupBy('participants.user_id', 'participants.course_id', 'lms_course_user.completed_at', 'users.id', 'users.first_name', 'users.last_name', 'users.email', 'lms_courses.id', 'lms_courses.name')
+            ->select($select)
+            ->groupBy($groupBy)
             ->orderBy('users.id', 'asc')
             ->orderBy('lms_courses.id', 'asc');
     }
@@ -64,9 +89,9 @@ class CourseProgressQueryService
     public static function sortByStatus($query, $direction)
     {
         return $query->reorder()
-            ->orderByRaw("CASE WHEN lms_course_user.completed_at IS NOT NULL THEN 1 ELSE 0 END {$direction}")
-            ->orderBy('users.id', 'asc')
-            ->orderBy('lms_courses.id', 'asc');
+            ->orderBy('status', $direction)
+            ->orderBy('user_id', 'asc')
+            ->orderBy('course_id', 'asc');
     }
 
     /**
@@ -76,9 +101,9 @@ class CourseProgressQueryService
     public static function sortByFirstName($query, $direction)
     {
         return $query->reorder()
-            ->orderBy('users.first_name', $direction)
-            ->orderBy('users.id', 'asc')
-            ->orderBy('lms_courses.id', 'asc');
+            ->orderBy('user_first_name', $direction)
+            ->orderBy('user_id', 'asc')
+            ->orderBy('course_id', 'asc');
     }
 
     /**
@@ -88,9 +113,9 @@ class CourseProgressQueryService
     public static function sortByLastName($query, $direction)
     {
         return $query->reorder()
-            ->orderBy('users.last_name', $direction)
-            ->orderBy('users.id', 'asc')
-            ->orderBy('lms_courses.id', 'asc');
+            ->orderBy('user_last_name', $direction)
+            ->orderBy('user_id', 'asc')
+            ->orderBy('course_id', 'asc');
     }
 
     /**
@@ -100,9 +125,9 @@ class CourseProgressQueryService
     public static function sortByEmail($query, $direction)
     {
         return $query->reorder()
-            ->orderBy('users.email', $direction)
-            ->orderBy('users.id', 'asc')
-            ->orderBy('lms_courses.id', 'asc');
+            ->orderBy('user_email', $direction)
+            ->orderBy('user_id', 'asc')
+            ->orderBy('course_id', 'asc');
     }
 
     /**
@@ -112,9 +137,9 @@ class CourseProgressQueryService
     public static function sortByCourseName($query, $direction)
     {
         return $query->reorder()
-            ->orderBy('lms_courses.name', $direction)
-            ->orderBy('users.id', 'asc')
-            ->orderBy('lms_courses.id', 'asc');
+            ->orderBy('course_name', $direction)
+            ->orderBy('user_id', 'asc')
+            ->orderBy('course_id', 'asc');
     }
 
     /**
@@ -125,8 +150,8 @@ class CourseProgressQueryService
     {
         return $query->reorder()
             ->orderBy('steps_completed', $direction)
-            ->orderBy('users.id', 'asc')
-            ->orderBy('lms_courses.id', 'asc');
+            ->orderBy('user_id', 'asc')
+            ->orderBy('course_id', 'asc');
     }
 
     /**
@@ -137,8 +162,8 @@ class CourseProgressQueryService
     {
         return $query->reorder()
             ->orderBy('started_at', $direction)
-            ->orderBy('users.id', 'asc')
-            ->orderBy('lms_courses.id', 'asc');
+            ->orderBy('user_id', 'asc')
+            ->orderBy('course_id', 'asc');
     }
 
     /**
@@ -148,8 +173,8 @@ class CourseProgressQueryService
     public static function sortByCompletedAt($query, $direction)
     {
         return $query->reorder()
-            ->orderBy('lms_course_user.completed_at', $direction)
-            ->orderBy('users.id', 'asc')
-            ->orderBy('lms_courses.id', 'asc');
+            ->orderBy('completed_at', $direction)
+            ->orderBy('user_id', 'asc')
+            ->orderBy('course_id', 'asc');
     }
 }


### PR DESCRIPTION
## Summary
- **CourseProgressReportRow** model wraps the course progress report query in an Eloquent Builder so Filament Tables accept it (they require Builder|Closure|null, not Query\\Builder).
- **report_user_name_columns** config supports `['first_name', 'last_name']` or `['name']` for apps with a single name column; report columns remain user_first_name / user_last_name.
- Filters and sort methods use the **report** column names (e.g. `completed_at`) so they work with the derived table; added synthetic `id` for default ordering.
- Fix `CourseProgressReportRow::$keyType` to be untyped to match parent Model.

## Testing
- Package tests: `CourseProgressQueryServiceTest` passes.
- Consuming app: set `report_user_name_columns` => `['name']` and use `user_search_columns` => `['name', 'email']` when users table has a single `name` column.

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core reporting SQL (selects, grouping, and ordering) and changes how Filament queries the dataset, which could affect report correctness/performance across different user schemas.
> 
> **Overview**
> Fixes the reporting table by wrapping the course progress query in a new dummy Eloquent model (`CourseProgressReportRow`) and querying it via `fromSub(...)`, so Filament Tables can operate on the results.
> 
> Adds `filament-lms.report_user_name_columns` to support apps with either `first_name`/`last_name` or a single `name` column, and updates the report query to select/group by the configured columns while exposing consistent `user_first_name`/`user_last_name` aliases (plus a synthetic composite `id`).
> 
> Updates reporting filters and all `CourseProgressQueryService` sort helpers to use the derived report column aliases (e.g., `completed_at`, `status`, `user_email`) instead of underlying table-qualified fields, ensuring sorting/filtering works against the subquery.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8cf3a5c9e4b80372d47609c86e66948fbcc71344. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->