### PR TITLE
Add filament library integration

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,6 +19,9 @@
         "spatie/eloquent-sortable": "^5.0",
         "tapp/filament-form-builder": "^4.0"
     },
+    "suggest": {
+        "tapp/filament-library": "Required for Library file / Library link step materials (enable filament-lms.integrations.filament_library)."
+    },
     "require-dev": {
         "filament/upgrade": "^4.0",
         "larastan/larastan": "^3.0||^2.9",

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         "tapp/filament-form-builder": "^4.0"
     },
     "suggest": {
-        "tapp/filament-library": "Required for Library file / Library link step materials (enable filament-lms.integrations.filament_library)."
+        "tapp/filament-library": "Required for Library file / Library link step materials (set filament-lms.integrations.filament_library.enabled for the admin material picker)."
     },
     "require-dev": {
         "filament/upgrade": "^4.0",

--- a/config/filament-lms.php
+++ b/config/filament-lms.php
@@ -115,4 +115,22 @@ return [
         //     return $this->teams()->whereKey($tenant)->exists();
         // }
     ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Plugin integrations
+    |--------------------------------------------------------------------------
+    |
+    | Optional integrations with other Filament packages.
+    |
+    */
+    'integrations' => [
+        'filament_library' => [
+            // When true (and tapp/filament-library is installed), Step materials may reference Library items.
+            'enabled' => false,
+
+            // Max rows returned when searching library files or links on the Step form.
+            'material_select_limit' => 200,
+        ],
+    ],
 ];

--- a/database/factories/DocumentFactory.php
+++ b/database/factories/DocumentFactory.php
@@ -18,15 +18,19 @@ class DocumentFactory extends Factory
 
     /**
      * Associate media after creating
+     *
+     * @return $this
      */
-    public function configure(): static
+    public function configure()
     {
-        return $this->afterCreating(function ($document) {
+        $this->afterCreating(function ($document) {
             /** @var Document $document */
             $testFile = './vendor/tapp/filament-lms/test.pdf';
             $document->addMedia($testFile)
                 ->preservingOriginal()
                 ->toMediaCollection();
         });
+
+        return $this;
     }
 }

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -30,3 +30,13 @@ parameters:
         - '#Call to method .* on an unknown class Tapp\\FilamentFormBuilder\\Models\\FilamentFormUser#'
         - '#Parameter .* has invalid type Tapp\\FilamentFormBuilder\\Models\\FilamentForm#'
         - '#Parameter .* has invalid type Tapp\\FilamentFormBuilder\\Models\\FilamentFormUser#'
+        # Optional filament-library integration (classes loaded only when the consuming app installs tapp/filament-library)
+        -
+            message: '#Property .+::\$libraryItem \(Illuminate\\Database\\Eloquent\\Model\) does not accept Tapp\\FilamentLibrary\\Models\\LibraryItem#'
+            paths:
+                - src/Livewire/LibraryFileStep.php
+                - src/Livewire/LibraryLinkStep.php
+        -
+            message: '#Call to an undefined method Illuminate\\Database\\Eloquent\\Model::(getFirstMedia|getSecureUrl)\(\)#'
+            paths:
+                - src/Livewire/LibraryFileStep.php

--- a/resources/views/livewire/library-file-step.blade.php
+++ b/resources/views/livewire/library-file-step.blade.php
@@ -1,0 +1,23 @@
+<div>
+    <x-filament::section class="flex-1 flex flex-col">
+        <div class="mb-8 flex-1">
+            @if($url = $this->getPreviewUrl())
+                <iframe
+                    src="{{ $url }}"
+                    class="step-material-container rounded-lg border border-gray-300"
+                    title="{{ $libraryItem->name }}"
+                ></iframe>
+            @else
+                <p class="text-sm text-gray-600 dark:text-gray-400">
+                    No preview is available for this file. Use Download to open it.
+                </p>
+            @endif
+        </div>
+
+        <x-filament::button wire:click="download" type="button">
+            Download
+        </x-filament::button>
+    </x-filament::section>
+
+    <x-filament-lms::next-button />
+</div>

--- a/resources/views/livewire/library-link-step.blade.php
+++ b/resources/views/livewire/library-link-step.blade.php
@@ -1,0 +1,51 @@
+<div>
+    <x-filament::section
+        icon="heroicon-o-link"
+        icon-color="primary"
+    >
+        <p class="mb-8">
+            In order to complete this step, please review the following resource from the library:
+        </p>
+
+        @if($description = $libraryItem->getAttribute('link_description'))
+            <p class="mb-6 text-sm text-gray-700 dark:text-gray-300">
+                {{ $description }}
+            </p>
+        @endif
+
+        @if($linkUrl = $this->getLinkUrl())
+            @if($this->getPreviewImage())
+                <div class="mb-8 flex-1">
+                    <a
+                        href="{{ $linkUrl }}"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        wire:click="visit"
+                    >
+                        <img
+                            src="{{ $this->getPreviewImage() }}"
+                            class="step-material-container rounded-lg border border-gray-300 cursor-pointer"
+                            alt="Preview of {{ $libraryItem->name }}"
+                        />
+                    </a>
+                </div>
+            @endif
+
+            <x-filament::button
+                wire:click="visit"
+                href="{{ $linkUrl }}"
+                rel="noopener noreferrer"
+                target="_blank"
+                tag="a"
+            >
+                Open link
+            </x-filament::button>
+        @else
+            <p class="text-sm text-danger-600 dark:text-danger-400">
+                This library link is missing a URL.
+            </p>
+        @endif
+    </x-filament::section>
+
+    <x-filament-lms::next-button :disabled="!$step->is_optional && !$visited" />
+</div>

--- a/resources/views/pages/step.blade.php
+++ b/resources/views/pages/step.blade.php
@@ -43,6 +43,10 @@
         <livewire:test-step :step="$step"/>
     @elseif ($step->material_type == 'image')
         <livewire:image-step :step="$step"/>
+    @elseif ($step->material_type == 'library_file')
+        <livewire:library-file-step :step="$step"/>
+    @elseif ($step->material_type == 'library_link')
+        <livewire:library-link-step :step="$step"/>
     @else
         unsupported material type: {{ $step->material_type }}
     @endif

--- a/resources/views/pages/step.blade.php
+++ b/resources/views/pages/step.blade.php
@@ -19,6 +19,18 @@
     @if (is_null($step->material_type))
         {{-- Intentionally text-only step: show the next button --}}
         <x-filament-lms::next-button />
+    @elseif (in_array($step->material_type, ['library_file', 'library_link'], true) && ! class_exists('Tapp\FilamentLibrary\Models\LibraryItem'))
+        {{-- Library morph types cannot be resolved without filament-library; avoid loading material() (fatal). --}}
+        <div class="flex items-center justify-center min-h-[60vh]">
+            <x-filament::card class="py-12 w-full max-w-md">
+                <div class="flex flex-col justify-center items-center text-center">
+                    <div class="mb-4 text-lg font-semibold text-red-600">
+                        This step uses library content, but the library package is not installed or unavailable.
+                    </div>
+                    <x-filament-lms::next-button :fixed="false" />
+                </div>
+            </x-filament::card>
+        </div>
     @elseif (is_null($step->material))
         {{-- Material type is set but material is missing (deleted): show error --}}
         <div class="flex items-center justify-center min-h-[60vh]">

--- a/src/Console/Commands/BackfillCourseCompletedAt.php
+++ b/src/Console/Commands/BackfillCourseCompletedAt.php
@@ -74,7 +74,7 @@ class BackfillCourseCompletedAt extends Command
                 if ($course->required_test_percentage !== null) {
                     $testSteps = $course->getOrderedTestSteps();
                     if ($testSteps->isNotEmpty()) {
-                        $overall = $course->getOverallTestPercentageForUser((int) $userId);
+                        $overall = $course->getOverallTestPercentageForUser($userId);
                         if ($overall < (float) $course->required_test_percentage) {
                             $totalSkippedTestPct++;
                             if ($logEach) {

--- a/src/FilamentLmsServiceProvider.php
+++ b/src/FilamentLmsServiceProvider.php
@@ -82,19 +82,33 @@ class FilamentLmsServiceProvider extends PackageServiceProvider
         Livewire::component('view-graded-entry', ViewGradedEntry::class);
         Livewire::component('image-step', ImageStep::class);
 
+        if (config('filament-lms.integrations.filament_library.enabled', false)
+            && class_exists(\Tapp\FilamentLibrary\Models\LibraryItem::class)) {
+            Livewire::component('library-file-step', \Tapp\FilamentLms\Livewire\LibraryFileStep::class);
+            Livewire::component('library-link-step', \Tapp\FilamentLms\Livewire\LibraryLinkStep::class);
+        }
+
         FilamentAsset::register([
             Css::make('filament-lms', __DIR__.'/../dist/filament-lms.css'),
             Js::make('filament-lms', __DIR__.'/../dist/filament-lms.js'),
         ], package: 'tapp/filament-lms');
 
-        Relation::morphMap([
+        $morphMap = [
             'video' => 'Tapp\FilamentLms\Models\Video',
             'document' => 'Tapp\FilamentLms\Models\Document',
             'link' => 'Tapp\FilamentLms\Models\Link',
             'form' => 'Tapp\FilamentFormBuilder\Models\FilamentForm',
             'test' => 'Tapp\FilamentLms\Models\Test',
             'image' => 'Tapp\FilamentLms\Models\Image',
-        ]);
+        ];
+
+        if (config('filament-lms.integrations.filament_library.enabled', false)
+            && class_exists(\Tapp\FilamentLibrary\Models\LibraryItem::class)) {
+            $morphMap['library_file'] = \Tapp\FilamentLibrary\Models\LibraryItem::class;
+            $morphMap['library_link'] = \Tapp\FilamentLibrary\Models\LibraryItem::class;
+        }
+
+        Relation::morphMap($morphMap);
 
         $this->loadRoutesFrom(__DIR__.'/../routes/web.php');
     }

--- a/src/FilamentLmsServiceProvider.php
+++ b/src/FilamentLmsServiceProvider.php
@@ -10,10 +10,13 @@ use Livewire\Livewire;
 use Spatie\LaravelPackageTools\Commands\InstallCommand;
 use Spatie\LaravelPackageTools\Package;
 use Spatie\LaravelPackageTools\PackageServiceProvider;
+use Tapp\FilamentLibrary\Models\LibraryItem;
 use Tapp\FilamentLms\Console\Commands\BackfillCourseCompletedAt;
 use Tapp\FilamentLms\Livewire\DocumentStep;
 use Tapp\FilamentLms\Livewire\FormStep;
 use Tapp\FilamentLms\Livewire\ImageStep;
+use Tapp\FilamentLms\Livewire\LibraryFileStep;
+use Tapp\FilamentLms\Livewire\LibraryLinkStep;
 use Tapp\FilamentLms\Livewire\LinkStep;
 use Tapp\FilamentLms\Livewire\TestStep;
 use Tapp\FilamentLms\Livewire\VideoPlayer;
@@ -83,9 +86,9 @@ class FilamentLmsServiceProvider extends PackageServiceProvider
         Livewire::component('image-step', ImageStep::class);
 
         if (config('filament-lms.integrations.filament_library.enabled', false)
-            && class_exists(\Tapp\FilamentLibrary\Models\LibraryItem::class)) {
-            Livewire::component('library-file-step', \Tapp\FilamentLms\Livewire\LibraryFileStep::class);
-            Livewire::component('library-link-step', \Tapp\FilamentLms\Livewire\LibraryLinkStep::class);
+            && class_exists(LibraryItem::class)) {
+            Livewire::component('library-file-step', LibraryFileStep::class);
+            Livewire::component('library-link-step', LibraryLinkStep::class);
         }
 
         FilamentAsset::register([
@@ -103,9 +106,9 @@ class FilamentLmsServiceProvider extends PackageServiceProvider
         ];
 
         if (config('filament-lms.integrations.filament_library.enabled', false)
-            && class_exists(\Tapp\FilamentLibrary\Models\LibraryItem::class)) {
-            $morphMap['library_file'] = \Tapp\FilamentLibrary\Models\LibraryItem::class;
-            $morphMap['library_link'] = \Tapp\FilamentLibrary\Models\LibraryItem::class;
+            && class_exists(LibraryItem::class)) {
+            $morphMap['library_file'] = LibraryItem::class;
+            $morphMap['library_link'] = LibraryItem::class;
         }
 
         Relation::morphMap($morphMap);

--- a/src/FilamentLmsServiceProvider.php
+++ b/src/FilamentLmsServiceProvider.php
@@ -85,8 +85,10 @@ class FilamentLmsServiceProvider extends PackageServiceProvider
         Livewire::component('view-graded-entry', ViewGradedEntry::class);
         Livewire::component('image-step', ImageStep::class);
 
-        if (config('filament-lms.integrations.filament_library.enabled', false)
-            && class_exists(LibraryItem::class)) {
+        // Register library step components whenever the optional package is present.
+        // Config `integrations.filament_library.enabled` only gates admin UI (material picker);
+        // morph resolution and learner-facing steps must work for existing DB rows even when disabled.
+        if (class_exists(LibraryItem::class)) {
             Livewire::component('library-file-step', LibraryFileStep::class);
             Livewire::component('library-link-step', LibraryLinkStep::class);
         }
@@ -105,8 +107,7 @@ class FilamentLmsServiceProvider extends PackageServiceProvider
             'image' => 'Tapp\FilamentLms\Models\Image',
         ];
 
-        if (config('filament-lms.integrations.filament_library.enabled', false)
-            && class_exists(LibraryItem::class)) {
+        if (class_exists(LibraryItem::class)) {
             $morphMap['library_file'] = LibraryItem::class;
             $morphMap['library_link'] = LibraryItem::class;
         }

--- a/src/Forms/Components/MorphToSelectWithCreate.php
+++ b/src/Forms/Components/MorphToSelectWithCreate.php
@@ -68,10 +68,11 @@ class MorphToSelectWithCreate
     {
         $limit = self::libraryMaterialSelectLimit();
 
-        /** @var class-string<Model> $modelClass */
-        $modelClass = self::LIBRARY_ITEM_CLASS;
+        if (! is_a(self::LIBRARY_ITEM_CLASS, Model::class, true)) {
+            return [];
+        }
 
-        $query = $modelClass::query()
+        $query = self::LIBRARY_ITEM_CLASS::query()
             ->orderBy('name')
             ->limit($limit);
 

--- a/src/Forms/Components/MorphToSelectWithCreate.php
+++ b/src/Forms/Components/MorphToSelectWithCreate.php
@@ -7,6 +7,7 @@ use Filament\Forms\Components\Select;
 use Filament\Schemas\Components\Utilities\Get;
 use Filament\Schemas\Components\Utilities\Set;
 use Filament\Schemas\Schema;
+use Illuminate\Database\Eloquent\Model;
 use Tapp\FilamentFormBuilder\Models\FilamentForm;
 use Tapp\FilamentLms\Models\Document;
 use Tapp\FilamentLms\Models\Image;
@@ -67,7 +68,7 @@ class MorphToSelectWithCreate
     {
         $limit = self::libraryMaterialSelectLimit();
 
-        /** @var class-string<\Illuminate\Database\Eloquent\Model> $modelClass */
+        /** @var class-string<Model> $modelClass */
         $modelClass = self::LIBRARY_ITEM_CLASS;
 
         $query = $modelClass::query()

--- a/src/Forms/Components/MorphToSelectWithCreate.php
+++ b/src/Forms/Components/MorphToSelectWithCreate.php
@@ -18,19 +18,79 @@ use Tapp\FilamentLms\Services\VideoUrlService;
 
 class MorphToSelectWithCreate
 {
+    private const LIBRARY_ITEM_CLASS = 'Tapp\\FilamentLibrary\\Models\\LibraryItem';
+
+    public static function filamentLibraryIntegrationEnabled(): bool
+    {
+        return (bool) config('filament-lms.integrations.filament_library.enabled', false)
+            && class_exists(self::LIBRARY_ITEM_CLASS);
+    }
+
+    public static function libraryMaterialSelectLimit(): int
+    {
+        $limit = (int) config('filament-lms.integrations.filament_library.material_select_limit', 200);
+
+        return max(1, min($limit, 500));
+    }
+
+    public static function isLibraryMaterialType(?string $materialType): bool
+    {
+        return in_array($materialType, ['library_file', 'library_link'], true);
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    public static function materialTypeOptions(): array
+    {
+        $options = [
+            'video' => 'Video',
+            'document' => 'Document',
+            'link' => 'Link',
+            'image' => 'Image',
+            'form' => 'Form',
+            'test' => 'Test',
+        ];
+
+        if (self::filamentLibraryIntegrationEnabled()) {
+            $options['library_file'] = 'Library file';
+            $options['library_link'] = 'Library link';
+        }
+
+        return $options;
+    }
+
+    /**
+     * @return array<int|string, string>
+     */
+    private static function libraryItemOptionsForMaterialType(string $materialType): array
+    {
+        $limit = self::libraryMaterialSelectLimit();
+
+        /** @var class-string<\Illuminate\Database\Eloquent\Model> $modelClass */
+        $modelClass = self::LIBRARY_ITEM_CLASS;
+
+        $query = $modelClass::query()
+            ->orderBy('name')
+            ->limit($limit);
+
+        if ($materialType === 'library_file') {
+            $query->where('type', 'file');
+        } elseif ($materialType === 'library_link') {
+            $query->where('type', 'link');
+        } else {
+            return [];
+        }
+
+        return $query->pluck('name', 'id')->all();
+    }
+
     public static function make(string $name): array
     {
         return [
             Select::make('material_type')
                 ->label('Material Type')
-                ->options([
-                    'video' => 'Video',
-                    'document' => 'Document',
-                    'link' => 'Link',
-                    'image' => 'Image',
-                    'form' => 'Form',
-                    'test' => 'Test',
-                ])
+                ->options(self::materialTypeOptions())
                 ->live()
                 ->placeholder('Select a material type if needed')
                 ->nullable()
@@ -40,13 +100,16 @@ class MorphToSelectWithCreate
 
             Select::make('material_id')
                 ->label('Select Material')
-                ->options(function (Get $get) {
+                ->options(function (Get $get): array {
                     $materialType = $get('material_type');
                     if (! $materialType) {
                         return [];
                     }
 
-                    // Map morph aliases to class names
+                    if (self::isLibraryMaterialType($materialType)) {
+                        return self::libraryItemOptionsForMaterialType($materialType);
+                    }
+
                     $classMap = [
                         'video' => Video::class,
                         'document' => Document::class,
@@ -61,7 +124,7 @@ class MorphToSelectWithCreate
                         return [];
                     }
 
-                    return $className::query()->pluck('name', 'id');
+                    return $className::query()->orderBy('name')->pluck('name', 'id')->all();
                 })
                 ->searchable()
                 ->requiredWith('material_type')

--- a/src/Livewire/LibraryFileStep.php
+++ b/src/Livewire/LibraryFileStep.php
@@ -4,11 +4,12 @@ namespace Tapp\FilamentLms\Livewire;
 
 use Illuminate\Database\Eloquent\Model;
 use Livewire\Component;
+use Tapp\FilamentLibrary\Models\LibraryItem;
 use Tapp\FilamentLms\Models\Step;
 
 class LibraryFileStep extends Component
 {
-    /** @var \Tapp\FilamentLibrary\Models\LibraryItem&Model */
+    /** @var LibraryItem&Model */
     public Model $libraryItem;
 
     public Step $step;

--- a/src/Livewire/LibraryFileStep.php
+++ b/src/Livewire/LibraryFileStep.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace Tapp\FilamentLms\Livewire;
+
+use Illuminate\Database\Eloquent\Model;
+use Livewire\Component;
+use Tapp\FilamentLms\Models\Step;
+
+class LibraryFileStep extends Component
+{
+    /** @var \Tapp\FilamentLibrary\Models\LibraryItem&Model */
+    public Model $libraryItem;
+
+    public Step $step;
+
+    public bool $downloaded;
+
+    public function mount($step): void
+    {
+        $this->step = $step;
+        $material = $step->material;
+        if (! $material instanceof Model) {
+            abort(404);
+        }
+        $this->libraryItem = $material;
+        $this->downloaded = (bool) $step->completed_at;
+    }
+
+    public function render()
+    {
+        return view('filament-lms::livewire.library-file-step');
+    }
+
+    public function download()
+    {
+        $this->downloaded = true;
+
+        $media = $this->libraryItem->getFirstMedia();
+
+        if (! $media) {
+            return null;
+        }
+
+        return response()->download($media->getPath(), $media->file_name);
+    }
+
+    public function getPreviewUrl(): ?string
+    {
+        if (method_exists($this->libraryItem, 'getSecureUrl')) {
+            $url = $this->libraryItem->getSecureUrl();
+
+            return $url !== '' ? $url : null;
+        }
+
+        $media = $this->libraryItem->getFirstMedia();
+
+        return $media?->getUrl();
+    }
+}

--- a/src/Livewire/LibraryFileStep.php
+++ b/src/Livewire/LibraryFileStep.php
@@ -4,12 +4,10 @@ namespace Tapp\FilamentLms\Livewire;
 
 use Illuminate\Database\Eloquent\Model;
 use Livewire\Component;
-use Tapp\FilamentLibrary\Models\LibraryItem;
 use Tapp\FilamentLms\Models\Step;
 
 class LibraryFileStep extends Component
 {
-    /** @var LibraryItem&Model */
     public Model $libraryItem;
 
     public Step $step;
@@ -20,9 +18,10 @@ class LibraryFileStep extends Component
     {
         $this->step = $step;
         $material = $step->material;
-        if (! $material instanceof Model) {
+        if (! is_object($material) || ! is_a($material, 'Tapp\FilamentLibrary\Models\LibraryItem', false)) {
             abort(404);
         }
+
         $this->libraryItem = $material;
         $this->downloaded = (bool) $step->completed_at;
     }
@@ -47,14 +46,8 @@ class LibraryFileStep extends Component
 
     public function getPreviewUrl(): ?string
     {
-        if (method_exists($this->libraryItem, 'getSecureUrl')) {
-            $url = $this->libraryItem->getSecureUrl();
+        $url = $this->libraryItem->getSecureUrl();
 
-            return $url !== '' ? $url : null;
-        }
-
-        $media = $this->libraryItem->getFirstMedia();
-
-        return $media?->getUrl();
+        return $url !== '' ? $url : null;
     }
 }

--- a/src/Livewire/LibraryLinkStep.php
+++ b/src/Livewire/LibraryLinkStep.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace Tapp\FilamentLms\Livewire;
+
+use Illuminate\Database\Eloquent\Model;
+use Livewire\Component;
+use Tapp\FilamentLms\Models\Step;
+
+class LibraryLinkStep extends Component
+{
+    /** @var \Tapp\FilamentLibrary\Models\LibraryItem&Model */
+    public Model $libraryItem;
+
+    public Step $step;
+
+    public bool $visited;
+
+    public function mount($step): void
+    {
+        $this->step = $step;
+        $material = $step->material;
+        if (! $material instanceof Model) {
+            abort(404);
+        }
+        $this->libraryItem = $material;
+        $this->visited = (bool) $step->completed_at;
+    }
+
+    public function render()
+    {
+        return view('filament-lms::livewire.library-link-step');
+    }
+
+    public function visit(): void
+    {
+        $this->visited = true;
+    }
+
+    public function getLinkUrl(): ?string
+    {
+        $url = $this->libraryItem->getAttribute('external_url');
+
+        return is_string($url) && $url !== '' ? $url : null;
+    }
+
+    /**
+     * Library links do not use LMS Link preview media; return null unless overridden by the host app.
+     */
+    public function getPreviewImage(): ?string
+    {
+        return null;
+    }
+}

--- a/src/Livewire/LibraryLinkStep.php
+++ b/src/Livewire/LibraryLinkStep.php
@@ -4,12 +4,10 @@ namespace Tapp\FilamentLms\Livewire;
 
 use Illuminate\Database\Eloquent\Model;
 use Livewire\Component;
-use Tapp\FilamentLibrary\Models\LibraryItem;
 use Tapp\FilamentLms\Models\Step;
 
 class LibraryLinkStep extends Component
 {
-    /** @var LibraryItem&Model */
     public Model $libraryItem;
 
     public Step $step;
@@ -20,9 +18,10 @@ class LibraryLinkStep extends Component
     {
         $this->step = $step;
         $material = $step->material;
-        if (! $material instanceof Model) {
+        if (! is_object($material) || ! is_a($material, 'Tapp\FilamentLibrary\Models\LibraryItem', false)) {
             abort(404);
         }
+
         $this->libraryItem = $material;
         $this->visited = (bool) $step->completed_at;
     }

--- a/src/Livewire/LibraryLinkStep.php
+++ b/src/Livewire/LibraryLinkStep.php
@@ -4,11 +4,12 @@ namespace Tapp\FilamentLms\Livewire;
 
 use Illuminate\Database\Eloquent\Model;
 use Livewire\Component;
+use Tapp\FilamentLibrary\Models\LibraryItem;
 use Tapp\FilamentLms\Models\Step;
 
 class LibraryLinkStep extends Component
 {
-    /** @var \Tapp\FilamentLibrary\Models\LibraryItem&Model */
+    /** @var LibraryItem&Model */
     public Model $libraryItem;
 
     public Step $step;

--- a/src/Models/Course.php
+++ b/src/Models/Course.php
@@ -203,7 +203,7 @@ final class Course extends Model implements HasMedia
         if (
             Auth::check()
             && $this->relationLoaded('authEnrollment')
-            && (int) $userId === (int) Auth::id()
+            && (string) $userId === (string) Auth::id()
         ) {
             $first = $this->authEnrollment->first();
             $pivot = $first ? $first->getRelationValue('pivot') : null;
@@ -222,7 +222,7 @@ final class Course extends Model implements HasMedia
      * and (if required) met the test percentage. Called after any step completion so that
      * retaking a test and passing will set completed_at.
      */
-    public function maybeSetCompletedAtForUser(int $userId): void
+    public function maybeSetCompletedAtForUser(int|string $userId): void
     {
         $pivot = $this->users()->where('user_id', $userId)->first()?->getRelationValue('pivot');
         $existing = $pivot instanceof Pivot ? $pivot->getAttribute('completed_at') : null;
@@ -298,7 +298,7 @@ final class Course extends Model implements HasMedia
         // Only safe when $userId matches the authenticated user, since progress is scoped to Auth::id()
         if (
             Auth::check()
-            && (int) $userId === (int) Auth::id()
+            && (string) $userId === (string) Auth::id()
             && $steps->first()->relationLoaded('progress')
         ) {
             $completedCount = $steps->filter(fn (Step $step) => $step->progress?->completed_at !== null)->count();
@@ -373,7 +373,7 @@ final class Course extends Model implements HasMedia
      * Check if all steps are completed by the user (regardless of test percentage requirement).
      * This is useful for determining if a user has finished all steps but may not have met the test percentage requirement.
      */
-    public function allStepsCompletedByUser(int $userId): bool
+    public function allStepsCompletedByUser(int|string $userId): bool
     {
         $steps = $this->steps()->get();
 
@@ -416,7 +416,7 @@ final class Course extends Model implements HasMedia
      * Overall test percentage for the user across all test steps in this course (0–100).
      * Steps with no entry or grading errors count as 0. Returns 0 if there are no test steps.
      */
-    public function getOverallTestPercentageForUser(int $userId): float
+    public function getOverallTestPercentageForUser(int|string $userId): float
     {
         $testSteps = $this->getOrderedTestSteps();
 
@@ -435,7 +435,7 @@ final class Course extends Model implements HasMedia
     /**
      * First test step (in course order) where the user scored below 100%, or null if all are 100%.
      */
-    public function getFirstTestStepBelowPerfectForUser(int $userId): ?Step
+    public function getFirstTestStepBelowPerfectForUser(int|string $userId): ?Step
     {
         $testSteps = $this->getOrderedTestSteps();
 
@@ -452,7 +452,7 @@ final class Course extends Model implements HasMedia
     /**
      * URL to the first test step below 100% for the user, or the dashboard URL if none.
      */
-    public function getUrlToFirstTestStepBelowPerfectForUser(int $userId): string
+    public function getUrlToFirstTestStepBelowPerfectForUser(int|string $userId): string
     {
         $step = $this->getFirstTestStepBelowPerfectForUser($userId);
 
@@ -482,7 +482,7 @@ final class Course extends Model implements HasMedia
     /**
      * Get the percentage score for a single test step for a user (0–100), or 0 if no entry or on error.
      */
-    protected function getTestStepPercentageForUser(Step $step, int $userId): float
+    protected function getTestStepPercentageForUser(Step $step, int|string $userId): float
     {
         $step->load('material');
         $test = $step->material;


### PR DESCRIPTION
# Details

Add filament library integration

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new step material types backed by an optional external package and updates morph mapping/rendering, which could affect step loading at runtime if misconfigured or the dependency is missing.
> 
> **Overview**
> Adds an *optional* `tapp/filament-library` integration: new config (`integrations.filament_library`) plus a `composer.json` suggestion, and extends the Step material picker (`MorphToSelectWithCreate`) to expose `library_file`/`library_link` types and query `LibraryItem` options with a configurable limit.
> 
> Updates runtime step rendering by registering `library-file-step`/`library-link-step` Livewire components and adding `library_file`/`library_link` entries to the Eloquent morph map when `LibraryItem` exists, plus learner-facing views/components to preview/download files or open links and a guard in `step.blade.php` to avoid fatals when the library package isn’t installed.
> 
> Separately adjusts course completion/test-percentage APIs to accept `int|string` user IDs (and compares IDs as strings) and makes a small factory typing tweak; adds PHPStan ignores for the optional integration classes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ea29e20f28a1736cfa422a43dbb9e0f7848cec84. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->