### PR TITLE
Add import course

### DIFF
--- a/database/migrations/change_name_to_text_on_lms_tests_table.php.stub
+++ b/database/migrations/change_name_to_text_on_lms_tests_table.php.stub
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('lms_tests', function (Blueprint $table): void {
+            $table->text('name')->change();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('lms_tests', function (Blueprint $table): void {
+            $table->string('name')->change();
+        });
+    }
+};

--- a/resources/views/livewire/video-step.blade.php
+++ b/resources/views/livewire/video-step.blade.php
@@ -3,6 +3,25 @@
         <livewire:vimeo-video :step="$step" :video="$video"/>
     @elseif ($video->provider == 'youtube')
         <livewire:video-player :step="$step" :video="$video"/>
+    @elseif ($video->provider == 'external')
+        <x-filament::section
+            icon="heroicon-o-arrow-top-right-on-square"
+            icon-color="primary"
+        >
+            <p class="mb-6">
+                This video is not embedded here. Open the link below to watch it in your browser.
+            </p>
+
+            <x-filament::button
+                wire:click="markExternalOpened"
+                href="{{ $video->url }}"
+                rel="noopener noreferrer"
+                target="_blank"
+                tag="a"
+            >
+                Open video
+            </x-filament::button>
+        </x-filament::section>
     @else
         Video provider "{{ $video->provider }}" not supported.
     @endif

--- a/src/FilamentLmsServiceProvider.php
+++ b/src/FilamentLmsServiceProvider.php
@@ -50,6 +50,7 @@ class FilamentLmsServiceProvider extends PackageServiceProvider
                 'add_completed_at_to_lms_course_user_table',
                 'make_material_nullable_in_lms_steps_table',
                 'backfill_lms_course_user_completed_at_from_step_dates',
+                'change_name_to_text_on_lms_tests_table',
             ])
             ->hasCommand(BackfillCourseCompletedAt::class)
             ->hasInstallCommand(function (InstallCommand $command) {

--- a/src/Imports/CourseStepsImport.php
+++ b/src/Imports/CourseStepsImport.php
@@ -90,7 +90,8 @@ class CourseStepsImport implements ToCollection, WithHeadingRow
 
             if ($hasStepNameColumn) {
                 $lessonName = $this->value($row, 'lesson_name');
-                $lessonName = $lessonName !== null ? trim((string) $lessonName) : $this->courseName;
+                $lessonNameTrimmed = $lessonName !== null ? trim((string) $lessonName) : '';
+                $lessonName = $lessonNameTrimmed !== '' ? $lessonNameTrimmed : $this->courseName;
                 if (! isset($lessons[$lessonName])) {
                     $lessonOrder++;
                     $lessons[$lessonName] = Lesson::create([

--- a/src/Imports/CourseStepsImport.php
+++ b/src/Imports/CourseStepsImport.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Tapp\FilamentLms\Imports;
 
 use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Str;
 use Maatwebsite\Excel\Concerns\ToCollection;
 use Maatwebsite\Excel\Concerns\WithHeadingRow;
@@ -62,6 +63,13 @@ class CourseStepsImport implements ToCollection, WithHeadingRow
             throw new \InvalidArgumentException('Unrecognized CSV format. Expected at least "Step Name" or "Lesson Name" column.');
         }
 
+        DB::transaction(function () use ($rows, $hasStepNameColumn, $hasScriptColumn): void {
+            $this->importRows($rows, $hasStepNameColumn, $hasScriptColumn);
+        });
+    }
+
+    protected function importRows(Collection $rows, bool $hasStepNameColumn, bool $hasScriptColumn): void
+    {
         $course = Course::create([
             'name' => $this->courseName,
             'slug' => Str::slug($this->courseName),

--- a/src/Imports/CourseStepsImport.php
+++ b/src/Imports/CourseStepsImport.php
@@ -1,0 +1,191 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tapp\FilamentLms\Imports;
+
+use Illuminate\Support\Collection;
+use Illuminate\Support\Str;
+use Maatwebsite\Excel\Concerns\ToCollection;
+use Maatwebsite\Excel\Concerns\WithHeadingRow;
+use Tapp\FilamentLms\Models\Course;
+use Tapp\FilamentLms\Models\Image;
+use Tapp\FilamentLms\Models\Lesson;
+use Tapp\FilamentLms\Models\Link;
+use Tapp\FilamentLms\Models\Step;
+use Tapp\FilamentLms\Models\Video;
+use Tapp\FilamentLms\Services\VideoUrlService;
+
+class CourseStepsImport implements ToCollection, WithHeadingRow
+{
+    public function __construct(
+        protected string $courseName
+    ) {}
+
+    /**
+     * Extract URL from cell that may be "label (url)" or just "url".
+     */
+    public static function extractUrl(mixed $value): ?string
+    {
+        if ($value === null || $value === '') {
+            return null;
+        }
+
+        $value = trim((string) $value);
+        if ($value === '') {
+            return null;
+        }
+
+        if (preg_match('/\((\s*https?:\/\/[^)]+)\s*\)/', $value, $matches)) {
+            return trim($matches[1]);
+        }
+
+        if (preg_match('/^https?:\/\//', $value)) {
+            return $value;
+        }
+
+        return null;
+    }
+
+    public function collection(Collection $rows): void
+    {
+        if ($rows->isEmpty()) {
+            return;
+        }
+
+        $first = $rows->first();
+        $headers = array_keys($first->toArray());
+        $hasStepNameColumn = in_array('step_name', $headers, true);
+        $hasScriptColumn = in_array('script', $headers, true);
+
+        if (! $hasStepNameColumn && ! in_array('lesson_name', $headers, true)) {
+            throw new \InvalidArgumentException('Unrecognized CSV format. Expected at least "Step Name" or "Lesson Name" column.');
+        }
+
+        $course = Course::create([
+            'name' => $this->courseName,
+            'slug' => Str::slug($this->courseName),
+            'external_id' => Str::slug($this->courseName, '_'),
+        ]);
+
+        $lessonOrder = 0;
+        $lessons = [];
+        $defaultLesson = null;
+
+        foreach ($rows as $row) {
+            $stepName = $this->value($row, 'step_name') ?? $this->value($row, 'lesson_name');
+            if ($stepName === null || trim((string) $stepName) === '') {
+                continue;
+            }
+
+            $stepName = trim((string) $stepName);
+
+            if ($hasStepNameColumn) {
+                $lessonName = $this->value($row, 'lesson_name');
+                $lessonName = $lessonName !== null ? trim((string) $lessonName) : $this->courseName;
+                if (! isset($lessons[$lessonName])) {
+                    $lessonOrder++;
+                    $lessons[$lessonName] = Lesson::create([
+                        'course_id' => $course->id,
+                        'name' => $lessonName,
+                        'slug' => Str::slug($lessonName),
+                        'order' => $lessonOrder,
+                    ]);
+                }
+                $lesson = $lessons[$lessonName];
+                $videoUrl = $this->value($row, 'url');
+                $videoUrl = $videoUrl !== null && trim((string) $videoUrl) !== '' ? trim((string) $videoUrl) : null;
+                $text = null;
+                $imageUrl = null;
+                $linkUrl = null;
+            } else {
+                if ($defaultLesson === null) {
+                    $defaultLesson = Lesson::create([
+                        'course_id' => $course->id,
+                        'name' => $this->courseName,
+                        'slug' => Str::slug($this->courseName),
+                        'order' => 1,
+                    ]);
+                }
+                $lesson = $defaultLesson;
+                $text = $hasScriptColumn ? $this->value($row, 'script') : null;
+                $text = $text !== null ? trim((string) $text) : null;
+                $videoUrl = self::extractUrl($this->value($row, 'video_audio_image'));
+                $imageUrl = self::extractUrl($this->value($row, 'slides_image'));
+                $linkUrlRaw = $this->value($row, 'url');
+                $linkUrl = $linkUrlRaw !== null && trim((string) $linkUrlRaw) !== ''
+                    ? self::extractUrl($linkUrlRaw) ?? trim((string) $linkUrlRaw)
+                    : null;
+            }
+
+            [$materialId, $materialType] = $this->createMaterialForStep(
+                $stepName,
+                $videoUrl,
+                $imageUrl,
+                $linkUrl
+            );
+
+            $stepOrder = $lesson->steps()->count() + 1;
+            $stepSlug = $lesson->slug.'-'.Str::slug($stepName);
+
+            Step::create([
+                'lesson_id' => $lesson->id,
+                'order' => $stepOrder,
+                'name' => $stepName,
+                'slug' => $stepSlug,
+                'text' => $text,
+                'material_id' => $materialId,
+                'material_type' => $materialType,
+            ]);
+        }
+    }
+
+    /**
+     * Create video, image, or link material (priority: video > image > link). Returns [material_id, material_type].
+     *
+     * @return array{0: int|null, 1: string|null}
+     */
+    protected function createMaterialForStep(
+        string $stepName,
+        ?string $videoUrl,
+        ?string $imageUrl,
+        ?string $linkUrl
+    ): array {
+        if ($videoUrl !== null && $videoUrl !== '') {
+            $videoUrl = VideoUrlService::convertToEmbedUrl($videoUrl);
+            $video = Video::create([
+                'name' => $stepName,
+                'url' => $videoUrl,
+            ]);
+
+            return [$video->id, 'video'];
+        }
+
+        if ($imageUrl !== null && $imageUrl !== '') {
+            $image = Image::create(['name' => $stepName]);
+            try {
+                $image->addMediaFromUrl($imageUrl)->toMediaCollection('image');
+            } catch (\Throwable) {
+                // If URL media add fails, step still has image record
+            }
+
+            return [$image->id, 'image'];
+        }
+
+        if ($linkUrl !== null && $linkUrl !== '') {
+            $link = Link::create([
+                'name' => $stepName,
+                'url' => $linkUrl,
+            ]);
+
+            return [$link->id, 'link'];
+        }
+
+        return [null, null];
+    }
+
+    protected function value(Collection $row, string $key): mixed
+    {
+        return $row->get($key);
+    }
+}

--- a/src/Jobs/ImportCourseFromCsv.php
+++ b/src/Jobs/ImportCourseFromCsv.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tapp\FilamentLms\Jobs;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Support\Facades\File;
+use Maatwebsite\Excel\Facades\Excel;
+use Tapp\FilamentLms\Imports\CourseStepsImport;
+
+class ImportCourseFromCsv implements ShouldQueue
+{
+    use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
+
+    public function __construct(
+        protected string $courseName,
+        protected string $filePath
+    ) {}
+
+    public function handle(): void
+    {
+        if (! File::isReadable($this->filePath)) {
+            return;
+        }
+
+        try {
+            Excel::import(new CourseStepsImport($this->courseName), $this->filePath);
+        } finally {
+            File::delete($this->filePath);
+        }
+    }
+}

--- a/src/Jobs/ImportCourseFromCsv.php
+++ b/src/Jobs/ImportCourseFromCsv.php
@@ -9,8 +9,9 @@ use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Bus\Dispatchable;
 use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Queue\SerializesModels;
-use Illuminate\Support\Facades\File;
+use Illuminate\Support\Facades\Storage;
 use Maatwebsite\Excel\Facades\Excel;
+use RuntimeException;
 use Tapp\FilamentLms\Imports\CourseStepsImport;
 
 class ImportCourseFromCsv implements ShouldQueue
@@ -19,17 +20,25 @@ class ImportCourseFromCsv implements ShouldQueue
 
     public function __construct(
         protected string $courseName,
-        protected string $filePath
+        protected string $storedPath
     ) {}
 
     public function handle(): void
     {
-        if (! File::isReadable($this->filePath)) {
-            return;
+        $disk = Storage::disk('local');
+
+        if (! $disk->exists($this->storedPath)) {
+            throw new RuntimeException("Course import file does not exist on local disk: {$this->storedPath}");
         }
 
-        Excel::import(new CourseStepsImport($this->courseName), $this->filePath);
+        $filePath = $disk->path($this->storedPath);
 
-        File::delete($this->filePath);
+        if (! is_readable($filePath)) {
+            throw new RuntimeException("Course import file is not readable: {$filePath}");
+        }
+
+        Excel::import(new CourseStepsImport($this->courseName), $filePath);
+
+        $disk->delete($this->storedPath);
     }
 }

--- a/src/Jobs/ImportCourseFromCsv.php
+++ b/src/Jobs/ImportCourseFromCsv.php
@@ -28,10 +28,8 @@ class ImportCourseFromCsv implements ShouldQueue
             return;
         }
 
-        try {
-            Excel::import(new CourseStepsImport($this->courseName), $this->filePath);
-        } finally {
-            File::delete($this->filePath);
-        }
+        Excel::import(new CourseStepsImport($this->courseName), $this->filePath);
+
+        File::delete($this->filePath);
     }
 }

--- a/src/Livewire/VideoStep.php
+++ b/src/Livewire/VideoStep.php
@@ -39,6 +39,11 @@ class VideoStep extends Component
         $this->step->complete();
     }
 
+    public function markExternalOpened(): void
+    {
+        $this->videoCompleted = true;
+    }
+
     public function render()
     {
         return view('filament-lms::livewire.video-step');

--- a/src/Models/Video.php
+++ b/src/Models/Video.php
@@ -27,12 +27,18 @@ class Video extends Model
         return $this->morphTo(Step::class);
     }
 
-    public function getProviderAttribute()
+    public function getProviderAttribute(): string
     {
-        if (str_contains($this->url, 'youtube')) {
+        $url = $this->url ?? '';
+
+        if (str_contains($url, 'youtube.com') || str_contains($url, 'youtu.be')) {
             return 'youtube';
         }
 
-        return 'vimeo';
+        if (str_contains($url, 'vimeo.com') || str_contains($url, 'player.vimeo.com')) {
+            return 'vimeo';
+        }
+
+        return 'external';
     }
 }

--- a/src/Models/Video.php
+++ b/src/Models/Video.php
@@ -31,7 +31,7 @@ class Video extends Model
     {
         $url = $this->url ?? '';
 
-        if (str_contains($url, 'youtube.com') || str_contains($url, 'youtu.be')) {
+        if (str_contains($url, 'youtube.com') || str_contains($url, 'youtube-nocookie.com') || str_contains($url, 'youtu.be')) {
             return 'youtube';
         }
 

--- a/src/Resources/CourseResource/Pages/ListCourses.php
+++ b/src/Resources/CourseResource/Pages/ListCourses.php
@@ -59,7 +59,8 @@ class ListCourses extends ListRecords
 
                     $storedPath = $file->storeAs(
                         'filament-lms/course-imports',
-                        Str::uuid().'.csv'
+                        Str::uuid().'.csv',
+                        'local'
                     );
 
                     if ($storedPath === false) {
@@ -72,7 +73,7 @@ class ListCourses extends ListRecords
                         return;
                     }
 
-                    ImportCourseFromCsv::dispatch($courseName, Storage::path($storedPath));
+                    ImportCourseFromCsv::dispatch($courseName, $storedPath);
 
                     Notification::make()
                         ->title('Import queued')

--- a/src/Resources/CourseResource/Pages/ListCourses.php
+++ b/src/Resources/CourseResource/Pages/ListCourses.php
@@ -2,8 +2,16 @@
 
 namespace Tapp\FilamentLms\Resources\CourseResource\Pages;
 
+use Filament\Actions\Action;
 use Filament\Actions\CreateAction;
+use Filament\Forms\Components\FileUpload;
+use Filament\Forms\Components\TextInput;
+use Filament\Notifications\Notification;
 use Filament\Resources\Pages\ListRecords;
+use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Facades\Storage;
+use Illuminate\Support\Str;
+use Tapp\FilamentLms\Jobs\ImportCourseFromCsv;
 use Tapp\FilamentLms\Resources\CourseResource;
 
 class ListCourses extends ListRecords
@@ -13,6 +21,65 @@ class ListCourses extends ListRecords
     protected function getHeaderActions(): array
     {
         return [
+            Action::make('import_course')
+                ->label('Import Course')
+                ->icon('heroicon-o-arrow-up-tray')
+                ->form([
+                    FileUpload::make('file')
+                        ->label('CSV file')
+                        ->required()
+                        ->storeFiles(false)
+                        ->acceptedFileTypes([
+                            'text/csv',
+                            'application/csv',
+                            'text/plain',
+                            'application/vnd.ms-excel',
+                        ])
+                        ->maxSize(10240)
+                        ->helperText('Upload a CSV with columns: "Step Name", "Lesson Name", "Url", "Script", "Slides (Image)", "Video (Audio + Image)"'),
+                    TextInput::make('course_name')
+                        ->label('Course name')
+                        ->required()
+                        ->maxLength(255)
+                        ->helperText('Name of the new course.'),
+                ])
+                ->action(function (array $data): void {
+                    $file = $data['file'];
+                    $courseName = trim($data['course_name']);
+
+                    if (! $file instanceof UploadedFile) {
+                        Notification::make()
+                            ->title('Import failed')
+                            ->body('Could not read the uploaded file.')
+                            ->danger()
+                            ->send();
+
+                        return;
+                    }
+
+                    $storedPath = $file->storeAs(
+                        'filament-lms/course-imports',
+                        Str::uuid().'.csv'
+                    );
+
+                    if ($storedPath === false) {
+                        Notification::make()
+                            ->title('Import failed')
+                            ->body('Could not store the uploaded file.')
+                            ->danger()
+                            ->send();
+
+                        return;
+                    }
+
+                    ImportCourseFromCsv::dispatch($courseName, Storage::path($storedPath));
+
+                    Notification::make()
+                        ->title('Import queued')
+                        ->body("Course \"{$courseName}\" will be imported in the background. You can continue working while the import runs.")
+                        ->success()
+                        ->send();
+                }),
             CreateAction::make(),
         ];
     }

--- a/src/Resources/CourseResource/Pages/ListCourses.php
+++ b/src/Resources/CourseResource/Pages/ListCourses.php
@@ -9,7 +9,6 @@ use Filament\Forms\Components\TextInput;
 use Filament\Notifications\Notification;
 use Filament\Resources\Pages\ListRecords;
 use Illuminate\Http\UploadedFile;
-use Illuminate\Support\Facades\Storage;
 use Illuminate\Support\Str;
 use Tapp\FilamentLms\Jobs\ImportCourseFromCsv;
 use Tapp\FilamentLms\Resources\CourseResource;

--- a/src/Resources/CourseResource/Pages/ListCourses.php
+++ b/src/Resources/CourseResource/Pages/ListCourses.php
@@ -24,7 +24,7 @@ class ListCourses extends ListRecords
             Action::make('import_course')
                 ->label('Import Course')
                 ->icon('heroicon-o-arrow-up-tray')
-                ->form([
+                ->schema([
                     FileUpload::make('file')
                         ->label('CSV file')
                         ->required()

--- a/tests/Feature/CourseImportTest.php
+++ b/tests/Feature/CourseImportTest.php
@@ -8,9 +8,10 @@ use Maatwebsite\Excel\Facades\Excel;
 use Tapp\FilamentLms\Imports\CourseStepsImport;
 use Tapp\FilamentLms\Models\Course;
 use Tapp\FilamentLms\Models\Video;
+use Tapp\FilamentLms\Tests\TestUser;
 
 beforeEach(function () {
-    config(['filament-lms.user_model' => \Tapp\FilamentLms\Tests\TestUser::class]);
+    config(['filament-lms.user_model' => TestUser::class]);
 });
 
 test('course steps import format a creates course lessons steps and videos', function () {

--- a/tests/Feature/CourseImportTest.php
+++ b/tests/Feature/CourseImportTest.php
@@ -7,7 +7,10 @@ namespace Tapp\FilamentLms\Tests\Feature;
 use Maatwebsite\Excel\Facades\Excel;
 use Tapp\FilamentLms\Imports\CourseStepsImport;
 use Tapp\FilamentLms\Models\Course;
+use Tapp\FilamentLms\Models\Lesson;
+use Tapp\FilamentLms\Models\Step;
 use Tapp\FilamentLms\Models\Video;
+use Tapp\FilamentLms\Tests\TestCase;
 
 beforeEach(function () {
     config(['filament-lms.user_model' => \Tapp\FilamentLms\Tests\TestUser::class]);
@@ -35,6 +38,20 @@ test('course steps import format a creates course lessons steps and videos', fun
     $firstStep = $steps->first();
     expect($firstStep->material_type)->toBe('video');
     expect($firstStep->material_id)->toBe($videos->first()->id);
+});
+
+test('course steps import format a falls back to course name when lesson name is empty', function () {
+    $path = __DIR__.'/../fixtures/course-import-format-a-empty-lesson-name.csv';
+
+    Excel::import(new CourseStepsImport('My Course'), $path);
+
+    $course = Course::where('name', 'My Course')->first();
+    expect($course)->not->toBeNull();
+
+    $lessons = $course->lessons()->orderBy('order')->get();
+    expect($lessons)->toHaveCount(1);
+    expect($lessons->first()->name)->toBe('My Course');
+    expect($lessons->first()->slug)->toBe('my-course');
 });
 
 test('course steps import format b creates course with steps and text', function () {

--- a/tests/Feature/CourseImportTest.php
+++ b/tests/Feature/CourseImportTest.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tapp\FilamentLms\Tests\Feature;
+
+use Maatwebsite\Excel\Facades\Excel;
+use Tapp\FilamentLms\Imports\CourseStepsImport;
+use Tapp\FilamentLms\Models\Course;
+use Tapp\FilamentLms\Models\Lesson;
+use Tapp\FilamentLms\Models\Step;
+use Tapp\FilamentLms\Models\Video;
+use Tapp\FilamentLms\Tests\TestCase;
+
+beforeEach(function () {
+    config(['filament-lms.user_model' => \Tapp\FilamentLms\Tests\TestUser::class]);
+});
+
+test('course steps import format a creates course lessons steps and videos', function () {
+    $path = __DIR__.'/../fixtures/course-import-format-a.csv';
+
+    Excel::import(new CourseStepsImport('Imported Course'), $path);
+
+    $course = Course::where('name', 'Imported Course')->first();
+    expect($course)->not->toBeNull();
+    expect($course->slug)->toBe('imported-course');
+
+    $lessons = $course->lessons()->orderBy('order')->get();
+    expect($lessons)->toHaveCount(2);
+    expect($lessons->pluck('name')->toArray())->toBe(['Background', 'Other Lesson']);
+
+    $steps = $course->steps()->orderBy('lms_lessons.order')->orderBy('lms_steps.order')->get();
+    expect($steps)->toHaveCount(3);
+
+    $videos = Video::all();
+    expect($videos)->toHaveCount(3);
+
+    $firstStep = $steps->first();
+    expect($firstStep->material_type)->toBe('video');
+    expect($firstStep->material_id)->toBe($videos->first()->id);
+});
+
+test('course steps import format b creates course with steps and text', function () {
+    $path = __DIR__.'/../fixtures/course-import-format-b.csv';
+
+    Excel::import(new CourseStepsImport('Format B Course'), $path);
+
+    $course = Course::where('name', 'Format B Course')->first();
+    expect($course)->not->toBeNull();
+
+    $steps = $course->steps()->orderBy('order')->get();
+    expect($steps)->toHaveCount(2);
+    expect($steps->first()->name)->toBe('Step One');
+    expect($steps->first()->text)->toBe('Some script text here');
+    expect($steps->get(1)->text)->toBe('More text');
+});

--- a/tests/Feature/CourseImportTest.php
+++ b/tests/Feature/CourseImportTest.php
@@ -7,10 +7,7 @@ namespace Tapp\FilamentLms\Tests\Feature;
 use Maatwebsite\Excel\Facades\Excel;
 use Tapp\FilamentLms\Imports\CourseStepsImport;
 use Tapp\FilamentLms\Models\Course;
-use Tapp\FilamentLms\Models\Lesson;
-use Tapp\FilamentLms\Models\Step;
 use Tapp\FilamentLms\Models\Video;
-use Tapp\FilamentLms\Tests\TestCase;
 
 beforeEach(function () {
     config(['filament-lms.user_model' => \Tapp\FilamentLms\Tests\TestUser::class]);

--- a/tests/Feature/VideoProviderTest.php
+++ b/tests/Feature/VideoProviderTest.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tapp\FilamentLms\Tests\Feature;
+
+use Tapp\FilamentLms\Models\Video;
+
+test('video provider returns youtube for youtube.com embed URL', function () {
+    $video = Video::create([
+        'name' => 'Test',
+        'url' => 'https://www.youtube.com/embed/abc123',
+    ]);
+    expect($video->provider)->toBe('youtube');
+});
+
+test('video provider returns youtube for youtube-nocookie.com embed URL', function () {
+    $video = Video::create([
+        'name' => 'Test',
+        'url' => 'https://www.youtube-nocookie.com/embed/abc123',
+    ]);
+    expect($video->provider)->toBe('youtube');
+});
+
+test('video provider returns youtube for youtu.be URL', function () {
+    $video = Video::create([
+        'name' => 'Test',
+        'url' => 'https://youtu.be/abc123',
+    ]);
+    expect($video->provider)->toBe('youtube');
+});
+
+test('video provider returns vimeo for vimeo.com URL', function () {
+    $video = Video::create([
+        'name' => 'Test',
+        'url' => 'https://vimeo.com/123456',
+    ]);
+    expect($video->provider)->toBe('vimeo');
+});
+
+test('video provider returns external for unknown URL', function () {
+    $video = Video::create([
+        'name' => 'Test',
+        'url' => 'https://example.com/video',
+    ]);
+    expect($video->provider)->toBe('external');
+});

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -8,6 +8,7 @@ use Filament\FilamentServiceProvider;
 use Filament\Support\SupportServiceProvider;
 use Illuminate\Database\Schema\Blueprint;
 use Livewire\LivewireServiceProvider;
+use Maatwebsite\Excel\ExcelServiceProvider;
 use Orchestra\Testbench\TestCase as Orchestra;
 use Spatie\MediaLibrary\MediaLibraryServiceProvider;
 use Tapp\FilamentFormBuilder\FilamentFormBuilderServiceProvider;
@@ -113,7 +114,7 @@ abstract class TestCase extends Orchestra
             $table->softDeletes();
         });
 
-        // Create lms_steps table
+        // Create lms_steps table (material nullable to match make_material_nullable migration)
         $app['db']->connection()->getSchemaBuilder()->create('lms_steps', function (Blueprint $table) {
             $table->id();
             $table->foreignId('lesson_id')->references('id')->on('lms_lessons')->onDelete('cascade');
@@ -121,7 +122,8 @@ abstract class TestCase extends Orchestra
             $table->boolean('is_optional')->default(false);
             $table->string('name');
             $table->string('slug');
-            $table->morphs('material');
+            $table->unsignedBigInteger('material_id')->nullable();
+            $table->string('material_type')->nullable();
             $table->text('text')->nullable();
             $table->foreignId('retry_step_id')->nullable()->constrained('lms_steps')->onDelete('set null');
             $table->boolean('require_perfect_score')->default(false);
@@ -256,6 +258,7 @@ abstract class TestCase extends Orchestra
         $providers = [
             LivewireServiceProvider::class,
             FilamentServiceProvider::class,
+            ExcelServiceProvider::class,
             SupportServiceProvider::class,
             MediaLibraryServiceProvider::class,
             FilamentLmsServiceProvider::class,

--- a/tests/fixtures/course-import-format-a-empty-lesson-name.csv
+++ b/tests/fixtures/course-import-format-a-empty-lesson-name.csv
@@ -1,0 +1,2 @@
+Step Name,Slide,Lesson Name,url
+Only Step,1,,https://vimeo.com/123

--- a/tests/fixtures/course-import-format-a.csv
+++ b/tests/fixtures/course-import-format-a.csv
@@ -1,0 +1,4 @@
+Step Name,Slide,Lesson Name,url
+Intro,1,Background,https://vimeo.com/123
+Part 2,2,Background,https://vimeo.com/456
+Other Lesson Step,1,Other Lesson,https://vimeo.com/789

--- a/tests/fixtures/course-import-format-b.csv
+++ b/tests/fixtures/course-import-format-b.csv
@@ -1,0 +1,3 @@
+Lesson Name,Script,Lesson,Slides (Image),Video (Audio + Image),Audio,url
+Step One,"Some script text here",,,,,
+Step Two,"More text",,,,,


### PR DESCRIPTION
# Details

Add import course.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new CSV-driven course creation flow that writes multiple related records in a transaction and runs via a queued job, increasing risk of bad imports or background processing misconfigurations. Also changes video provider detection/rendering which can affect step completion behavior for non-YouTube/Vimeo URLs.
> 
> **Overview**
> Adds an **Import Course** action to the courses list that uploads a CSV, stores it locally, and dispatches a queued `ImportCourseFromCsv` job to build a new course from the file.
> 
> Introduces `CourseStepsImport` to parse two supported CSV header formats, create courses/lessons/steps, and attach step materials (video/image/link) with basic URL extraction and video URL normalization.
> 
> Expands video handling by detecting YouTube/Vimeo more robustly and treating unknown URLs as `external`, rendering an “Open video” link that enables progressing the step; also adds a migration to change `lms_tests.name` from `string` to `text` and updates/extends tests + fixtures to cover the new import/provider behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 91d7d882cb4ae800e49c6e8b5f13a360f7cc6dfc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->