### PR TITLE
Fix CI compatibility for Excel 4 and Laravel CSRF middleware

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         "filament/filament": "^5.0|^4.0",
         "filament/spatie-laravel-media-library-plugin": "^5.0|^4.0",
         "illuminate/contracts": "^13.0||^12.0",
-        "maatwebsite/excel": "^3.1",
+        "maatwebsite/excel": "^4.0",
         "spatie/browsershot": "^5.0",
         "spatie/eloquent-sortable": "^5.0",
         "tapp/filament-form-builder": "^4.0"

--- a/src/LmsPanelProvider.php
+++ b/src/LmsPanelProvider.php
@@ -18,7 +18,7 @@ use Filament\Widgets\FilamentInfoWidget;
 use Illuminate\Contracts\View\View;
 use Illuminate\Cookie\Middleware\AddQueuedCookiesToResponse;
 use Illuminate\Cookie\Middleware\EncryptCookies;
-use Illuminate\Foundation\Http\Middleware\VerifyCsrfToken;
+use Illuminate\Foundation\Http\Middleware\PreventRequestForgery;
 use Illuminate\Routing\Middleware\SubstituteBindings;
 use Illuminate\Session\Middleware\AuthenticateSession;
 use Illuminate\Session\Middleware\StartSession;
@@ -128,7 +128,7 @@ class LmsPanelProvider extends PanelProvider
                 StartSession::class,
                 AuthenticateSession::class,
                 ShareErrorsFromSession::class,
-                VerifyCsrfToken::class,
+                PreventRequestForgery::class,
                 SubstituteBindings::class,
                 DisableBladeIconComponents::class,
                 DispatchServingFilamentEvent::class,

--- a/src/LmsPanelProvider.php
+++ b/src/LmsPanelProvider.php
@@ -18,6 +18,7 @@ use Filament\Widgets\FilamentInfoWidget;
 use Illuminate\Contracts\View\View;
 use Illuminate\Cookie\Middleware\AddQueuedCookiesToResponse;
 use Illuminate\Cookie\Middleware\EncryptCookies;
+use Illuminate\Foundation\Http\Middleware\PreventRequestForgery;
 use Illuminate\Routing\Middleware\SubstituteBindings;
 use Illuminate\Session\Middleware\AuthenticateSession;
 use Illuminate\Session\Middleware\StartSession;
@@ -220,8 +221,8 @@ class LmsPanelProvider extends PanelProvider
 
     private function csrfMiddleware(): string
     {
-        if (class_exists(\Illuminate\Foundation\Http\Middleware\PreventRequestForgery::class)) {
-            return \Illuminate\Foundation\Http\Middleware\PreventRequestForgery::class;
+        if (class_exists(PreventRequestForgery::class)) {
+            return PreventRequestForgery::class;
         }
 
         return 'Illuminate\Foundation\Http\Middleware\VerifyCsrfToken';

--- a/src/LmsPanelProvider.php
+++ b/src/LmsPanelProvider.php
@@ -18,7 +18,7 @@ use Filament\Widgets\FilamentInfoWidget;
 use Illuminate\Contracts\View\View;
 use Illuminate\Cookie\Middleware\AddQueuedCookiesToResponse;
 use Illuminate\Cookie\Middleware\EncryptCookies;
-use Illuminate\Foundation\Http\Middleware\PreventRequestForgery;
+use Illuminate\Foundation\Http\Middleware\VerifyCsrfToken;
 use Illuminate\Routing\Middleware\SubstituteBindings;
 use Illuminate\Session\Middleware\AuthenticateSession;
 use Illuminate\Session\Middleware\StartSession;
@@ -128,7 +128,7 @@ class LmsPanelProvider extends PanelProvider
                 StartSession::class,
                 AuthenticateSession::class,
                 ShareErrorsFromSession::class,
-                PreventRequestForgery::class,
+                VerifyCsrfToken::class,
                 SubstituteBindings::class,
                 DisableBladeIconComponents::class,
                 DispatchServingFilamentEvent::class,

--- a/src/LmsPanelProvider.php
+++ b/src/LmsPanelProvider.php
@@ -18,7 +18,6 @@ use Filament\Widgets\FilamentInfoWidget;
 use Illuminate\Contracts\View\View;
 use Illuminate\Cookie\Middleware\AddQueuedCookiesToResponse;
 use Illuminate\Cookie\Middleware\EncryptCookies;
-use Illuminate\Foundation\Http\Middleware\VerifyCsrfToken;
 use Illuminate\Routing\Middleware\SubstituteBindings;
 use Illuminate\Session\Middleware\AuthenticateSession;
 use Illuminate\Session\Middleware\StartSession;
@@ -128,7 +127,7 @@ class LmsPanelProvider extends PanelProvider
                 StartSession::class,
                 AuthenticateSession::class,
                 ShareErrorsFromSession::class,
-                VerifyCsrfToken::class,
+                $this->csrfMiddleware(),
                 SubstituteBindings::class,
                 DisableBladeIconComponents::class,
                 DispatchServingFilamentEvent::class,
@@ -217,5 +216,14 @@ class LmsPanelProvider extends PanelProvider
                 ->isActiveWhen(fn (): bool => request()->routeIs(Dashboard::getRouteName()))
                 ->url(fn (): string => Dashboard::getUrl()),
         ]);
+    }
+
+    private function csrfMiddleware(): string
+    {
+        if (class_exists(\Illuminate\Foundation\Http\Middleware\PreventRequestForgery::class)) {
+            return \Illuminate\Foundation\Http\Middleware\PreventRequestForgery::class;
+        }
+
+        return 'Illuminate\Foundation\Http\Middleware\VerifyCsrfToken';
     }
 }


### PR DESCRIPTION
## What changed
- Bumped `maatwebsite/excel` in `composer.json` from `^3.1` to `^4.0` to align with `tapp/filament-form-builder` `v4.3.3`.
- Updated panel middleware from `VerifyCsrfToken` to `PreventRequestForgery` in `LmsPanelProvider` for current Laravel compatibility.

## Why
This branch addresses CI and dependency compatibility issues after the Form Builder Excel 4.x support release. These updates ensure dependency resolution succeeds and the panel middleware uses the supported framework class.

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small dependency bump and middleware class selection change; main risk is runtime incompatibility if the CSRF middleware class resolution behaves differently across supported Laravel versions.
> 
> **Overview**
> Bumps `maatwebsite/excel` from `^3.1` to `^4.0` to resolve dependency/CI compatibility with newer integrations.
> 
> Updates `LmsPanelProvider` to use Laravel’s newer `PreventRequestForgery` middleware when available, falling back to `VerifyCsrfToken` via a small `csrfMiddleware()` helper for cross-version support.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2d201988e06ecf7acc5d351320feb10c13d51047. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->