### PR TITLE
Add PHP 8.5 to CI testing matrix

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -17,7 +17,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        php: [8.4, 8.3]
+        php: [8.5, 8.4, 8.3]
         laravel: [13.*, 12.*]
         stability: [prefer-lowest, prefer-stable]
         include:


### PR DESCRIPTION
## Summary

- Adds PHP 8.5 to the `php` matrix in the CI test workflow

## Why

PHP 8.5 is an upcoming release and this PR verifies the package works with it. The existing `composer.json` constraint (`^8.3`) already covers 8.5 semantically — this just confirms it in CI.

## Test plan

- [ ] CI passes for all PHP 8.5 matrix jobs (prefer-stable and prefer-lowest, Laravel 12 and 13)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk CI-only change that increases test coverage by adding a new PHP version; main risk is potential CI failures due to upstream PHP 8.5/tooling incompatibilities.
> 
> **Overview**
> Expands the GitHub Actions `run-tests` workflow matrix to run the existing Laravel/Testbench test suite against **PHP 8.5** in addition to 8.4 and 8.3.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7d03b40855685aa96bda86f43a3869a01c01a7ca. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->