### PR TITLE
Credits

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,6 +8,7 @@
         }
     ],
     "minimum-stability": "dev",
+    "prefer-stable": true,
     "require": {
         "php": "^8.3",
         "filament/filament": "^5.0|^4.0",

--- a/config/filament-lms.php
+++ b/config/filament-lms.php
@@ -53,9 +53,6 @@ return [
         'use_signed_urls' => false,
         // Default expiration time for signed URLs in minutes (default: 60 minutes)
         'signed_url_expiration' => 60,
-        // Used when a course has no course image media (or URL resolution fails).
-        // Keeps $course->image_url a non-empty string for templates and APIs.
-        'course_image_placeholder_url' => 'https://picsum.photos/200',
     ],
 
     // Credits configuration

--- a/config/filament-lms.php
+++ b/config/filament-lms.php
@@ -1,5 +1,7 @@
 <?php
 
+use App\Models\User;
+
 return [
     'theme' => 'default',
     'font' => 'Poppins',
@@ -32,7 +34,7 @@ return [
 
     // User model class for course assignments
     // @phpstan-ignore-next-line - User model is defined in consuming application
-    'user_model' => \App\Models\User::class,
+    'user_model' => User::class,
 
     // User search columns for relation managers
     'user_search_columns' => [

--- a/config/filament-lms.php
+++ b/config/filament-lms.php
@@ -58,6 +58,8 @@ return [
     // Credits configuration
     'credits_enabled' => false,
     'credits_label' => 'Credits',
+    'credits_repeater_label' => 'Credits',
+    'credits_add_action_label' => 'Add credits',
 
     // Multi-Tenancy configuration
     'tenancy' => [

--- a/config/filament-lms.php
+++ b/config/filament-lms.php
@@ -53,6 +53,10 @@ return [
         'signed_url_expiration' => 60,
     ],
 
+    // Credits configuration
+    'credits_enabled' => false,
+    'credits_label' => 'Credits',
+
     // Multi-Tenancy configuration
     'tenancy' => [
         // Enable tenancy support

--- a/config/filament-lms.php
+++ b/config/filament-lms.php
@@ -53,6 +53,9 @@ return [
         'use_signed_urls' => false,
         // Default expiration time for signed URLs in minutes (default: 60 minutes)
         'signed_url_expiration' => 60,
+        // Used when a course has no course image media (or URL resolution fails).
+        // Keeps $course->image_url a non-empty string for templates and APIs.
+        'course_image_placeholder_url' => 'https://picsum.photos/200',
     ],
 
     // Credits configuration

--- a/database/factories/CourseCreditCategoryFactory.php
+++ b/database/factories/CourseCreditCategoryFactory.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Tapp\FilamentLms\Database\Factories;
+
+use Illuminate\Database\Eloquent\Factories\Factory;
+use Tapp\FilamentLms\Models\Course;
+use Tapp\FilamentLms\Models\CourseCreditCategory;
+use Tapp\FilamentLms\Models\CreditCategory;
+
+class CourseCreditCategoryFactory extends Factory
+{
+    protected $model = CourseCreditCategory::class;
+
+    /**
+     * Define the model's default state.
+     */
+    public function definition(): array
+    {
+        return [
+            'course_id' => Course::factory(),
+            'credit_category_id' => CreditCategory::factory(),
+            'credits' => $this->faker->randomFloat(2, 0.5, 10),
+        ];
+    }
+}

--- a/database/factories/CreditCategoryFactory.php
+++ b/database/factories/CreditCategoryFactory.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Tapp\FilamentLms\Database\Factories;
+
+use Illuminate\Database\Eloquent\Factories\Factory;
+use Illuminate\Support\Str;
+use Tapp\FilamentLms\Models\CreditCategory;
+
+class CreditCategoryFactory extends Factory
+{
+    protected $model = CreditCategory::class;
+
+    /**
+     * Define the model's default state.
+     */
+    public function definition(): array
+    {
+        $name = $this->faker->unique()->word();
+
+        return [
+            'name' => ucfirst($name),
+            'slug' => Str::slug($name),
+            'color' => $this->faker->randomElement(array_keys(CreditCategory::COLORS)),
+        ];
+    }
+}

--- a/database/migrations/create_lms_course_credit_category_table.php.stub
+++ b/database/migrations/create_lms_course_credit_category_table.php.stub
@@ -1,0 +1,26 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('lms_course_credit_category', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('course_id')->constrained('lms_courses')->cascadeOnDelete();
+            $table->foreignId('credit_category_id')->constrained('lms_credit_categories')->cascadeOnDelete();
+            $table->decimal('credits', 5, 2);
+            $table->timestamps();
+
+            $table->unique(['course_id', 'credit_category_id']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('lms_course_credit_category');
+    }
+};

--- a/database/migrations/create_lms_course_credit_category_table.php.stub
+++ b/database/migrations/create_lms_course_credit_category_table.php.stub
@@ -3,6 +3,7 @@
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
+use Tapp\FilamentLms\Helpers\TenantHelper;
 
 return new class extends Migration
 {
@@ -10,6 +11,19 @@ return new class extends Migration
     {
         Schema::create('lms_course_credit_category', function (Blueprint $table) {
             $table->id();
+
+            // Add tenant foreign key if tenancy is enabled
+            if (config('filament-lms.tenancy.enabled')) {
+                $tenantModel = config('filament-lms.tenancy.model');
+                if (! $tenantModel) {
+                    throw new \Exception('Tenant model must be configured when tenancy is enabled.');
+                }
+
+                $table->foreignId(TenantHelper::getTenantColumnName())
+                    ->constrained(TenantHelper::getTenantTableName())
+                    ->cascadeOnDelete();
+            }
+
             $table->foreignId('course_id')->constrained('lms_courses')->cascadeOnDelete();
             $table->foreignId('credit_category_id')->constrained('lms_credit_categories')->cascadeOnDelete();
             $table->decimal('credits', 5, 2);

--- a/database/migrations/create_lms_credit_categories_table.php.stub
+++ b/database/migrations/create_lms_credit_categories_table.php.stub
@@ -3,6 +3,7 @@
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
+use Tapp\FilamentLms\Helpers\TenantHelper;
 
 return new class extends Migration
 {
@@ -10,6 +11,19 @@ return new class extends Migration
     {
         Schema::create('lms_credit_categories', function (Blueprint $table) {
             $table->id();
+
+            // Add tenant foreign key if tenancy is enabled
+            if (config('filament-lms.tenancy.enabled')) {
+                $tenantModel = config('filament-lms.tenancy.model');
+                if (! $tenantModel) {
+                    throw new \Exception('Tenant model must be configured when tenancy is enabled.');
+                }
+
+                $table->foreignId(TenantHelper::getTenantColumnName())
+                    ->constrained(TenantHelper::getTenantTableName())
+                    ->cascadeOnDelete();
+            }
+
             $table->string('name');
             $table->string('slug')->unique();
             $table->text('description')->nullable();

--- a/database/migrations/create_lms_credit_categories_table.php.stub
+++ b/database/migrations/create_lms_credit_categories_table.php.stub
@@ -13,6 +13,7 @@ return new class extends Migration
             $table->string('name');
             $table->string('slug')->unique();
             $table->text('description')->nullable();
+            $table->string('color', 20)->default('gray');
             $table->timestamps();
         });
     }

--- a/database/migrations/create_lms_credit_categories_table.php.stub
+++ b/database/migrations/create_lms_credit_categories_table.php.stub
@@ -1,0 +1,24 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('lms_credit_categories', function (Blueprint $table) {
+            $table->id();
+            $table->string('name');
+            $table->string('slug')->unique();
+            $table->text('description')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('lms_credit_categories');
+    }
+};

--- a/database/migrations/create_lms_credit_categories_table.php.stub
+++ b/database/migrations/create_lms_credit_categories_table.php.stub
@@ -13,7 +13,7 @@ return new class extends Migration
             $table->string('name');
             $table->string('slug')->unique();
             $table->text('description')->nullable();
-            $table->string('color', 20)->default('gray');
+            $table->string('color', 20)->default('blue');
             $table->timestamps();
         });
     }

--- a/docs/SIGNED_URLS.md
+++ b/docs/SIGNED_URLS.md
@@ -12,8 +12,6 @@ To enable signed URLs, update your `config/filament-lms.php` file:
     'use_signed_urls' => true,
     // Expiration time in minutes (default: 60)
     'signed_url_expiration' => 60,
-    // Shown as $course->image_url when the course has no course image (default: picsum)
-    'course_image_placeholder_url' => 'https://picsum.photos/200',
 ],
 ```
 
@@ -26,10 +24,10 @@ Course images will automatically use signed URLs when the configuration is enabl
 ```php
 // This will return a signed URL if use_signed_urls is true
 $course = Course::find(1);
-$imageUrl = $course->image_url; // Always a string: media URL or placeholder; signed when configured
+$imageUrl = $course->image_url; // Returns the media URL (signed when configured), or null if no image
 ```
 
-When there is no media (or URL resolution fails), `image_url` falls back to `course_image_placeholder_url`. For a nullable URL, call `$course->getMediaUrl('courses')` instead.
+When there is no media (or URL resolution fails), `image_url` returns `null`.
 
 ### For Other Media
 

--- a/docs/SIGNED_URLS.md
+++ b/docs/SIGNED_URLS.md
@@ -12,6 +12,8 @@ To enable signed URLs, update your `config/filament-lms.php` file:
     'use_signed_urls' => true,
     // Expiration time in minutes (default: 60)
     'signed_url_expiration' => 60,
+    // Shown as $course->image_url when the course has no course image (default: picsum)
+    'course_image_placeholder_url' => 'https://picsum.photos/200',
 ],
 ```
 
@@ -24,8 +26,10 @@ Course images will automatically use signed URLs when the configuration is enabl
 ```php
 // This will return a signed URL if use_signed_urls is true
 $course = Course::find(1);
-$imageUrl = $course->image_url; // Automatically signed if configured
+$imageUrl = $course->image_url; // Always a string: media URL or placeholder; signed when configured
 ```
+
+When there is no media (or URL resolution fails), `image_url` falls back to `course_image_placeholder_url`. For a nullable URL, call `$course->getMediaUrl('courses')` instead.
 
 ### For Other Media
 

--- a/resources/views/components/course-card.blade.php
+++ b/resources/views/components/course-card.blade.php
@@ -15,8 +15,8 @@
       class="object-cover w-full h-full group-hover:opacity-90"
       onerror="this.style.display='none'; this.nextElementSibling.style.display='flex';"
     />
-    <div style="display:none" class="items-center justify-center w-full h-full bg-gray-300" aria-hidden="true">
-      <x-heroicon-o-academic-cap class="size-12 shrink-0 text-gray-400" />
+    <div style="display:none" class="items-center justify-center w-full h-full bg-gray-100" aria-hidden="true">
+      <x-heroicon-o-academic-cap class="size-12 shrink-0 text-gray-300" />
     </div>
 
     {{-- Credits overlay: top-right, one badge per category --}}
@@ -24,9 +24,9 @@
       <div class="absolute top-2 right-2 flex flex-col items-end gap-1.5">
         @foreach ($creditCategories as $ccc)
           @if ($ccc->creditCategory)
-            <span class="inline-flex items-center gap-1.5 rounded-full bg-white/95 px-2.5 py-1 text-xs font-medium text-gray-800 shadow-sm">
-              <span>{{ number_format((float) $ccc->credits, 1) }} {{ $ccc->creditCategory->name }}</span>
-            </span>
+            <x-filament-lms::credit-badge :category="$ccc->creditCategory" class="gap-1.5 px-2.5 py-1 shadow-sm">
+              {{ number_format((float) $ccc->credits, 1) }} {{ $ccc->creditCategory->name }}
+            </x-filament-lms::credit-badge>
           @endif
         @endforeach
       </div>

--- a/resources/views/components/course-card.blade.php
+++ b/resources/views/components/course-card.blade.php
@@ -1,17 +1,71 @@
-  <div class="flex overflow-hidden relative flex-col bg-white rounded-lg border border-gray-200 group">
-    <img src="{{ $course->image_url }}" class="object-cover w-full bg-gray-200 group-hover:opacity-75 sm:aspect-auto">
-    <div class="flex flex-col flex-1 p-4 space-y-2">
+@php
+    $creditsEnabled = config('filament-lms.credits_enabled');
+    $creditCategories = $course->courseCreditCategories ?? collect();
+    $hasImage = $course->hasValidCourseImage();
+    $isCompleted = $course->completed_at !== null;
+    $isInProgress = ! $isCompleted && $course->completion_percentage > 0;
+    $moduleCount = $course->lessons()->count();
+@endphp
+<div class="flex overflow-hidden relative flex-col bg-white rounded-lg border border-gray-200 group">
+  {{-- Image section: fixed height, image or grey + icon --}}
+  <div class="relative h-28 shrink-0 overflow-hidden bg-gray-200">
+    @if ($hasImage && $course->image_url)
+      <img src="{{ $course->image_url }}" alt="" class="object-cover w-full h-full group-hover:opacity-90" />
+    @else
+      <div class="flex items-center justify-center w-full h-full bg-gray-300" aria-hidden="true">
+        <x-heroicon-o-academic-cap class="size-12 shrink-0 text-gray-400" />
+      </div>
+    @endif
+
+    {{-- Credits overlay: top-right, one badge per category --}}
+    @if ($creditsEnabled && $creditCategories->isNotEmpty())
+      <div class="absolute top-2 right-2 flex flex-col items-end gap-1.5">
+        @foreach ($creditCategories as $ccc)
+          @if ($ccc->creditCategory)
+            <span class="inline-flex items-center gap-1.5 rounded-full bg-white/95 px-2.5 py-1 text-xs font-medium text-gray-800 shadow-sm">
+              <span>{{ number_format((float) $ccc->credits, 1) }} {{ $ccc->creditCategory->name }}</span>
+            </span>
+          @endif
+        @endforeach
+      </div>
+    @endif
+  </div>
+
+  <div class="flex min-h-0 flex-1 flex-col p-4">
+    <div class="min-h-0 flex-1 space-y-2 pb-3">
       <h3 class="text-sm font-medium text-gray-900">
         <a href="{{ $course->linkToCurrentStep() }}">
           <span aria-hidden="true" class="absolute inset-0"></span>
           {{ $course->name }}
         </a>
       </h3>
-      <p class="text-sm text-gray-500">
-       {{ $course->description }}
+      <p class="line-clamp-3 text-sm text-gray-500">
+        {{ $course->description }}
       </p>
     </div>
-    <div class="overflow-hidden bg-gray-200">
-      <div class="h-2 bg-primary-600" style="width: {{$course->completion_percentage}}%"></div>
+    {{-- Module count and status pinned to bottom, just above progress bar --}}
+    <div class="mt-auto flex items-center justify-between gap-2 border-t border-gray-100 pt-3">
+      <p class="text-sm text-gray-500">
+        {{ $moduleCount }} {{ Str::plural('module', $moduleCount) }}
+      </p>
+      @if ($isCompleted)
+        <span class="inline-flex items-center rounded-full bg-success-50 px-2.5 py-1 text-xs font-medium text-success-700">Completed</span>
+      @elseif ($isInProgress)
+        <span class="inline-flex items-center rounded-full bg-amber-50 px-2.5 py-1 text-xs font-medium text-amber-700">In Progress</span>
+      @else
+        <span class="inline-flex items-center rounded-full bg-gray-100 px-2.5 py-1 text-xs font-medium text-gray-600">Not Started</span>
+      @endif
     </div>
   </div>
+
+  {{-- Progress bar: fill color matches status badge (success / amber / gray) --}}
+  @php
+    $progressBarFillClass = $isCompleted ? 'bg-success-600' : ($isInProgress ? 'bg-amber-600' : 'bg-gray-400');
+  @endphp
+  <div class="shrink-0 overflow-hidden rounded-b-lg bg-gray-300">
+    <div
+      class="h-2 rounded-full transition-[width] {{ $progressBarFillClass }}"
+      style="width: {{ min(100, (float) $course->completion_percentage) }}%"
+    ></div>
+  </div>
+</div>

--- a/resources/views/components/course-card.blade.php
+++ b/resources/views/components/course-card.blade.php
@@ -2,7 +2,8 @@
     $creditsEnabled = config('filament-lms.credits_enabled');
     $creditCategories = $creditsEnabled ? $course->courseCreditCategories : collect();
     $isCompleted = $course->completed_at !== null;
-    $isInProgress = ! $isCompleted && $course->completion_percentage > 0;
+    $completionPercentage = $course->completion_percentage;
+    $isInProgress = ! $isCompleted && $completionPercentage > 0;
     $moduleCount = (int) ($course->lessons_count ?? $course->lessons()->count());
 @endphp
 <div class="flex overflow-hidden relative flex-col bg-white rounded-lg border border-gray-200 group">
@@ -66,7 +67,7 @@
   <div class="shrink-0 overflow-hidden rounded-b-lg bg-gray-300">
     <div
       class="h-2 rounded-full transition-[width] {{ $progressBarFillClass }}"
-      style="width: {{ min(100, (float) $course->completion_percentage) }}%"
+      style="width: {{ min(100, (float) $completionPercentage) }}%"
     ></div>
   </div>
 </div>

--- a/resources/views/components/course-card.blade.php
+++ b/resources/views/components/course-card.blade.php
@@ -1,15 +1,14 @@
 @php
     $creditsEnabled = config('filament-lms.credits_enabled');
-    $creditCategories = $course->courseCreditCategories ?? collect();
-    $hasImage = $course->hasValidCourseImage();
+    $creditCategories = $creditsEnabled ? $course->courseCreditCategories : collect();
     $isCompleted = $course->completed_at !== null;
     $isInProgress = ! $isCompleted && $course->completion_percentage > 0;
-    $moduleCount = $course->lessons()->count();
+    $moduleCount = (int) ($course->lessons_count ?? $course->lessons()->count());
 @endphp
 <div class="flex overflow-hidden relative flex-col bg-white rounded-lg border border-gray-200 group">
   {{-- Image section: fixed height, image or grey + icon --}}
   <div class="relative h-28 shrink-0 overflow-hidden bg-gray-200">
-    @if ($hasImage && $course->image_url)
+    @if (filled($course->image_url))
       <img src="{{ $course->image_url }}" alt="" class="object-cover w-full h-full group-hover:opacity-90" />
     @else
       <div class="flex items-center justify-center w-full h-full bg-gray-300" aria-hidden="true">

--- a/resources/views/components/course-card.blade.php
+++ b/resources/views/components/course-card.blade.php
@@ -8,13 +8,15 @@
 <div class="flex overflow-hidden relative flex-col bg-white rounded-lg border border-gray-200 group">
   {{-- Image section: fixed height, image or grey + icon --}}
   <div class="relative h-28 shrink-0 overflow-hidden bg-gray-200">
-    @if (filled($course->image_url))
-      <img src="{{ $course->image_url }}" alt="" class="object-cover w-full h-full group-hover:opacity-90" />
-    @else
-      <div class="flex items-center justify-center w-full h-full bg-gray-300" aria-hidden="true">
-        <x-heroicon-o-academic-cap class="size-12 shrink-0 text-gray-400" />
-      </div>
-    @endif
+    <img
+      src="{{ $course->image_url }}"
+      alt=""
+      class="object-cover w-full h-full group-hover:opacity-90"
+      onerror="this.style.display='none'; this.nextElementSibling.style.display='flex';"
+    />
+    <div style="display:none" class="items-center justify-center w-full h-full bg-gray-300" aria-hidden="true">
+      <x-heroicon-o-academic-cap class="size-12 shrink-0 text-gray-400" />
+    </div>
 
     {{-- Credits overlay: top-right, one badge per category --}}
     @if ($creditsEnabled && $creditCategories->isNotEmpty())

--- a/resources/views/components/course-card.blade.php
+++ b/resources/views/components/course-card.blade.php
@@ -8,16 +8,21 @@
 @endphp
 <div class="flex overflow-hidden relative flex-col bg-white rounded-lg border border-gray-200 group">
   {{-- Image section: fixed height, image or grey + icon --}}
-  <div class="relative h-28 shrink-0 overflow-hidden bg-gray-200">
-    <img
-      src="{{ $course->image_url }}"
-      alt=""
-      class="object-cover w-full h-full group-hover:opacity-90"
-      onerror="this.style.display='none'; this.nextElementSibling.style.display='flex';"
-    />
-    <div style="display:none" class="items-center justify-center w-full h-full bg-gray-100" aria-hidden="true">
+  <div class="relative h-28 shrink-0 overflow-hidden bg-gray-100">
+    {{-- Fallback icon: always rendered as base layer --}}
+    <div class="flex items-center justify-center w-full h-full" aria-hidden="true">
       <x-heroicon-o-academic-cap class="size-12 shrink-0 text-gray-300" />
     </div>
+
+    {{-- Image: layered on top, covers icon when loaded successfully --}}
+    @if ($course->image_url)
+      <img
+        src="{{ $course->image_url }}"
+        alt=""
+        class="absolute inset-0 object-cover w-full h-full group-hover:opacity-90"
+        onerror="this.style.visibility='hidden';"
+      />
+    @endif
 
     {{-- Credits overlay: top-right, one badge per category --}}
     @if ($creditsEnabled && $creditCategories->isNotEmpty())

--- a/resources/views/components/credit-badge.blade.php
+++ b/resources/views/components/credit-badge.blade.php
@@ -1,0 +1,6 @@
+@props(['category'])
+
+<span style="background-color: {{ $category->hexColor() }}1a; color: {{ $category->hexColor() }}; backdrop-filter: blur(4px); -webkit-backdrop-filter: blur(4px);"
+      {{ $attributes->merge(['class' => 'inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-medium']) }}>
+    {{ $slot }}
+</span>

--- a/resources/views/pages/dashboard.blade.php
+++ b/resources/views/pages/dashboard.blade.php
@@ -1,13 +1,24 @@
 <x-filament-panels::page>
-    @if ($courses->isEmpty())
+    @if(config('filament-lms.credits_enabled') && $this->getSchema('filtersForm'))
+        <div class="mb-6">
+            {!! $this->getSchema('filtersForm')->toHtml() !!}
+        </div>
+    @endif
+
+    @php
+        $displayCourses = config('filament-lms.credits_enabled') ? $this->filteredCourses : $courses;
+    @endphp
+    @if ($displayCourses->isEmpty())
         <x-filament::card>
             <div class="flex flex-col items-center justify-center py-12">
-                <span class="text-lg text-gray-500">Courses will be made available to you soon.</span>
+                <span class="text-lg text-gray-500">
+                    {{ $this->hasActiveFilters() ? 'No courses matching the filters.' : 'Courses will be made available to you soon.' }}
+                </span>
             </div>
         </x-filament::card>
     @else
         <div class="grid grid-cols-1 gap-y-4 sm:grid-cols-2 sm:gap-x-6 sm:gap-y-10 lg:grid-cols-3 lg:gap-x-8">
-            @foreach ($courses as $course)
+            @foreach ($displayCourses as $course)
                 <x-filament-lms::course-card :course="$course"/>
             @endforeach
         </div>

--- a/resources/views/pages/dashboard.blade.php
+++ b/resources/views/pages/dashboard.blade.php
@@ -5,10 +5,7 @@
         </div>
     @endif
 
-    @php
-        $displayCourses = config('filament-lms.credits_enabled') ? $this->filteredCourses : $courses;
-    @endphp
-    @if ($displayCourses->isEmpty())
+    @if ($this->filteredCourses->isEmpty())
         <x-filament::card>
             <div class="flex flex-col items-center justify-center py-12">
                 <span class="text-lg text-gray-500">
@@ -18,7 +15,7 @@
         </x-filament::card>
     @else
         <div class="grid grid-cols-1 gap-y-4 sm:grid-cols-2 sm:gap-x-6 sm:gap-y-10 lg:grid-cols-3 lg:gap-x-8">
-            @foreach ($displayCourses as $course)
+            @foreach ($this->filteredCourses as $course)
                 <x-filament-lms::course-card :course="$course"/>
             @endforeach
         </div>

--- a/src/Actions/AssignCoursesBulkAction.php
+++ b/src/Actions/AssignCoursesBulkAction.php
@@ -5,6 +5,9 @@ namespace Tapp\FilamentLms\Actions;
 use Filament\Actions\BulkAction;
 use Filament\Forms\Components\Select;
 use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Database\Eloquent\Model;
+use Tapp\FilamentLms\Contracts\FilamentLmsUserInterface;
+use Tapp\FilamentLms\Models\Course;
 
 class AssignCoursesBulkAction extends BulkAction
 {
@@ -23,14 +26,14 @@ class AssignCoursesBulkAction extends BulkAction
                 Select::make('courses')
                     ->label('Courses to Assign')
                     ->multiple()
-                    ->options(\Tapp\FilamentLms\Models\Course::all()->pluck('name', 'id'))
+                    ->options(Course::all()->pluck('name', 'id'))
                     ->searchable()
                     ->preload()
                     ->required(),
             ])
             ->action(function (Collection $records, array $data) {
                 foreach ($records as $record) {
-                    /** @var \Illuminate\Database\Eloquent\Model&\Tapp\FilamentLms\Contracts\FilamentLmsUserInterface $record */
+                    /** @var Model&FilamentLmsUserInterface $record */
                     if (method_exists($record, 'courses')) {
                         // @phpstan-ignore-next-line - courses() method is provided by FilamentLmsUser trait
                         $record->courses()->syncWithoutDetaching($data['courses']);

--- a/src/FilamentLmsServiceProvider.php
+++ b/src/FilamentLmsServiceProvider.php
@@ -50,6 +50,8 @@ class FilamentLmsServiceProvider extends PackageServiceProvider
                 'add_completed_at_to_lms_course_user_table',
                 'make_material_nullable_in_lms_steps_table',
                 'backfill_lms_course_user_completed_at_from_step_dates',
+                'create_lms_credit_categories_table',
+                'create_lms_course_credit_category_table',
             ])
             ->hasCommand(BackfillCourseCompletedAt::class)
             ->hasInstallCommand(function (InstallCommand $command) {

--- a/src/Forms/Components/MorphToSelectWithCreate.php
+++ b/src/Forms/Components/MorphToSelectWithCreate.php
@@ -6,6 +6,7 @@ use Filament\Actions\Action;
 use Filament\Forms\Components\Select;
 use Filament\Schemas\Components\Utilities\Get;
 use Filament\Schemas\Components\Utilities\Set;
+use Filament\Schemas\Schema;
 use Tapp\FilamentFormBuilder\Models\FilamentForm;
 use Tapp\FilamentLms\Models\Document;
 use Tapp\FilamentLms\Models\Image;
@@ -70,7 +71,7 @@ class MorphToSelectWithCreate
                         ->icon('heroicon-o-plus')
                         ->color('primary')
                         ->visible(fn (Get $get) => $get('material_type') === 'video')
-                        ->schema(VideoResource::form(\Filament\Schemas\Schema::make())->getComponents())
+                        ->schema(VideoResource::form(Schema::make())->getComponents())
                         ->action(function (array $data, Set $set) {
                             // Convert the URL (validation already happened in the form rules)
                             $data['url'] = VideoUrlService::convertToEmbedUrl($data['url']);

--- a/src/Lms.php
+++ b/src/Lms.php
@@ -9,6 +9,7 @@ use Tapp\FilamentLms\Pages\CreateRubric;
 use Tapp\FilamentLms\Pages\Reporting;
 use Tapp\FilamentLms\Pages\ViewRubric;
 use Tapp\FilamentLms\Resources\CourseResource;
+use Tapp\FilamentLms\Resources\CreditCategoryResource;
 use Tapp\FilamentLms\Resources\DocumentResource;
 use Tapp\FilamentLms\Resources\ImageResource;
 use Tapp\FilamentLms\Resources\LessonResource;
@@ -28,6 +29,7 @@ class Lms implements Plugin
     {
         $panel->resources([
             CourseResource::class,
+            CreditCategoryResource::class,
             LessonResource::class,
             StepResource::class,
             VideoResource::class,

--- a/src/Lms.php
+++ b/src/Lms.php
@@ -27,9 +27,8 @@ class Lms implements Plugin
 
     public function register(Panel $panel): void
     {
-        $panel->resources([
+        $resources = [
             CourseResource::class,
-            CreditCategoryResource::class,
             LessonResource::class,
             StepResource::class,
             VideoResource::class,
@@ -37,7 +36,13 @@ class Lms implements Plugin
             LinkResource::class,
             TestResource::class,
             ImageResource::class,
-        ]);
+        ];
+
+        if (config('filament-lms.credits_enabled', false)) {
+            $resources[] = CreditCategoryResource::class;
+        }
+
+        $panel->resources($resources);
 
         $panel->pages([
             Reporting::class,

--- a/src/LmsPanelProvider.php
+++ b/src/LmsPanelProvider.php
@@ -180,7 +180,7 @@ class LmsPanelProvider extends PanelProvider
                     ->collapsed(fn (): bool => ! $lesson->isActive())
                     // ->collapsible(true)
                     ->items($lesson->steps->map(function ($step) {
-                        /** @var \Tapp\FilamentLms\Models\Step $step */
+                        /** @var Models\Step $step */
                         return NavigationItem::make($step->name)
                             ->icon(fn (): string => $step->completed_at ? 'heroicon-o-check-circle' : '')
                             ->isActiveWhen(fn (): bool => $step->isActive())

--- a/src/Models/Course.php
+++ b/src/Models/Course.php
@@ -309,7 +309,7 @@ final class Course extends Model implements HasMedia
 
     public function getImageUrlAttribute(): ?string
     {
-        return $this->getMediaUrl('courses') ?? config('filament-lms.course_image_placeholder_url');
+        return $this->getMediaUrl('courses');
     }
 
     // Add the users() relationship for the pivot table

--- a/src/Models/Course.php
+++ b/src/Models/Course.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Tapp\FilamentLms\Models;
 
+use Carbon\Carbon;
 use DateTimeInterface;
 use Exception;
 use Illuminate\Database\Eloquent\Builder;
@@ -12,6 +13,7 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\Relations\HasManyThrough;
 use Illuminate\Foundation\Auth\User as Authenticatable;
+use Illuminate\Support\Collection;
 use Illuminate\Support\Collection as BaseCollection;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Storage;
@@ -37,8 +39,8 @@ use Tapp\FilamentLms\Traits\HasMediaUrl;
  * @property string|null $description
  * @property int|null $required_test_percentage
  * @property bool $is_private
- * @property \Carbon\Carbon $created_at
- * @property \Carbon\Carbon $updated_at
+ * @property Carbon $created_at
+ * @property Carbon $updated_at
  * @property-read \Illuminate\Database\Eloquent\Collection|Lesson[] $lessons
  * @property-read \Illuminate\Database\Eloquent\Collection|Step[] $steps
  */
@@ -449,9 +451,9 @@ final class Course extends Model implements HasMedia
     /**
      * Get all test steps for this course in lesson/step order.
      *
-     * @return \Illuminate\Support\Collection<int, Step>
+     * @return Collection<int, Step>
      */
-    public function getOrderedTestSteps(): \Illuminate\Support\Collection
+    public function getOrderedTestSteps(): Collection
     {
         return $this->lessons()
             ->with(['steps' => fn ($q) => $q->where('material_type', 'test')->orderBy('order')])

--- a/src/Models/Course.php
+++ b/src/Models/Course.php
@@ -295,7 +295,7 @@ final class Course extends Model implements HasMedia
         }
 
         // When steps have eager-loaded progress (e.g. from dashboard), use it directly
-        if ($steps->first()?->relationLoaded('progress')) {
+        if ($steps->first()->relationLoaded('progress')) {
             $completedCount = $steps->filter(fn (Step $step) => $step->progress?->completed_at !== null)->count();
 
             return $completedCount / $steps->count() * 100;

--- a/src/Models/Course.php
+++ b/src/Models/Course.php
@@ -308,18 +308,9 @@ final class Course extends Model implements HasMedia
         return CourseCompleted::getUrl([$this->slug]);
     }
 
-    public function getImageUrlAttribute(): string
+    public function getImageUrlAttribute(): ?string
     {
-        $mediaUrl = $this->getMediaUrl('courses');
-
-        if (filled($mediaUrl)) {
-            return $mediaUrl;
-        }
-
-        return (string) config(
-            'filament-lms.media.course_image_placeholder_url',
-            'https://picsum.photos/200'
-        );
+        return $this->getMediaUrl('courses');
     }
 
     /**

--- a/src/Models/Course.php
+++ b/src/Models/Course.php
@@ -12,7 +12,9 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\Relations\HasManyThrough;
 use Illuminate\Foundation\Auth\User as Authenticatable;
+use Illuminate\Support\Collection as BaseCollection;
 use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Storage;
 use Spatie\MediaLibrary\HasMedia;
 use Spatie\MediaLibrary\InteractsWithMedia;
 use Tapp\FilamentFormBuilder\Models\FilamentFormUser;
@@ -296,11 +298,24 @@ final class Course extends Model implements HasMedia
         return CourseCompleted::getUrl([$this->slug]);
     }
 
-    public function getImageUrlAttribute()
+    public function getImageUrlAttribute(): ?string
     {
-        $mediaUrl = $this->getMediaUrl('courses');
+        return $this->getMediaUrl('courses');
+    }
 
-        return $mediaUrl ?: 'https://picsum.photos/200';
+    /**
+     * True only when the course has course media and the file exists on disk.
+     * Use this to decide whether to show the image or the placeholder (e.g. broken/missing files).
+     */
+    public function hasValidCourseImage(): bool
+    {
+        $media = $this->getFirstMedia('courses');
+
+        if (! $media) {
+            return false;
+        }
+
+        return Storage::disk($media->disk)->exists($media->getPathRelativeToRoot());
     }
 
     // Add the users() relationship for the pivot table
@@ -311,6 +326,34 @@ final class Course extends Model implements HasMedia
         return $this->belongsToMany($userModel, 'lms_course_user', 'course_id', 'user_id')
             ->withPivot('completed_at')
             ->withTimestamps();
+    }
+
+    public function courseCreditCategories(): HasMany
+    {
+        return $this->hasMany(CourseCreditCategory::class);
+    }
+
+    /**
+     * Total credits across all categories for this course.
+     */
+    public function getTotalCreditsAttribute(): float
+    {
+        return (float) $this->courseCreditCategories->sum('credits');
+    }
+
+    /**
+     * Credits grouped by category: Collection of ['category' => CreditCategory, 'credits' => float].
+     *
+     * @return BaseCollection<int, array{category: CreditCategory, credits: float}>
+     */
+    public function getCreditsByCategoryAttribute(): BaseCollection
+    {
+        return $this->courseCreditCategories
+            ->load('creditCategory')
+            ->map(fn (CourseCreditCategory $ccc) => [
+                'category' => $ccc->creditCategory,
+                'credits' => (float) $ccc->credits,
+            ]);
     }
 
     /**

--- a/src/Models/Course.php
+++ b/src/Models/Course.php
@@ -10,11 +10,12 @@ use Exception;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\Relations\HasManyThrough;
+use Illuminate\Database\Eloquent\Relations\Pivot;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Support\Collection;
-use Illuminate\Support\Collection as BaseCollection;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Storage;
 use Spatie\MediaLibrary\HasMedia;
@@ -200,15 +201,21 @@ final class Course extends Model implements HasMedia
      */
     public function completedByUserAt($userId): ?string
     {
-        $pivot = $this->users()->where('user_id', $userId)->first()?->pivot;
+        if (
+            Auth::check()
+            && $this->relationLoaded('authEnrollment')
+            && (int) $userId === (int) Auth::id()
+        ) {
+            $first = $this->authEnrollment->first();
+            $pivot = $first ? $first->getRelationValue('pivot') : null;
 
-        if (! $pivot || $pivot->completed_at === null) {
-            return null;
+            return $this->formatPivotCompletedAt($pivot instanceof Pivot ? $pivot : null);
         }
 
-        $at = $pivot->completed_at;
+        $attached = $this->users()->where('user_id', $userId)->first();
+        $pivot = $attached ? $attached->getRelationValue('pivot') : null;
 
-        return $at instanceof DateTimeInterface ? $at->format('Y-m-d H:i:s') : (string) $at;
+        return $this->formatPivotCompletedAt($pivot instanceof Pivot ? $pivot : null);
     }
 
     /**
@@ -218,7 +225,8 @@ final class Course extends Model implements HasMedia
      */
     public function maybeSetCompletedAtForUser(int $userId): void
     {
-        $existing = $this->users()->where('user_id', $userId)->first()?->pivot?->completed_at;
+        $pivot = $this->users()->where('user_id', $userId)->first()?->getRelationValue('pivot');
+        $existing = $pivot instanceof Pivot ? $pivot->getAttribute('completed_at') : null;
         if ($existing !== null) {
             return;
         }
@@ -240,7 +248,7 @@ final class Course extends Model implements HasMedia
         $this->users()->syncWithoutDetaching([$userId => ['completed_at' => now()]]);
     }
 
-    public function getCompletedAtAttribute()
+    public function getCompletedAtAttribute(): ?string
     {
         if (! Auth::check()) {
             return null;
@@ -300,14 +308,25 @@ final class Course extends Model implements HasMedia
         return CourseCompleted::getUrl([$this->slug]);
     }
 
-    public function getImageUrlAttribute(): ?string
+    public function getImageUrlAttribute(): string
     {
-        return $this->getMediaUrl('courses');
+        $mediaUrl = $this->getMediaUrl('courses');
+
+        if (filled($mediaUrl)) {
+            return $mediaUrl;
+        }
+
+        return (string) config(
+            'filament-lms.media.course_image_placeholder_url',
+            'https://picsum.photos/200'
+        );
     }
 
     /**
-     * True only when the course has course media and the file exists on disk.
-     * Use this to decide whether to show the image or the placeholder (e.g. broken/missing files).
+     * True when the course has course media and the file exists on disk.
+     *
+     * Performs a storage exists() check — avoid in list views (e.g. dashboards). For a display URL that
+     * is never null, use {@see getImageUrlAttribute}; for raw media only, use {@see getMediaUrl}.
      */
     public function hasValidCourseImage(): bool
     {
@@ -321,13 +340,42 @@ final class Course extends Model implements HasMedia
     }
 
     // Add the users() relationship for the pivot table
-    public function users()
+    public function users(): BelongsToMany
     {
         $userModel = config('filament-lms.user_model');
 
         return $this->belongsToMany($userModel, 'lms_course_user', 'course_id', 'user_id')
             ->withPivot('completed_at')
             ->withTimestamps();
+    }
+
+    /**
+     * The authenticated user's row on lms_course_user (0 or 1). Eager-load on course lists (e.g. dashboard)
+     * so {@see getCompletedAtAttribute} does not run a pivot query per course.
+     */
+    public function authEnrollment(): BelongsToMany
+    {
+        $userModel = config('filament-lms.user_model');
+
+        return $this->belongsToMany($userModel, 'lms_course_user', 'course_id', 'user_id')
+            ->withPivot('completed_at')
+            ->withTimestamps()
+            ->where('lms_course_user.user_id', Auth::id());
+    }
+
+    private function formatPivotCompletedAt(?Pivot $pivot): ?string
+    {
+        if ($pivot === null) {
+            return null;
+        }
+
+        $at = $pivot->getAttribute('completed_at');
+
+        if ($at === null) {
+            return null;
+        }
+
+        return $at instanceof DateTimeInterface ? $at->format('Y-m-d H:i:s') : (string) $at;
     }
 
     public function courseCreditCategories(): HasMany
@@ -346,9 +394,9 @@ final class Course extends Model implements HasMedia
     /**
      * Credits grouped by category: Collection of ['category' => CreditCategory, 'credits' => float].
      *
-     * @return BaseCollection<int, array{category: CreditCategory, credits: float}>
+     * @return Collection<int, array{category: CreditCategory, credits: float}>
      */
-    public function getCreditsByCategoryAttribute(): BaseCollection
+    public function getCreditsByCategoryAttribute(): Collection
     {
         return $this->courseCreditCategories
             ->load('creditCategory')

--- a/src/Models/Course.php
+++ b/src/Models/Course.php
@@ -307,9 +307,9 @@ final class Course extends Model implements HasMedia
         return CourseCompleted::getUrl([$this->slug]);
     }
 
-    public function getImageUrlAttribute(): string
+    public function getImageUrlAttribute(): ?string
     {
-        return $this->getMediaUrl('courses') ?? config('filament-lms.course_image_placeholder_url', 'https://picsum.photos/200');
+        return $this->getMediaUrl('courses') ?? config('filament-lms.course_image_placeholder_url');
     }
 
     // Add the users() relationship for the pivot table

--- a/src/Models/Course.php
+++ b/src/Models/Course.php
@@ -357,29 +357,6 @@ final class Course extends Model implements HasMedia
     }
 
     /**
-     * Total credits across all categories for this course.
-     */
-    public function getTotalCreditsAttribute(): float
-    {
-        return (float) $this->courseCreditCategories->sum('credits');
-    }
-
-    /**
-     * Credits grouped by category: Collection of ['category' => CreditCategory, 'credits' => float].
-     *
-     * @return Collection<int, array{category: CreditCategory, credits: float}>
-     */
-    public function getCreditsByCategoryAttribute(): Collection
-    {
-        return $this->courseCreditCategories
-            ->load('creditCategory')
-            ->map(fn (CourseCreditCategory $ccc) => [
-                'category' => $ccc->creditCategory,
-                'credits' => (float) $ccc->credits,
-            ]);
-    }
-
-    /**
      * Check if all steps are completed by the user (regardless of test percentage requirement).
      * This is useful for determining if a user has finished all steps but may not have met the test percentage requirement.
      */

--- a/src/Models/Course.php
+++ b/src/Models/Course.php
@@ -295,7 +295,12 @@ final class Course extends Model implements HasMedia
         }
 
         // When steps have eager-loaded progress (e.g. from dashboard), use it directly
-        if ($steps->first()->relationLoaded('progress')) {
+        // Only safe when $userId matches the authenticated user, since progress is scoped to Auth::id()
+        if (
+            Auth::check()
+            && (int) $userId === (int) Auth::id()
+            && $steps->first()->relationLoaded('progress')
+        ) {
             $completedCount = $steps->filter(fn (Step $step) => $step->progress?->completed_at !== null)->count();
 
             return $completedCount / $steps->count() * 100;

--- a/src/Models/Course.php
+++ b/src/Models/Course.php
@@ -287,13 +287,21 @@ final class Course extends Model implements HasMedia
 
     public function getCompletionPercentageForUser($userId): float
     {
-        $steps = $this->steps()->get();
+        // Use eager-loaded steps when available to avoid N+1 queries on dashboard
+        $steps = $this->relationLoaded('steps') ? $this->steps : $this->steps()->get();
 
         if ($steps->isEmpty()) {
             return 0;
         }
 
-        // Get all completed steps for this specific user (including optional steps)
+        // When steps have eager-loaded progress (e.g. from dashboard), use it directly
+        if ($steps->first()?->relationLoaded('progress')) {
+            $completedCount = $steps->filter(fn (Step $step) => $step->progress?->completed_at !== null)->count();
+
+            return $completedCount / $steps->count() * 100;
+        }
+
+        // Fallback: query for completed steps
         $completedStepUsers = StepUser::whereIn('step_id', $steps->pluck('id'))
             ->where('user_id', $userId)
             ->whereNotNull('completed_at')

--- a/src/Models/Course.php
+++ b/src/Models/Course.php
@@ -17,7 +17,6 @@ use Illuminate\Database\Eloquent\Relations\Pivot;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Auth;
-use Illuminate\Support\Facades\Storage;
 use Spatie\MediaLibrary\HasMedia;
 use Spatie\MediaLibrary\InteractsWithMedia;
 use Tapp\FilamentFormBuilder\Models\FilamentFormUser;
@@ -308,26 +307,9 @@ final class Course extends Model implements HasMedia
         return CourseCompleted::getUrl([$this->slug]);
     }
 
-    public function getImageUrlAttribute(): ?string
+    public function getImageUrlAttribute(): string
     {
-        return $this->getMediaUrl('courses');
-    }
-
-    /**
-     * True when the course has course media and the file exists on disk.
-     *
-     * Performs a storage exists() check — avoid in list views (e.g. dashboards). For a display URL that
-     * is never null, use {@see getImageUrlAttribute}; for raw media only, use {@see getMediaUrl}.
-     */
-    public function hasValidCourseImage(): bool
-    {
-        $media = $this->getFirstMedia('courses');
-
-        if (! $media) {
-            return false;
-        }
-
-        return Storage::disk($media->disk)->exists($media->getPathRelativeToRoot());
+        return $this->getMediaUrl('courses') ?? config('filament-lms.course_image_placeholder_url', 'https://picsum.photos/200');
     }
 
     // Add the users() relationship for the pivot table

--- a/src/Models/CourseCreditCategory.php
+++ b/src/Models/CourseCreditCategory.php
@@ -5,8 +5,11 @@ declare(strict_types=1);
 namespace Tapp\FilamentLms\Models;
 
 use Carbon\Carbon;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Tapp\FilamentLms\Database\Factories\CourseCreditCategoryFactory;
+use Tapp\FilamentLms\Models\Traits\BelongsToTenant;
 
 /**
  * @property int $id
@@ -18,11 +21,19 @@ use Illuminate\Database\Eloquent\Relations\BelongsTo;
  * @property-read Course $course
  * @property-read CreditCategory $creditCategory
  */
-final class CourseCreditCategory extends Model
+class CourseCreditCategory extends Model
 {
+    use BelongsToTenant;
+    use HasFactory;
+
     protected $guarded = [];
 
     protected $table = 'lms_course_credit_category';
+
+    protected static function newFactory(): CourseCreditCategoryFactory
+    {
+        return CourseCreditCategoryFactory::new();
+    }
 
     protected function casts(): array
     {

--- a/src/Models/CourseCreditCategory.php
+++ b/src/Models/CourseCreditCategory.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Tapp\FilamentLms\Models;
 
+use Carbon\Carbon;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 
@@ -12,8 +13,8 @@ use Illuminate\Database\Eloquent\Relations\BelongsTo;
  * @property int $course_id
  * @property int $credit_category_id
  * @property float $credits
- * @property \Carbon\Carbon $created_at
- * @property \Carbon\Carbon $updated_at
+ * @property Carbon $created_at
+ * @property Carbon $updated_at
  * @property-read Course $course
  * @property-read CreditCategory $creditCategory
  */

--- a/src/Models/CourseCreditCategory.php
+++ b/src/Models/CourseCreditCategory.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tapp\FilamentLms\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+/**
+ * @property int $id
+ * @property int $course_id
+ * @property int $credit_category_id
+ * @property float $credits
+ * @property \Carbon\Carbon $created_at
+ * @property \Carbon\Carbon $updated_at
+ * @property-read Course $course
+ * @property-read CreditCategory $creditCategory
+ */
+final class CourseCreditCategory extends Model
+{
+    protected $guarded = [];
+
+    protected $table = 'lms_course_credit_category';
+
+    protected function casts(): array
+    {
+        return [
+            'credits' => 'decimal:2',
+        ];
+    }
+
+    public function course(): BelongsTo
+    {
+        return $this->belongsTo(Course::class);
+    }
+
+    public function creditCategory(): BelongsTo
+    {
+        return $this->belongsTo(CreditCategory::class);
+    }
+}

--- a/src/Models/CreditCategory.php
+++ b/src/Models/CreditCategory.php
@@ -63,7 +63,7 @@ class CreditCategory extends Model
         return self::COLORS[$this->color] ?? '#6b7280';
     }
 
-    /** @return array{int, int, int} */
+    /** @return array<int, string> */
     public static function badgeColor(string $state): array
     {
         static $hexMap = null;

--- a/src/Models/CreditCategory.php
+++ b/src/Models/CreditCategory.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Tapp\FilamentLms\Models;
 
+use Carbon\Carbon;
+use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\HasMany;
@@ -13,9 +15,9 @@ use Illuminate\Database\Eloquent\Relations\HasMany;
  * @property string $name
  * @property string $slug
  * @property string|null $description
- * @property \Carbon\Carbon $created_at
- * @property \Carbon\Carbon $updated_at
- * @property-read \Illuminate\Database\Eloquent\Collection<int, CourseCreditCategory> $courseCreditCategories
+ * @property Carbon $created_at
+ * @property Carbon $updated_at
+ * @property-read Collection<int, CourseCreditCategory> $courseCreditCategories
  */
 final class CreditCategory extends Model
 {

--- a/src/Models/CreditCategory.php
+++ b/src/Models/CreditCategory.php
@@ -67,7 +67,7 @@ final class CreditCategory extends Model
 
     public static function nextAvailableColor(): string
     {
-        $usedColors = static::query()->pluck('color')->toArray();
+        $usedColors = self::query()->pluck('color')->toArray();
 
         foreach (array_keys(self::COLORS) as $color) {
             if (! in_array($color, $usedColors)) {

--- a/src/Models/CreditCategory.php
+++ b/src/Models/CreditCategory.php
@@ -66,8 +66,7 @@ class CreditCategory extends Model
     /** @return array<int, string> */
     public static function badgeColor(string $state): array
     {
-        static $hexMap = null;
-        $hexMap ??= static::all()->mapWithKeys(fn ($cat) => [$cat->name => $cat->hexColor()])->all();
+        $hexMap = once(fn () => static::all()->mapWithKeys(fn ($cat) => [$cat->name => $cat->hexColor()])->all());
         $categoryName = Str::beforeLast($state, ':');
 
         return Color::hex($hexMap[$categoryName] ?? '#6b7280');

--- a/src/Models/CreditCategory.php
+++ b/src/Models/CreditCategory.php
@@ -58,13 +58,6 @@ final class CreditCategory extends Model
         return self::COLORS[$this->color] ?? '#6b7280';
     }
 
-    public function badgeStyle(): string
-    {
-        $hex = $this->hexColor();
-
-        return "background-color: {$hex}1a; color: {$hex};";
-    }
-
     public static function nextAvailableColor(): string
     {
         $usedColors = self::query()->pluck('color')->toArray();

--- a/src/Models/CreditCategory.php
+++ b/src/Models/CreditCategory.php
@@ -9,6 +9,8 @@ use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\HasMany;
+use Filament\Support\Colors\Color;
+use Illuminate\Support\Str;
 use Tapp\FilamentLms\Database\Factories\CreditCategoryFactory;
 use Tapp\FilamentLms\Models\Traits\BelongsToTenant;
 
@@ -59,6 +61,16 @@ class CreditCategory extends Model
     public function hexColor(): string
     {
         return self::COLORS[$this->color] ?? '#6b7280';
+    }
+
+    /** @return array{int, int, int} */
+    public static function badgeColor(string $state): array
+    {
+        static $hexMap = null;
+        $hexMap ??= static::all()->mapWithKeys(fn ($cat) => [$cat->name => $cat->hexColor()])->all();
+        $categoryName = Str::beforeLast($state, ':');
+
+        return Color::hex($hexMap[$categoryName] ?? '#6b7280');
     }
 
     protected static function newFactory(): CreditCategoryFactory

--- a/src/Models/CreditCategory.php
+++ b/src/Models/CreditCategory.php
@@ -9,6 +9,8 @@ use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\HasMany;
+use Tapp\FilamentLms\Database\Factories\CreditCategoryFactory;
+use Tapp\FilamentLms\Models\Traits\BelongsToTenant;
 
 /**
  * @property int $id
@@ -20,8 +22,9 @@ use Illuminate\Database\Eloquent\Relations\HasMany;
  * @property Carbon $updated_at
  * @property-read Collection<int, CourseCreditCategory> $courseCreditCategories
  */
-final class CreditCategory extends Model
+class CreditCategory extends Model
 {
+    use BelongsToTenant;
     use HasFactory;
 
     /** @var array<string, string> */
@@ -56,6 +59,11 @@ final class CreditCategory extends Model
     public function hexColor(): string
     {
         return self::COLORS[$this->color] ?? '#6b7280';
+    }
+
+    protected static function newFactory(): CreditCategoryFactory
+    {
+        return CreditCategoryFactory::new();
     }
 
     public static function nextAvailableColor(): string

--- a/src/Models/CreditCategory.php
+++ b/src/Models/CreditCategory.php
@@ -5,11 +5,11 @@ declare(strict_types=1);
 namespace Tapp\FilamentLms\Models;
 
 use Carbon\Carbon;
+use Filament\Support\Colors\Color;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\HasMany;
-use Filament\Support\Colors\Color;
 use Illuminate\Support\Str;
 use Tapp\FilamentLms\Database\Factories\CreditCategoryFactory;
 use Tapp\FilamentLms\Models\Traits\BelongsToTenant;

--- a/src/Models/CreditCategory.php
+++ b/src/Models/CreditCategory.php
@@ -15,6 +15,7 @@ use Illuminate\Database\Eloquent\Relations\HasMany;
  * @property string $name
  * @property string $slug
  * @property string|null $description
+ * @property string $color
  * @property Carbon $created_at
  * @property Carbon $updated_at
  * @property-read Collection<int, CourseCreditCategory> $courseCreditCategories
@@ -23,6 +24,26 @@ final class CreditCategory extends Model
 {
     use HasFactory;
 
+    /** @var array<string, string> */
+    public const COLORS = [
+        'red' => '#ef4444',
+        'orange' => '#f97316',
+        'amber' => '#f59e0b',
+        'lime' => '#84cc16',
+        'green' => '#22c55e',
+        'emerald' => '#10b981',
+        'teal' => '#14b8a6',
+        'cyan' => '#06b6d4',
+        'sky' => '#0ea5e9',
+        'blue' => '#3b82f6',
+        'indigo' => '#6366f1',
+        'violet' => '#8b5cf6',
+        'purple' => '#a855f7',
+        'fuchsia' => '#d946ef',
+        'pink' => '#ec4899',
+        'rose' => '#f43f5e',
+    ];
+
     protected $guarded = [];
 
     protected $table = 'lms_credit_categories';
@@ -30,5 +51,30 @@ final class CreditCategory extends Model
     public function courseCreditCategories(): HasMany
     {
         return $this->hasMany(CourseCreditCategory::class);
+    }
+
+    public function hexColor(): string
+    {
+        return self::COLORS[$this->color] ?? '#6b7280';
+    }
+
+    public function badgeStyle(): string
+    {
+        $hex = $this->hexColor();
+
+        return "background-color: {$hex}1a; color: {$hex};";
+    }
+
+    public static function nextAvailableColor(): string
+    {
+        $usedColors = static::query()->pluck('color')->toArray();
+
+        foreach (array_keys(self::COLORS) as $color) {
+            if (! in_array($color, $usedColors)) {
+                return $color;
+            }
+        }
+
+        return array_key_first(self::COLORS);
     }
 }

--- a/src/Models/CreditCategory.php
+++ b/src/Models/CreditCategory.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tapp\FilamentLms\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+
+/**
+ * @property int $id
+ * @property string $name
+ * @property string $slug
+ * @property string|null $description
+ * @property \Carbon\Carbon $created_at
+ * @property \Carbon\Carbon $updated_at
+ * @property-read \Illuminate\Database\Eloquent\Collection<int, CourseCreditCategory> $courseCreditCategories
+ */
+final class CreditCategory extends Model
+{
+    use HasFactory;
+
+    protected $guarded = [];
+
+    protected $table = 'lms_credit_categories';
+
+    public function courseCreditCategories(): HasMany
+    {
+        return $this->hasMany(CourseCreditCategory::class);
+    }
+}

--- a/src/Models/Lesson.php
+++ b/src/Models/Lesson.php
@@ -2,6 +2,7 @@
 
 namespace Tapp\FilamentLms\Models;
 
+use Carbon\Carbon;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
@@ -18,8 +19,8 @@ use Tapp\FilamentLms\Models\Traits\BelongsToTenant;
  * @property int $order
  * @property string $name
  * @property string $slug
- * @property \Carbon\Carbon $created_at
- * @property \Carbon\Carbon $updated_at
+ * @property Carbon $created_at
+ * @property Carbon $updated_at
  * @property-read Course $course
  * @property-read Collection<int, Step> $steps
  */

--- a/src/Models/Step.php
+++ b/src/Models/Step.php
@@ -2,6 +2,7 @@
 
 namespace Tapp\FilamentLms\Models;
 
+use Carbon\Carbon;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
@@ -28,9 +29,9 @@ use Tapp\FilamentLms\Pages\Step as StepPage;
  * @property string $type
  * @property int|null $material_id
  * @property string|null $material_type
- * @property \Carbon\Carbon|null $completed_at
- * @property \Carbon\Carbon $created_at
- * @property \Carbon\Carbon $updated_at
+ * @property Carbon|null $completed_at
+ * @property Carbon $created_at
+ * @property Carbon $updated_at
  * @property int|null $retry_step_id
  * @property bool $require_perfect_score
  * @property-read Lesson $lesson

--- a/src/Models/Traits/BelongsToTenant.php
+++ b/src/Models/Traits/BelongsToTenant.php
@@ -2,6 +2,7 @@
 
 namespace Tapp\FilamentLms\Models\Traits;
 
+use Filament\Facades\Filament;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Tapp\FilamentLms\Helpers\TenantHelper;
 use Tapp\FilamentLms\Models\Scopes\TenantScope;
@@ -47,8 +48,8 @@ trait BelongsToTenant
 
             // Try to get tenant from Filament context (Filament's standard method)
             // This handles top-level resources created outside Filament's Resource observers
-            if (class_exists(\Filament\Facades\Filament::class)) {
-                $tenant = \Filament\Facades\Filament::getTenant();
+            if (class_exists(Filament::class)) {
+                $tenant = Filament::getTenant();
                 if ($tenant) {
                     $model->{$tenantRelationshipName}()->associate($tenant);
 

--- a/src/Pages/CourseCompleted.php
+++ b/src/Pages/CourseCompleted.php
@@ -7,8 +7,10 @@ namespace Tapp\FilamentLms\Pages;
 use BackedEnum;
 use Exception;
 use Filament\Pages\Page;
+use Tapp\FilamentFormBuilder\Models\FilamentFormUser;
 use Tapp\FilamentLms\Concerns\CourseLayout;
 use Tapp\FilamentLms\Models\Course;
+use Tapp\FilamentLms\Models\Test;
 
 final class CourseCompleted extends Page
 {
@@ -102,20 +104,20 @@ final class CourseCompleted extends Page
             $step->load('material');
             $test = $step->material;
 
-            if (! $test instanceof \Tapp\FilamentLms\Models\Test) {
+            if (! $test instanceof Test) {
                 continue;
             }
 
             $test->load('rubric');
             $rubric = $test->rubric;
 
-            if (! $rubric instanceof \Tapp\FilamentFormBuilder\Models\FilamentFormUser) {
+            if (! $rubric instanceof FilamentFormUser) {
                 continue;
             }
 
             $totalQuestions = count($rubric->entry);
 
-            $entry = \Tapp\FilamentFormBuilder\Models\FilamentFormUser::where('filament_form_id', $test->filament_form_id)
+            $entry = FilamentFormUser::where('filament_form_id', $test->filament_form_id)
                 ->where('user_id', $userId)
                 ->when($test->filament_form_user_id, fn ($q) => $q->where('id', '!=', $test->filament_form_user_id))
                 ->first();

--- a/src/Pages/Dashboard.php
+++ b/src/Pages/Dashboard.php
@@ -11,6 +11,10 @@ use Livewire\Attributes\Computed;
 use Tapp\FilamentLms\Models\Course;
 use Tapp\FilamentLms\Models\CreditCategory;
 
+/**
+ * @property Collection $courses
+ * @property Collection $filteredCourses
+ */
 class Dashboard extends \Filament\Pages\Dashboard
 {
     use HasFiltersForm;
@@ -23,9 +27,13 @@ class Dashboard extends \Filament\Pages\Dashboard
 
     protected static ?string $title = 'Courses';
 
-    public $courses;
-
     public function mount(): void
+    {
+        // Courses loaded via computed property
+    }
+
+    #[Computed]
+    public function courses(): Collection
     {
         $user = Auth::user();
 
@@ -33,20 +41,20 @@ class Dashboard extends \Filament\Pages\Dashboard
             ? ['courseCreditCategories.creditCategory']
             : [];
 
+        $stepEager = $user ? ['steps.progress'] : [];
+
         if ($user) {
-            $courses = Course::accessibleTo($user)
-                ->with(array_merge($creditEager, ['authEnrollment']))
-                ->withCount('lessons')
-                ->get();
-        } else {
-            $courses = Course::where('is_private', false)
-                ->whereHas('steps')
-                ->with($creditEager)
+            return Course::accessibleTo($user)
+                ->with(array_merge($creditEager, $stepEager, ['authEnrollment']))
                 ->withCount('lessons')
                 ->get();
         }
 
-        $this->courses = $courses;
+        return Course::where('is_private', false)
+            ->whereHas('steps')
+            ->with(array_merge($creditEager, $stepEager))
+            ->withCount('lessons')
+            ->get();
     }
 
     public function filtersForm(Schema $schema): Schema
@@ -67,7 +75,7 @@ class Dashboard extends \Filament\Pages\Dashboard
     #[Computed]
     public function filteredCourses(): Collection
     {
-        $courses = $this->courses ?? collect();
+        $courses = $this->courses;
 
         $creditCategoryId = $this->filters['credit_category_id'] ?? null;
         if (blank($creditCategoryId)) {

--- a/src/Pages/Dashboard.php
+++ b/src/Pages/Dashboard.php
@@ -58,7 +58,7 @@ class Dashboard extends \Filament\Pages\Dashboard
         return $schema->components([
             Select::make('credit_category_id')
                 ->label('Credit Category')
-                ->options(fn (): array => CreditCategory::query()->orderBy('name')->pluck('name', 'id')->all())
+                ->options(fn (): array => ['any' => 'Any credit category'] + CreditCategory::query()->orderBy('name')->pluck('name', 'id')->all())
                 ->placeholder('All categories')
                 ->native(false),
         ]);
@@ -72,6 +72,10 @@ class Dashboard extends \Filament\Pages\Dashboard
         $creditCategoryId = $this->filters['credit_category_id'] ?? null;
         if (blank($creditCategoryId)) {
             return $courses;
+        }
+
+        if ($creditCategoryId === 'any') {
+            return $courses->filter(fn (Course $course): bool => $course->courseCreditCategories->isNotEmpty())->values();
         }
 
         return $courses->filter(function (Course $course) use ($creditCategoryId): bool {

--- a/src/Pages/Dashboard.php
+++ b/src/Pages/Dashboard.php
@@ -2,11 +2,17 @@
 
 namespace Tapp\FilamentLms\Pages;
 
+use Filament\Forms\Components\Select;
+use Filament\Pages\Dashboard\Concerns\HasFiltersForm;
+use Filament\Schemas\Schema;
 use Illuminate\Support\Facades\Auth;
 use Tapp\FilamentLms\Models\Course;
+use Tapp\FilamentLms\Models\CreditCategory;
 
 class Dashboard extends \Filament\Pages\Dashboard
 {
+    use HasFiltersForm;
+
     protected static string|\BackedEnum|null $navigationIcon = 'heroicon-o-home';
 
     protected string $view = 'filament-lms::pages.dashboard';
@@ -17,18 +23,60 @@ class Dashboard extends \Filament\Pages\Dashboard
 
     public $courses;
 
-    public function mount()
+    public function mount(): void
     {
         $user = Auth::user();
 
+        $eagerLoad = config('filament-lms.credits_enabled')
+            ? ['courseCreditCategories.creditCategory']
+            : [];
+
         if ($user) {
-            // Use the new accessibleTo scope for better performance
-            $courses = Course::accessibleTo($user)->get();
+            $courses = Course::accessibleTo($user)->with($eagerLoad)->get();
         } else {
-            // For non-authenticated users, only show public courses (not private) with steps
-            $courses = Course::where('is_private', false)->whereHas('steps')->get();
+            $courses = Course::where('is_private', false)->whereHas('steps')->with($eagerLoad)->get();
         }
 
         $this->courses = $courses;
+    }
+
+    public function filtersForm(Schema $schema): Schema
+    {
+        if (! config('filament-lms.credits_enabled', false)) {
+            return $schema;
+        }
+
+        return $schema->components([
+            Select::make('credit_category_id')
+                ->label('Credit Category')
+                ->options(fn (): array => CreditCategory::query()->orderBy('name')->pluck('name', 'id')->all())
+                ->placeholder('All categories')
+                ->native(false),
+        ]);
+    }
+
+    public function getFilteredCoursesProperty(): \Illuminate\Support\Collection
+    {
+        $courses = $this->courses ?? collect();
+
+        $creditCategoryId = $this->filters['credit_category_id'] ?? null;
+        if (blank($creditCategoryId)) {
+            return $courses;
+        }
+
+        return $courses->filter(function (Course $course) use ($creditCategoryId): bool {
+            return $course->courseCreditCategories->contains('credit_category_id', (int) $creditCategoryId);
+        })->values();
+    }
+
+    public function hasActiveFilters(): bool
+    {
+        if (! config('filament-lms.credits_enabled', false)) {
+            return false;
+        }
+
+        $creditCategoryId = $this->filters['credit_category_id'] ?? null;
+
+        return ! blank($creditCategoryId);
     }
 }

--- a/src/Pages/Dashboard.php
+++ b/src/Pages/Dashboard.php
@@ -28,14 +28,21 @@ class Dashboard extends \Filament\Pages\Dashboard
     {
         $user = Auth::user();
 
-        $eagerLoad = config('filament-lms.credits_enabled')
+        $creditEager = config('filament-lms.credits_enabled')
             ? ['courseCreditCategories.creditCategory']
             : [];
 
         if ($user) {
-            $courses = Course::accessibleTo($user)->with($eagerLoad)->get();
+            $courses = Course::accessibleTo($user)
+                ->with(array_merge($creditEager, ['authEnrollment']))
+                ->withCount('lessons')
+                ->get();
         } else {
-            $courses = Course::where('is_private', false)->whereHas('steps')->with($eagerLoad)->get();
+            $courses = Course::where('is_private', false)
+                ->whereHas('steps')
+                ->with($creditEager)
+                ->withCount('lessons')
+                ->get();
         }
 
         $this->courses = $courses;

--- a/src/Pages/Dashboard.php
+++ b/src/Pages/Dashboard.php
@@ -7,6 +7,7 @@ use Filament\Pages\Dashboard\Concerns\HasFiltersForm;
 use Filament\Schemas\Schema;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Auth;
+use Livewire\Attributes\Computed;
 use Tapp\FilamentLms\Models\Course;
 use Tapp\FilamentLms\Models\CreditCategory;
 
@@ -63,6 +64,7 @@ class Dashboard extends \Filament\Pages\Dashboard
         ]);
     }
 
+    #[Computed]
     public function getFilteredCoursesProperty(): Collection
     {
         $courses = $this->courses ?? collect();

--- a/src/Pages/Dashboard.php
+++ b/src/Pages/Dashboard.php
@@ -5,6 +5,7 @@ namespace Tapp\FilamentLms\Pages;
 use Filament\Forms\Components\Select;
 use Filament\Pages\Dashboard\Concerns\HasFiltersForm;
 use Filament\Schemas\Schema;
+use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Auth;
 use Tapp\FilamentLms\Models\Course;
 use Tapp\FilamentLms\Models\CreditCategory;
@@ -55,7 +56,7 @@ class Dashboard extends \Filament\Pages\Dashboard
         ]);
     }
 
-    public function getFilteredCoursesProperty(): \Illuminate\Support\Collection
+    public function getFilteredCoursesProperty(): Collection
     {
         $courses = $this->courses ?? collect();
 

--- a/src/Pages/Dashboard.php
+++ b/src/Pages/Dashboard.php
@@ -65,7 +65,7 @@ class Dashboard extends \Filament\Pages\Dashboard
     }
 
     #[Computed]
-    public function getFilteredCoursesProperty(): Collection
+    public function filteredCourses(): Collection
     {
         $courses = $this->courses ?? collect();
 

--- a/src/Resources/CourseResource.php
+++ b/src/Resources/CourseResource.php
@@ -140,8 +140,8 @@ class CourseResource extends Resource
                         TextInput::make('credits')
                             ->numeric()
                             ->required()
-                            ->minValue(0.01)
-                            ->step(0.01),
+                            ->minValue(0.5)
+                            ->step(0.5),
                     ])
                     ->columns(2)
                     ->defaultItems(0)

--- a/src/Resources/CourseResource.php
+++ b/src/Resources/CourseResource.php
@@ -6,8 +6,8 @@ use Filament\Actions\ActionGroup;
 use Filament\Actions\BulkActionGroup;
 use Filament\Actions\DeleteBulkAction;
 use Filament\Actions\EditAction;
-use Filament\Forms;
 use Filament\Forms\Components\Checkbox;
+use Filament\Forms\Components\Repeater;
 use Filament\Forms\Components\Select;
 use Filament\Forms\Components\SpatieMediaLibraryFileUpload;
 use Filament\Forms\Components\Textarea;
@@ -17,11 +17,14 @@ use Filament\Schemas\Components\Utilities\Set;
 use Filament\Schemas\Schema;
 use Filament\Tables\Columns\TextColumn;
 use Filament\Tables\Enums\RecordActionsPosition;
+use Filament\Tables\Filters\SelectFilter;
 use Filament\Tables\Table;
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Support\HtmlString;
 use Illuminate\Support\Str;
 use Tapp\FilamentLms\Concerns\HasLmsSlug;
 use Tapp\FilamentLms\Models\Course;
+use Tapp\FilamentLms\Models\CreditCategory;
 use Tapp\FilamentLms\RelationManagers\CourseUsersRelationManager;
 use Tapp\FilamentLms\Resources\CourseResource\Pages\CreateCourse;
 use Tapp\FilamentLms\Resources\CourseResource\Pages\EditCourse;
@@ -124,12 +127,26 @@ class CourseResource extends Resource
                     ->label('Private Course')
                     ->helperText('Private courses are only visible to assigned users and LMS admins'),
 
-                /*
-                     * TODO: Implement award layout and content
-                     */
-                // Forms\Components\Select::make('award_layout')
-                //     ->relationship(name: 'award', titleAttribute: 'name')
-                //     ->required(),
+                Repeater::make('courseCreditCategories')
+                    ->relationship()
+                    ->label(config('filament-lms.credits_repeater_label', 'Credits'))
+                    ->schema([
+                        Select::make('credit_category_id')
+                            ->label('Category')
+                            ->relationship('creditCategory', 'name', modifyQueryUsing: fn ($query) => $query->orderBy('name'))
+                            ->required()
+                            ->searchable()
+                            ->preload(),
+                        TextInput::make('credits')
+                            ->numeric()
+                            ->required()
+                            ->minValue(0.01)
+                            ->step(0.01),
+                    ])
+                    ->columns(2)
+                    ->defaultItems(0)
+                    ->addActionLabel(config('filament-lms.credits_add_action_label', 'Add credits'))
+                    ->visible(fn (): bool => config('filament-lms.credits_enabled', false)),
             ]);
     }
 
@@ -152,9 +169,38 @@ class CourseResource extends Resource
                     ->badge()
                     ->color(fn (bool $state): string => $state ? 'danger' : 'success')
                     ->formatStateUsing(fn (bool $state): string => $state ? 'Private (Manual Assignment)' : 'Public'),
+                TextColumn::make('credits_summary')
+                    ->label(config('filament-lms.credits_label', 'Credits'))
+                    ->getStateUsing(function ($record): array {
+                        $items = $record->courseCreditCategories
+                            ->loadMissing('creditCategory')
+                            ->groupBy('credit_category_id')
+                            ->map(fn ($group) => [
+                                'name' => $group->first()->creditCategory->name,
+                                'credits' => (float) $group->sum('credits'),
+                            ])
+                            ->values();
+
+                        return $items->map(fn ($item) => $item['name'].': '.number_format($item['credits'], 2))->values()->all();
+                    })
+                    ->placeholder('—')
+                    ->badge()
+                    ->limitList(3)
+                    ->expandableLimitedList()
+                    ->visible(fn (): bool => config('filament-lms.credits_enabled', false)),
             ])
             ->filters([
-                //
+                SelectFilter::make('credit_category_id')
+                    ->label('Credit Category')
+                    ->options(fn (): array => CreditCategory::query()->orderBy('name')->pluck('name', 'id')->all())
+                    ->query(function (Builder $query, array $data): void {
+                        $value = $data['value'] ?? null;
+                        if (blank($value)) {
+                            return;
+                        }
+                        $query->whereHas('courseCreditCategories', fn (Builder $q): Builder => $q->where('credit_category_id', $value));
+                    })
+                    ->visible(fn (): bool => config('filament-lms.credits_enabled', false)),
             ])
             ->recordActions([
                 ActionGroup::make([

--- a/src/Resources/CourseResource.php
+++ b/src/Resources/CourseResource.php
@@ -15,6 +15,7 @@ use Filament\Forms\Components\TextInput;
 use Filament\Resources\Resource;
 use Filament\Schemas\Components\Utilities\Set;
 use Filament\Schemas\Schema;
+use Filament\Support\Colors\Color;
 use Filament\Tables\Columns\TextColumn;
 use Filament\Tables\Enums\RecordActionsPosition;
 use Filament\Tables\Filters\SelectFilter;
@@ -136,7 +137,8 @@ class CourseResource extends Resource
                             ->relationship('creditCategory', 'name', modifyQueryUsing: fn ($query) => $query->orderBy('name'))
                             ->required()
                             ->searchable()
-                            ->preload(),
+                            ->preload()
+                            ->disableOptionsWhenSelectedInSiblingRepeaterItems(),
                         TextInput::make('credits')
                             ->numeric()
                             ->required()
@@ -185,6 +187,14 @@ class CourseResource extends Resource
                     })
                     ->placeholder('—')
                     ->badge()
+                    ->color(function (string $state): array {
+                        static $colorMap = null;
+                        $colorMap ??= CreditCategory::query()->pluck('color', 'name')->all();
+                        $categoryName = Str::before($state, ':');
+                        $colorName = $colorMap[$categoryName] ?? 'gray';
+
+                        return Color::all()[$colorName] ?? Color::all()['gray'];
+                    })
                     ->limitList(3)
                     ->expandableLimitedList()
                     ->visible(fn (): bool => config('filament-lms.credits_enabled', false)),

--- a/src/Resources/CourseResource.php
+++ b/src/Resources/CourseResource.php
@@ -15,7 +15,6 @@ use Filament\Forms\Components\TextInput;
 use Filament\Resources\Resource;
 use Filament\Schemas\Components\Utilities\Set;
 use Filament\Schemas\Schema;
-use Filament\Support\Colors\Color;
 use Filament\Tables\Columns\TextColumn;
 use Filament\Tables\Enums\RecordActionsPosition;
 use Filament\Tables\Filters\SelectFilter;
@@ -187,13 +186,7 @@ class CourseResource extends Resource
                     })
                     ->placeholder('—')
                     ->badge()
-                    ->color(function (string $state): array {
-                        static $hexMap = null;
-                        $hexMap ??= CreditCategory::all()->mapWithKeys(fn ($cat) => [$cat->name => $cat->hexColor()])->all();
-                        $categoryName = Str::before($state, ':');
-
-                        return Color::hex($hexMap[$categoryName] ?? '#6b7280');
-                    })
+                    ->color(CreditCategory::badgeColor(...))
                     ->limitList(3)
                     ->expandableLimitedList()
                     ->visible(fn (): bool => config('filament-lms.credits_enabled', false)),

--- a/src/Resources/CourseResource.php
+++ b/src/Resources/CourseResource.php
@@ -188,12 +188,11 @@ class CourseResource extends Resource
                     ->placeholder('—')
                     ->badge()
                     ->color(function (string $state): array {
-                        static $colorMap = null;
-                        $colorMap ??= CreditCategory::query()->pluck('color', 'name')->all();
+                        static $hexMap = null;
+                        $hexMap ??= CreditCategory::all()->mapWithKeys(fn ($cat) => [$cat->name => $cat->hexColor()])->all();
                         $categoryName = Str::before($state, ':');
-                        $colorName = $colorMap[$categoryName] ?? 'gray';
 
-                        return Color::all()[$colorName] ?? Color::all()['gray'];
+                        return Color::hex($hexMap[$categoryName] ?? '#6b7280');
                     })
                     ->limitList(3)
                     ->expandableLimitedList()
@@ -202,10 +201,15 @@ class CourseResource extends Resource
             ->filters([
                 SelectFilter::make('credit_category_id')
                     ->label('Credit Category')
-                    ->options(fn (): array => CreditCategory::query()->orderBy('name')->pluck('name', 'id')->all())
+                    ->options(fn (): array => ['any' => 'Any credit category'] + CreditCategory::query()->orderBy('name')->pluck('name', 'id')->all())
                     ->query(function (Builder $query, array $data): void {
                         $value = $data['value'] ?? null;
                         if (blank($value)) {
+                            return;
+                        }
+                        if ($value === 'any') {
+                            $query->whereHas('courseCreditCategories');
+
                             return;
                         }
                         $query->whereHas('courseCreditCategories', fn (Builder $q): Builder => $q->where('credit_category_id', $value));

--- a/src/Resources/CreditCategoryResource.php
+++ b/src/Resources/CreditCategoryResource.php
@@ -4,6 +4,7 @@ namespace Tapp\FilamentLms\Resources;
 
 use Filament\Actions\ActionGroup;
 use Filament\Actions\BulkActionGroup;
+use Filament\Actions\DeleteAction;
 use Filament\Actions\DeleteBulkAction;
 use Filament\Actions\EditAction;
 use Filament\Forms\Components\Select;
@@ -16,6 +17,7 @@ use Filament\Support\Colors\Color;
 use Filament\Tables\Columns\TextColumn;
 use Filament\Tables\Enums\RecordActionsPosition;
 use Filament\Tables\Table;
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Str;
 use Tapp\FilamentLms\Models\CreditCategory;
 use Tapp\FilamentLms\Resources\CreditCategoryResource\Pages\CreateCreditCategory;
@@ -33,6 +35,17 @@ class CreditCategoryResource extends Resource
     public static function shouldRegisterNavigation(): bool
     {
         return config('filament-lms.credits_enabled', false);
+    }
+
+    /**
+     * Prevent deletion of credit categories that are used by courses.
+     *
+     * TODO: Future — add swap functionality: move all credits from one category to another before deleting.
+     */
+    public static function canDelete(Model $record): bool
+    {
+        /** @var CreditCategory $record */
+        return ! $record->courseCreditCategories()->exists();
     }
 
     public static function form(Schema $schema): Schema
@@ -81,6 +94,8 @@ class CreditCategoryResource extends Resource
             ->recordActions([
                 ActionGroup::make([
                     EditAction::make(),
+                    DeleteAction::make()
+                        ->hidden(fn (CreditCategory $record): bool => $record->courseCreditCategories()->exists()),
                 ]),
             ], position: RecordActionsPosition::BeforeColumns)
             ->toolbarActions([

--- a/src/Resources/CreditCategoryResource.php
+++ b/src/Resources/CreditCategoryResource.php
@@ -1,0 +1,87 @@
+<?php
+
+namespace Tapp\FilamentLms\Resources;
+
+use Filament\Actions\ActionGroup;
+use Filament\Actions\BulkActionGroup;
+use Filament\Actions\DeleteBulkAction;
+use Filament\Actions\EditAction;
+use Filament\Forms\Components\Textarea;
+use Filament\Forms\Components\TextInput;
+use Filament\Resources\Resource;
+use Filament\Schemas\Components\Utilities\Set;
+use Filament\Schemas\Schema;
+use Filament\Tables\Columns\TextColumn;
+use Filament\Tables\Enums\RecordActionsPosition;
+use Filament\Tables\Table;
+use Illuminate\Support\Str;
+use Tapp\FilamentLms\Models\CreditCategory;
+use Tapp\FilamentLms\Resources\CreditCategoryResource\Pages\CreateCreditCategory;
+use Tapp\FilamentLms\Resources\CreditCategoryResource\Pages\EditCreditCategory;
+use Tapp\FilamentLms\Resources\CreditCategoryResource\Pages\ListCreditCategories;
+
+class CreditCategoryResource extends Resource
+{
+    protected static ?string $model = CreditCategory::class;
+
+    protected static string|\BackedEnum|null $navigationIcon = 'heroicon-o-tag';
+
+    protected static string|\UnitEnum|null $navigationGroup = 'LMS';
+
+    public static function shouldRegisterNavigation(): bool
+    {
+        return config('filament-lms.credits_enabled', false);
+    }
+
+    public static function form(Schema $schema): Schema
+    {
+        return $schema
+            ->components([
+                TextInput::make('name')
+                    ->required()
+                    ->maxLength(255)
+                    ->live(onBlur: true)
+                    ->afterStateUpdated(fn (Set $set, ?string $state) => $set('slug', Str::slug($state))),
+                TextInput::make('slug')
+                    ->required()
+                    ->maxLength(255)
+                    ->unique(ignoreRecord: true),
+                Textarea::make('description'),
+            ]);
+    }
+
+    public static function table(Table $table): Table
+    {
+        return $table
+            ->columns([
+                TextColumn::make('name')
+                    ->searchable()
+                    ->sortable(),
+                TextColumn::make('slug')
+                    ->searchable(),
+                TextColumn::make('course_credit_categories_count')
+                    ->counts('courseCreditCategories')
+                    ->label('Courses')
+                    ->sortable(),
+            ])
+            ->recordActions([
+                ActionGroup::make([
+                    EditAction::make(),
+                ]),
+            ], position: RecordActionsPosition::BeforeColumns)
+            ->toolbarActions([
+                BulkActionGroup::make([
+                    DeleteBulkAction::make(),
+                ]),
+            ]);
+    }
+
+    public static function getPages(): array
+    {
+        return [
+            'index' => ListCreditCategories::route('/'),
+            'create' => CreateCreditCategory::route('/create'),
+            'edit' => EditCreditCategory::route('/{record}/edit'),
+        ];
+    }
+}

--- a/src/Resources/CreditCategoryResource.php
+++ b/src/Resources/CreditCategoryResource.php
@@ -6,11 +6,13 @@ use Filament\Actions\ActionGroup;
 use Filament\Actions\BulkActionGroup;
 use Filament\Actions\DeleteBulkAction;
 use Filament\Actions\EditAction;
+use Filament\Forms\Components\Select;
 use Filament\Forms\Components\Textarea;
 use Filament\Forms\Components\TextInput;
 use Filament\Resources\Resource;
 use Filament\Schemas\Components\Utilities\Set;
 use Filament\Schemas\Schema;
+use Filament\Support\Colors\Color;
 use Filament\Tables\Columns\TextColumn;
 use Filament\Tables\Enums\RecordActionsPosition;
 use Filament\Tables\Table;
@@ -47,6 +49,14 @@ class CreditCategoryResource extends Resource
                     ->maxLength(255)
                     ->unique(ignoreRecord: true),
                 Textarea::make('description'),
+                Select::make('color')
+                    ->options(
+                        collect(CreditCategory::COLORS)->mapWithKeys(
+                            fn (string $hex, string $name): array => [$name => ucfirst($name)]
+                        )->toArray()
+                    )
+                    ->default(fn (): string => CreditCategory::nextAvailableColor())
+                    ->required(),
             ]);
     }
 
@@ -59,6 +69,10 @@ class CreditCategoryResource extends Resource
                     ->sortable(),
                 TextColumn::make('slug')
                     ->searchable(),
+                TextColumn::make('color')
+                    ->badge()
+                    ->formatStateUsing(fn (string $state): string => ucfirst($state))
+                    ->color(fn (CreditCategory $record): array => Color::hex($record->hexColor())),
                 TextColumn::make('course_credit_categories_count')
                     ->counts('courseCreditCategories')
                     ->label('Courses')

--- a/src/Resources/CreditCategoryResource/Pages/CreateCreditCategory.php
+++ b/src/Resources/CreditCategoryResource/Pages/CreateCreditCategory.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Tapp\FilamentLms\Resources\CreditCategoryResource\Pages;
+
+use Filament\Resources\Pages\CreateRecord;
+use Tapp\FilamentLms\Resources\CreditCategoryResource;
+
+class CreateCreditCategory extends CreateRecord
+{
+    protected static string $resource = CreditCategoryResource::class;
+}

--- a/src/Resources/CreditCategoryResource/Pages/EditCreditCategory.php
+++ b/src/Resources/CreditCategoryResource/Pages/EditCreditCategory.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Tapp\FilamentLms\Resources\CreditCategoryResource\Pages;
+
+use Filament\Actions\DeleteAction;
+use Filament\Resources\Pages\EditRecord;
+use Tapp\FilamentLms\Resources\CreditCategoryResource;
+
+class EditCreditCategory extends EditRecord
+{
+    protected static string $resource = CreditCategoryResource::class;
+
+    protected function getHeaderActions(): array
+    {
+        return [
+            DeleteAction::make(),
+        ];
+    }
+}

--- a/src/Resources/CreditCategoryResource/Pages/ListCreditCategories.php
+++ b/src/Resources/CreditCategoryResource/Pages/ListCreditCategories.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Tapp\FilamentLms\Resources\CreditCategoryResource\Pages;
+
+use Filament\Actions\CreateAction;
+use Filament\Resources\Pages\ListRecords;
+use Tapp\FilamentLms\Resources\CreditCategoryResource;
+
+class ListCreditCategories extends ListRecords
+{
+    protected static string $resource = CreditCategoryResource::class;
+
+    protected function getHeaderActions(): array
+    {
+        return [
+            CreateAction::make(),
+        ];
+    }
+}

--- a/src/Resources/StepResource.php
+++ b/src/Resources/StepResource.php
@@ -167,7 +167,7 @@ final class StepResource extends Resource
                             $lessonId = $get('lesson_id');
                             if ($lessonId) {
                                 $query->whereHas('lesson', function ($q) use ($lessonId) {
-                                    $lesson = \Tapp\FilamentLms\Models\Lesson::find($lessonId);
+                                    $lesson = Lesson::find($lessonId);
                                     if ($lesson) {
                                         $q->where('course_id', $lesson->course_id);
                                     }

--- a/tests/Feature/CourseRedirectTest.php
+++ b/tests/Feature/CourseRedirectTest.php
@@ -3,6 +3,7 @@
 namespace Tapp\FilamentLms\Tests\Feature;
 
 use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\DB;
 use Livewire\Livewire;
 use Tapp\FilamentFormBuilder\Models\FilamentForm;
 use Tapp\FilamentFormBuilder\Models\FilamentFormField;
@@ -391,4 +392,79 @@ test('dashboard filters out courses without steps for authenticated users', func
     // The private course might not be visible if user is not assigned/admin
     // But the public course should be visible
     expect($courseSlugs)->toContain('public-course-with-steps');
+});
+
+test('dashboard mount query eager loads lessons count', function () {
+    config(['filament-lms.credits_enabled' => false]);
+
+    $user = TestUser::create([
+        'name' => 'Test User',
+        'email' => 'test@example.com',
+        'password' => bcrypt('password'),
+    ]);
+
+    Auth::login($user);
+
+    $course = Course::factory()->create([
+        'name' => 'Multi Lesson Course',
+        'slug' => 'multi-lesson-course',
+        'is_private' => false,
+    ]);
+
+    $lessonOne = Lesson::factory()->create(['course_id' => $course->id, 'order' => 1]);
+    $lessonTwo = Lesson::factory()->create(['course_id' => $course->id, 'order' => 2]);
+    Step::factory()->create(['lesson_id' => $lessonOne->id]);
+    Step::factory()->create(['lesson_id' => $lessonTwo->id]);
+
+    $creditEager = config('filament-lms.credits_enabled')
+        ? ['courseCreditCategories.creditCategory']
+        : [];
+
+    $courses = Course::accessibleTo($user)
+        ->with(array_merge($creditEager, ['authEnrollment']))
+        ->withCount('lessons')
+        ->get();
+
+    expect($courses)->toHaveCount(1);
+    expect((int) $courses->first()->lessons_count)->toBe(2);
+});
+
+test('course list with authEnrollment does not query pivot again when reading completed_at per course', function (): void {
+    config(['filament-lms.credits_enabled' => false]);
+
+    $user = TestUser::create([
+        'name' => 'Test User',
+        'email' => 'test@example.com',
+        'password' => bcrypt('password'),
+    ]);
+
+    Auth::login($user);
+
+    $courses = collect([
+        Course::factory()->create(['is_private' => false]),
+        Course::factory()->create(['is_private' => false]),
+        Course::factory()->create(['is_private' => false]),
+    ]);
+
+    foreach ($courses as $course) {
+        $lesson = Lesson::factory()->create(['course_id' => $course->id]);
+        Step::factory()->create(['lesson_id' => $lesson->id]);
+        $course->users()->attach($user->id, ['completed_at' => now()]);
+    }
+
+    $loaded = Course::accessibleTo($user)
+        ->with(['authEnrollment'])
+        ->withCount('lessons')
+        ->get();
+
+    expect($loaded)->toHaveCount(3);
+
+    DB::flushQueryLog();
+    DB::enableQueryLog();
+
+    foreach ($loaded as $course) {
+        expect($course->completed_at)->not->toBeNull();
+    }
+
+    expect(DB::getQueryLog())->toHaveCount(0);
 });

--- a/tests/Feature/SignedUrlsTest.php
+++ b/tests/Feature/SignedUrlsTest.php
@@ -9,7 +9,7 @@ test('course image url fallback to placeholder when no media', function () {
 
     $imageUrl = $course->image_url;
 
-    expect($imageUrl)->toBe('https://picsum.photos/200');
+    expect($imageUrl)->toBeNull();
 });
 
 test('course image url uses regular url when signed urls disabled', function () {
@@ -20,8 +20,8 @@ test('course image url uses regular url when signed urls disabled', function () 
 
     $imageUrl = $course->image_url;
 
-    // Should return placeholder since no media is attached
-    expect($imageUrl)->toBe('https://picsum.photos/200');
+    // Should return null since no media is attached (UI handles with icon)
+    expect($imageUrl)->toBeNull();
 });
 
 test('has media url trait returns null when no media', function () {

--- a/tests/Feature/StepResourceTest.php
+++ b/tests/Feature/StepResourceTest.php
@@ -2,6 +2,7 @@
 
 namespace Tapp\FilamentLms\Tests\Feature;
 
+use Filament\Schemas\Schema;
 use Tapp\FilamentLms\Models\Course;
 use Tapp\FilamentLms\Models\Lesson;
 use Tapp\FilamentLms\Models\Step;
@@ -33,8 +34,8 @@ class StepResourceTest extends TestCase
 
     public function test_step_form_can_be_rendered_without_errors(): void
     {
-        $schema = StepResource::form(\Filament\Schemas\Schema::make());
-        $this->assertInstanceOf(\Filament\Schemas\Schema::class, $schema);
+        $schema = StepResource::form(Schema::make());
+        $this->assertInstanceOf(Schema::class, $schema);
     }
 
     public function test_lesson_select_has_preload(): void

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -4,14 +4,20 @@ declare(strict_types=1);
 
 namespace Tapp\FilamentLms\Tests;
 
+use Filament\Facades\Filament;
 use Filament\FilamentServiceProvider;
 use Filament\Support\SupportServiceProvider;
 use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\MessageBag;
+use Illuminate\Support\ViewErrorBag;
 use Livewire\LivewireServiceProvider;
 use Orchestra\Testbench\TestCase as Orchestra;
+use Spatie\MediaLibrary\MediaCollections\Models\Media;
 use Spatie\MediaLibrary\MediaLibraryServiceProvider;
 use Tapp\FilamentFormBuilder\FilamentFormBuilderServiceProvider;
+use Tapp\FilamentFormBuilder\Models\FilamentForm;
 use Tapp\FilamentLms\FilamentLmsServiceProvider;
+use Tapp\FilamentLms\LmsPanelProvider;
 
 abstract class TestCase extends Orchestra
 {
@@ -20,7 +26,7 @@ abstract class TestCase extends Orchestra
         parent::setUp();
 
         // Set the current panel for testing
-        \Filament\Facades\Filament::setCurrentPanel('lms');
+        Filament::setCurrentPanel('lms');
 
         // Initialize session
         if (! $this->app->bound('session.store')) {
@@ -29,8 +35,8 @@ abstract class TestCase extends Orchestra
 
         // Ensure ViewErrorBag is available
         if ($this->app->bound('view')) {
-            $errorBag = new \Illuminate\Support\ViewErrorBag;
-            $errorBag->put('default', new \Illuminate\Support\MessageBag);
+            $errorBag = new ViewErrorBag;
+            $errorBag->put('default', new MessageBag);
             $this->app['view']->share('errors', $errorBag);
         }
     }
@@ -60,7 +66,7 @@ abstract class TestCase extends Orchestra
 
         // Set up media library configuration
         $app['config']->set('media-library.disk_name', 'local');
-        $app['config']->set('media-library.media_model', \Spatie\MediaLibrary\MediaCollections\Models\Media::class);
+        $app['config']->set('media-library.media_model', Media::class);
 
         // Set up app key for testing
         $app['config']->set('app.key', 'base64:'.base64_encode(random_bytes(32)));
@@ -214,7 +220,7 @@ abstract class TestCase extends Orchestra
             $table->nullableTimestamps();
         });
 
-        if (class_exists(\Tapp\FilamentFormBuilder\Models\FilamentForm::class)) {
+        if (class_exists(FilamentForm::class)) {
             $app['db']->connection()->getSchemaBuilder()->create('filament_forms', function (Blueprint $table) {
                 $table->id();
                 $table->timestamps();
@@ -259,7 +265,7 @@ abstract class TestCase extends Orchestra
             SupportServiceProvider::class,
             MediaLibraryServiceProvider::class,
             FilamentLmsServiceProvider::class,
-            \Tapp\FilamentLms\LmsPanelProvider::class,
+            LmsPanelProvider::class,
         ];
 
         // Only add FilamentFormBuilderServiceProvider if it exists


### PR DESCRIPTION
Adds optional credits support: config (credits_enabled, credits_label), credit categories model and resource, course–credit category pivot, dashboard/course-card credits display, and migration stubs.

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces new persisted data (credit categories and course-credit mappings) plus new dashboard filtering and eager-loading changes; main risk is migration/relationship correctness and performance regressions on course lists.
> 
> **Overview**
> Adds an *optional* “credits” feature flag (`filament-lms.credits_enabled`) that, when enabled, lets admins define `CreditCategory` records and assign per-course credits via a new `lms_course_credit_category` relationship.
> 
> Updates the LMS UI and admin to surface credits: course cards now render a resilient image fallback plus credit badges, the dashboard adds a credit-category filter and uses computed `courses`/`filteredCourses`, and `CourseResource` gains a credits repeater, credits summary column, and a credit-category table filter. Registers the new `CreditCategoryResource` only when credits are enabled.
> 
> Improves course list performance by eager-loading `lessons_count`, step progress, and a new `authEnrollment` pivot relation to avoid per-course `completed_at` queries; also changes `Course::image_url` to return `null` when no media (tests/docs updated accordingly).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 984826194cefb1c14125f27c779f7229554494b8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->