### PR TITLE
Table actions in ActionGroup at row start

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,6 @@
 {
     "name": "tapp/filament-lms",
+    "version": "4.1.9",
     "type": "library",
     "license": "MIT",
     "authors": [

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,5 @@
 {
     "name": "tapp/filament-lms",
-    "version": "4.1.9",
     "type": "library",
     "license": "MIT",
     "authors": [

--- a/src/RelationManagers/CourseUsersRelationManager.php
+++ b/src/RelationManagers/CourseUsersRelationManager.php
@@ -2,6 +2,7 @@
 
 namespace Tapp\FilamentLms\RelationManagers;
 
+use Filament\Actions\ActionGroup;
 use Filament\Actions\AttachAction;
 use Filament\Actions\BulkActionGroup;
 use Filament\Actions\DetachAction;
@@ -10,6 +11,7 @@ use Filament\Forms;
 use Filament\Resources\RelationManagers\RelationManager;
 use Filament\Schemas\Schema;
 use Filament\Tables;
+use Filament\Tables\Enums\RecordActionsPosition;
 use Filament\Tables\Table;
 use Illuminate\Database\Eloquent\Builder;
 
@@ -82,8 +84,10 @@ class CourseUsersRelationManager extends RelationManager
                     ]),
             ])
             ->recordActions([
-                DetachAction::make(),
-            ])
+                ActionGroup::make([
+                    DetachAction::make(),
+                ]),
+            ], position: RecordActionsPosition::BeforeColumns)
             ->toolbarActions([
                 BulkActionGroup::make([
                     DetachBulkAction::make(),

--- a/src/RelationManagers/CoursesRelationManager.php
+++ b/src/RelationManagers/CoursesRelationManager.php
@@ -2,10 +2,12 @@
 
 namespace Tapp\FilamentLms\RelationManagers;
 
+use Filament\Actions\ActionGroup;
 use Filament\Actions\AttachAction;
 use Filament\Actions\DetachAction;
 use Filament\Resources\RelationManagers\RelationManager;
 use Filament\Tables\Columns\TextColumn;
+use Filament\Tables\Enums\RecordActionsPosition;
 use Filament\Tables\Table;
 
 class CoursesRelationManager extends RelationManager
@@ -35,7 +37,9 @@ class CoursesRelationManager extends RelationManager
                 AttachAction::make()->label('Add Course')->preloadRecordSelect(),
             ])
             ->recordActions([
-                DetachAction::make()->label('Remove'),
-            ]);
+                ActionGroup::make([
+                    DetachAction::make()->label('Remove'),
+                ]),
+            ], position: RecordActionsPosition::BeforeColumns);
     }
 }

--- a/src/Resources/CourseResource.php
+++ b/src/Resources/CourseResource.php
@@ -2,6 +2,7 @@
 
 namespace Tapp\FilamentLms\Resources;
 
+use Filament\Actions\ActionGroup;
 use Filament\Actions\BulkActionGroup;
 use Filament\Actions\DeleteBulkAction;
 use Filament\Actions\EditAction;
@@ -15,6 +16,7 @@ use Filament\Resources\Resource;
 use Filament\Schemas\Components\Utilities\Set;
 use Filament\Schemas\Schema;
 use Filament\Tables\Columns\TextColumn;
+use Filament\Tables\Enums\RecordActionsPosition;
 use Filament\Tables\Table;
 use Illuminate\Support\HtmlString;
 use Illuminate\Support\Str;
@@ -154,8 +156,10 @@ class CourseResource extends Resource
                 //
             ])
             ->recordActions([
-                EditAction::make(),
-            ])
+                ActionGroup::make([
+                    EditAction::make(),
+                ]),
+            ], position: RecordActionsPosition::BeforeColumns)
             ->toolbarActions([
                 BulkActionGroup::make([
                     DeleteBulkAction::make(),

--- a/src/Resources/CourseResource/RelationManagers/LessonsRelationManager.php
+++ b/src/Resources/CourseResource/RelationManagers/LessonsRelationManager.php
@@ -2,6 +2,7 @@
 
 namespace Tapp\FilamentLms\Resources\CourseResource\RelationManagers;
 
+use Filament\Actions\ActionGroup;
 use Filament\Actions\BulkActionGroup;
 use Filament\Actions\CreateAction;
 use Filament\Actions\DeleteAction;
@@ -13,6 +14,7 @@ use Filament\Resources\RelationManagers\RelationManager;
 use Filament\Schemas\Components\Utilities\Set;
 use Filament\Schemas\Schema;
 use Filament\Tables\Columns\TextColumn;
+use Filament\Tables\Enums\RecordActionsPosition;
 use Filament\Tables\Table;
 use Illuminate\Support\Str;
 use Tapp\FilamentLms\Resources\LessonResource\Pages\CreateLesson;
@@ -60,10 +62,12 @@ class LessonsRelationManager extends RelationManager
                     ->url(fn () => CreateLesson::getUrl(['course_id' => $this->ownerRecord])),
             ])
             ->recordActions([
-                EditAction::make()
-                    ->url(fn ($record) => EditLesson::getUrl([$record])),
-                DeleteAction::make(),
-            ])
+                ActionGroup::make([
+                    EditAction::make()
+                        ->url(fn ($record) => EditLesson::getUrl([$record])),
+                    DeleteAction::make(),
+                ]),
+            ], position: RecordActionsPosition::BeforeColumns)
             ->toolbarActions([
                 BulkActionGroup::make([
                     DeleteBulkAction::make(),

--- a/src/Resources/DocumentResource.php
+++ b/src/Resources/DocumentResource.php
@@ -2,6 +2,7 @@
 
 namespace Tapp\FilamentLms\Resources;
 
+use Filament\Actions\ActionGroup;
 use Filament\Actions\BulkActionGroup;
 use Filament\Actions\DeleteBulkAction;
 use Filament\Actions\EditAction;
@@ -12,6 +13,7 @@ use Filament\Forms\Components\TextInput;
 use Filament\Resources\Resource;
 use Filament\Schemas\Schema;
 use Filament\Tables\Columns\TextColumn;
+use Filament\Tables\Enums\RecordActionsPosition;
 use Filament\Tables\Filters\TrashedFilter;
 use Filament\Tables\Table;
 use Illuminate\Database\Eloquent\Builder;
@@ -95,8 +97,10 @@ class DocumentResource extends Resource
                 TrashedFilter::make(),
             ])
             ->recordActions([
-                EditAction::make(),
-            ])
+                ActionGroup::make([
+                    EditAction::make(),
+                ]),
+            ], position: RecordActionsPosition::BeforeColumns)
             ->toolbarActions([
                 BulkActionGroup::make([
                     DeleteBulkAction::make(),

--- a/src/Resources/ImageResource.php
+++ b/src/Resources/ImageResource.php
@@ -2,6 +2,7 @@
 
 namespace Tapp\FilamentLms\Resources;
 
+use Filament\Actions\ActionGroup;
 use Filament\Actions\BulkActionGroup;
 use Filament\Actions\DeleteBulkAction;
 use Filament\Actions\EditAction;
@@ -12,6 +13,7 @@ use Filament\Forms\Components\TextInput;
 use Filament\Resources\Resource;
 use Filament\Schemas\Schema;
 use Filament\Tables\Columns\TextColumn;
+use Filament\Tables\Enums\RecordActionsPosition;
 use Filament\Tables\Filters\TrashedFilter;
 use Filament\Tables\Table;
 use Illuminate\Database\Eloquent\Builder;
@@ -85,8 +87,10 @@ class ImageResource extends Resource
                 TrashedFilter::make(),
             ])
             ->recordActions([
-                EditAction::make(),
-            ])
+                ActionGroup::make([
+                    EditAction::make(),
+                ]),
+            ], position: RecordActionsPosition::BeforeColumns)
             ->toolbarActions([
                 BulkActionGroup::make([
                     DeleteBulkAction::make(),

--- a/src/Resources/LessonResource.php
+++ b/src/Resources/LessonResource.php
@@ -2,6 +2,7 @@
 
 namespace Tapp\FilamentLms\Resources;
 
+use Filament\Actions\ActionGroup;
 use Filament\Actions\BulkActionGroup;
 use Filament\Actions\DeleteBulkAction;
 use Filament\Actions\EditAction;
@@ -11,6 +12,7 @@ use Filament\Resources\Resource;
 use Filament\Schemas\Components\Utilities\Set;
 use Filament\Schemas\Schema;
 use Filament\Tables\Columns\TextColumn;
+use Filament\Tables\Enums\RecordActionsPosition;
 use Filament\Tables\Table;
 use Illuminate\Support\Str;
 use Tapp\FilamentLms\Concerns\HasLmsSlug;
@@ -90,8 +92,10 @@ class LessonResource extends Resource
                 //
             ])
             ->recordActions([
-                EditAction::make(),
-            ])
+                ActionGroup::make([
+                    EditAction::make(),
+                ]),
+            ], position: RecordActionsPosition::BeforeColumns)
             ->toolbarActions([
                 BulkActionGroup::make([
                     DeleteBulkAction::make(),

--- a/src/Resources/LessonResource/RelationManagers/StepsRelationManager.php
+++ b/src/Resources/LessonResource/RelationManagers/StepsRelationManager.php
@@ -2,6 +2,7 @@
 
 namespace Tapp\FilamentLms\Resources\LessonResource\RelationManagers;
 
+use Filament\Actions\ActionGroup;
 use Filament\Actions\BulkActionGroup;
 use Filament\Actions\CreateAction;
 use Filament\Actions\DeleteAction;
@@ -12,6 +13,7 @@ use Filament\Forms\Components\TextInput;
 use Filament\Resources\RelationManagers\RelationManager;
 use Filament\Schemas\Schema;
 use Filament\Tables\Columns\TextColumn;
+use Filament\Tables\Enums\RecordActionsPosition;
 use Filament\Tables\Table;
 use Tapp\FilamentLms\Resources\StepResource\Pages\CreateStep;
 use Tapp\FilamentLms\Resources\StepResource\Pages\EditStep;
@@ -61,10 +63,12 @@ class StepsRelationManager extends RelationManager
                     ->url(fn () => CreateStep::getUrl(['lesson_id' => $this->ownerRecord])),
             ])
             ->recordActions([
-                EditAction::make()
-                    ->url(fn ($record) => EditStep::getUrl([$record])),
-                DeleteAction::make(),
-            ])
+                ActionGroup::make([
+                    EditAction::make()
+                        ->url(fn ($record) => EditStep::getUrl([$record])),
+                    DeleteAction::make(),
+                ]),
+            ], position: RecordActionsPosition::BeforeColumns)
             ->toolbarActions([
                 BulkActionGroup::make([
                     DeleteBulkAction::make(),

--- a/src/Resources/LinkResource.php
+++ b/src/Resources/LinkResource.php
@@ -3,6 +3,7 @@
 namespace Tapp\FilamentLms\Resources;
 
 use Filament\Actions\Action;
+use Filament\Actions\ActionGroup;
 use Filament\Actions\BulkActionGroup;
 use Filament\Actions\DeleteBulkAction;
 use Filament\Actions\EditAction;
@@ -14,6 +15,7 @@ use Filament\Resources\Resource;
 use Filament\Schemas\Components\Actions;
 use Filament\Schemas\Schema;
 use Filament\Tables\Columns\TextColumn;
+use Filament\Tables\Enums\RecordActionsPosition;
 use Filament\Tables\Filters\TrashedFilter;
 use Filament\Tables\Table;
 use Illuminate\Database\Eloquent\Builder;
@@ -104,8 +106,10 @@ class LinkResource extends Resource
                 TrashedFilter::make(),
             ])
             ->recordActions([
-                EditAction::make(),
-            ])
+                ActionGroup::make([
+                    EditAction::make(),
+                ]),
+            ], position: RecordActionsPosition::BeforeColumns)
             ->toolbarActions([
                 BulkActionGroup::make([
                     DeleteBulkAction::make(),

--- a/src/Resources/StepResource.php
+++ b/src/Resources/StepResource.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Tapp\FilamentLms\Resources;
 
 use BackedEnum;
+use Filament\Actions\ActionGroup;
 use Filament\Actions\BulkActionGroup;
 use Filament\Actions\DeleteBulkAction;
 use Filament\Actions\EditAction;
@@ -18,6 +19,7 @@ use Filament\Schemas\Components\Utilities\Set;
 use Filament\Schemas\Schema;
 use Filament\Tables\Columns\IconColumn;
 use Filament\Tables\Columns\TextColumn;
+use Filament\Tables\Enums\RecordActionsPosition;
 use Filament\Tables\Table;
 use Illuminate\Support\Str;
 use Tapp\FilamentLms\Concerns\HasLmsSlug;
@@ -217,8 +219,10 @@ final class StepResource extends Resource
             ])
             ->filters([])
             ->recordActions([
-                EditAction::make(),
-            ])
+                ActionGroup::make([
+                    EditAction::make(),
+                ]),
+            ], position: RecordActionsPosition::BeforeColumns)
             ->toolbarActions([
                 BulkActionGroup::make([
                     DeleteBulkAction::make(),

--- a/src/Resources/TestResource.php
+++ b/src/Resources/TestResource.php
@@ -3,6 +3,7 @@
 namespace Tapp\FilamentLms\Resources;
 
 use Filament\Actions\Action;
+use Filament\Actions\ActionGroup;
 use Filament\Actions\BulkActionGroup;
 use Filament\Actions\DeleteBulkAction;
 use Filament\Actions\EditAction;
@@ -12,6 +13,7 @@ use Filament\Resources\Resource;
 use Filament\Schemas\Schema;
 use Filament\Tables\Columns\IconColumn;
 use Filament\Tables\Columns\TextColumn;
+use Filament\Tables\Enums\RecordActionsPosition;
 use Filament\Tables\Table;
 use Tapp\FilamentLms\Concerns\HasLmsSlug;
 use Tapp\FilamentLms\Models\Test;
@@ -99,24 +101,26 @@ class TestResource extends Resource
                 //
             ])
             ->recordActions([
-                EditAction::make(),
-                Action::make('create_rubric')
-                    ->color('success')
-                    ->action(function (Test $record) {
-                        return redirect(route('filament.admin.pages.create-rubric', ['test' => $record]));
-                    })
-                    ->visible(function (Test $record) {
-                        return ! $record->filament_form_user_id;
-                    }),
-                Action::make('view_rubric')
-                    ->color('success')
-                    ->action(function (Test $record) {
-                        return redirect(route('filament.admin.pages.view-rubric', ['test' => $record]));
-                    })
-                    ->visible(function (Test $record) {
-                        return $record->filament_form_user_id;
-                    }),
-            ])
+                ActionGroup::make([
+                    EditAction::make(),
+                    Action::make('create_rubric')
+                        ->color('success')
+                        ->action(function (Test $record) {
+                            return redirect(route('filament.admin.pages.create-rubric', ['test' => $record]));
+                        })
+                        ->visible(function (Test $record) {
+                            return ! $record->filament_form_user_id;
+                        }),
+                    Action::make('view_rubric')
+                        ->color('success')
+                        ->action(function (Test $record) {
+                            return redirect(route('filament.admin.pages.view-rubric', ['test' => $record]));
+                        })
+                        ->visible(function (Test $record) {
+                            return $record->filament_form_user_id;
+                        }),
+                ]),
+            ], position: RecordActionsPosition::BeforeColumns)
             ->toolbarActions([
                 BulkActionGroup::make([
                     DeleteBulkAction::make(),

--- a/src/Resources/VideoResource.php
+++ b/src/Resources/VideoResource.php
@@ -2,6 +2,7 @@
 
 namespace Tapp\FilamentLms\Resources;
 
+use Filament\Actions\ActionGroup;
 use Filament\Actions\BulkActionGroup;
 use Filament\Actions\DeleteBulkAction;
 use Filament\Actions\EditAction;
@@ -9,6 +10,7 @@ use Filament\Forms\Components\TextInput;
 use Filament\Resources\Resource;
 use Filament\Schemas\Schema;
 use Filament\Tables\Columns\TextColumn;
+use Filament\Tables\Enums\RecordActionsPosition;
 use Filament\Tables\Table;
 use Illuminate\Support\HtmlString;
 use Tapp\FilamentLms\Concerns\HasLmsSlug;
@@ -86,8 +88,10 @@ class VideoResource extends Resource
             ])
             ->filters([])
             ->recordActions([
-                EditAction::make(),
-            ])
+                ActionGroup::make([
+                    EditAction::make(),
+                ]),
+            ], position: RecordActionsPosition::BeforeColumns)
             ->toolbarActions([
                 BulkActionGroup::make([
                     DeleteBulkAction::make(),


### PR DESCRIPTION
Puts all admin table row actions in a single ActionGroup and positions them at row start (BeforeColumns).

- CourseResource, LessonResource, DocumentResource, LinkResource, TestResource, VideoResource, ImageResource, StepResource
- Relation managers: CoursesRelationManager, CourseUsersRelationManager, LessonsRelationManager, StepsRelationManager
- composer.json: add version for path repo installs

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only refactor of Filament table action presentation; behavior of the actions themselves is unchanged aside from their grouping/position.
> 
> **Overview**
> **Admin table UX change:** Updates multiple Filament resources and relation managers to wrap all per-row actions (e.g., `Edit`, `Delete`, `Detach`, rubric actions) into a single `ActionGroup` and places the action group at the start of each row via `RecordActionsPosition::BeforeColumns`.
> 
> This is applied consistently across LMS resources (`Course`, `Lesson`, `Step`, `Test`, `Video`, `Image`, `Document`, `Link`) and relation managers (course/users, user/courses, course/lessons, lesson/steps), without changing underlying business logic.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 335b0510adbc7694365229996f5715e5c52326e8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->