### PR TITLE
Add configurable resources

### DIFF
--- a/config/filament-lms.php
+++ b/config/filament-lms.php
@@ -139,7 +139,7 @@ return [
     | Filament resource class overrides
     |--------------------------------------------------------------------------
     |
-    | Optional map of short keys to custom Filament Resource classes 
+    | Optional map of short keys to custom Filament Resource classes
     | Only keys listed below are recognized; each value must
     | be a class extending Filament\Resources\Resource.
     |

--- a/config/filament-lms.php
+++ b/config/filament-lms.php
@@ -133,4 +133,25 @@ return [
             'material_select_limit' => 200,
         ],
     ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Filament resource class overrides
+    |--------------------------------------------------------------------------
+    |
+    | Optional map of short keys to custom Filament Resource classes (similar to
+    | filament-maillog). Only keys listed below are recognized; each value must
+    | be a class extending Filament\Resources\Resource.
+    |
+    | Example (in your app's config/filament-lms.php):
+    |
+    | 'resources' => [
+    |     'CourseResource' => \App\Filament\Resources\Lms\CourseResource::class,
+    | ],
+    |
+    | Keys: CourseResource, LessonResource, StepResource, VideoResource, DocumentResource,
+    | LinkResource, TestResource, ImageResource, CreditCategoryResource (when credits_enabled).
+    |
+    */
+    'resources' => [],
 ];

--- a/config/filament-lms.php
+++ b/config/filament-lms.php
@@ -139,8 +139,8 @@ return [
     | Filament resource class overrides
     |--------------------------------------------------------------------------
     |
-    | Optional map of short keys to custom Filament Resource classes (similar to
-    | filament-maillog). Only keys listed below are recognized; each value must
+    | Optional map of short keys to custom Filament Resource classes 
+    | Only keys listed below are recognized; each value must
     | be a class extending Filament\Resources\Resource.
     |
     | Example (in your app's config/filament-lms.php):

--- a/src/Lms.php
+++ b/src/Lms.php
@@ -59,6 +59,8 @@ class Lms implements Plugin
     /**
      * Filament resource classes registered by this plugin, after merging `filament-lms.resources` overrides.
      *
+     * Class strings are unique so Filament does not register the same resource twice (duplicate nav, routes).
+     *
      * @return list<class-string<resource>>
      */
     public static function registeredResourceClasses(): array
@@ -102,6 +104,6 @@ class Lms implements Plugin
             $classes[] = $class;
         }
 
-        return $classes;
+        return array_values(array_unique($classes));
     }
 }

--- a/src/Lms.php
+++ b/src/Lms.php
@@ -4,6 +4,8 @@ namespace Tapp\FilamentLms;
 
 use Filament\Contracts\Plugin;
 use Filament\Panel;
+use Filament\Resources\Resource;
+use InvalidArgumentException;
 use Tapp\FilamentFormBuilder\FilamentFormBuilderPlugin;
 use Tapp\FilamentLms\Pages\CreateRubric;
 use Tapp\FilamentLms\Pages\Reporting;
@@ -27,22 +29,7 @@ class Lms implements Plugin
 
     public function register(Panel $panel): void
     {
-        $resources = [
-            CourseResource::class,
-            LessonResource::class,
-            StepResource::class,
-            VideoResource::class,
-            DocumentResource::class,
-            LinkResource::class,
-            TestResource::class,
-            ImageResource::class,
-        ];
-
-        if (config('filament-lms.credits_enabled', false)) {
-            $resources[] = CreditCategoryResource::class;
-        }
-
-        $panel->resources($resources);
+        $panel->resources(self::registeredResourceClasses());
 
         $panel->pages([
             Reporting::class,
@@ -67,5 +54,54 @@ class Lms implements Plugin
     public static function get(): static
     {
         return filament(app(static::class)->getId());
+    }
+
+    /**
+     * Filament resource classes registered by this plugin, after merging `filament-lms.resources` overrides.
+     *
+     * @return list<class-string<resource>>
+     */
+    public static function registeredResourceClasses(): array
+    {
+        $defaults = [
+            'CourseResource' => CourseResource::class,
+            'LessonResource' => LessonResource::class,
+            'StepResource' => StepResource::class,
+            'VideoResource' => VideoResource::class,
+            'DocumentResource' => DocumentResource::class,
+            'LinkResource' => LinkResource::class,
+            'TestResource' => TestResource::class,
+            'ImageResource' => ImageResource::class,
+            'CreditCategoryResource' => CreditCategoryResource::class,
+        ];
+
+        /** @var array<string, mixed> $overrides */
+        $overrides = config('filament-lms.resources', []);
+
+        $classes = [];
+
+        foreach ($defaults as $key => $defaultClass) {
+            if ($key === 'CreditCategoryResource' && ! config('filament-lms.credits_enabled', false)) {
+                continue;
+            }
+
+            $class = array_key_exists($key, $overrides) ? $overrides[$key] : $defaultClass;
+
+            if (! is_string($class) || $class === '') {
+                throw new InvalidArgumentException("filament-lms.resources.{$key} must be a non-empty class-string.");
+            }
+
+            if (! class_exists($class)) {
+                throw new InvalidArgumentException("filament-lms.resources.{$key} class [{$class}] does not exist.");
+            }
+
+            if (! is_subclass_of($class, Resource::class)) {
+                throw new InvalidArgumentException("filament-lms.resources.{$key} class [{$class}] must extend ".Resource::class.'.');
+            }
+
+            $classes[] = $class;
+        }
+
+        return $classes;
     }
 }

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -14,6 +14,7 @@ use Tapp\FilamentLms\Tests\TestCase;
 */
 
 pest()->extend(TestCase::class)->in('Feature');
+pest()->extend(TestCase::class)->in('Unit');
 
 /*
 |--------------------------------------------------------------------------

--- a/tests/Unit/LmsResourcesConfigTest.php
+++ b/tests/Unit/LmsResourcesConfigTest.php
@@ -22,7 +22,7 @@ test('registeredResourceClasses respects CourseResource override from config', f
 
     expect($classes)->not->toContain(CourseResource::class);
     expect($classes)->toContain(LessonResource::class);
-    expect(array_count_values($classes)[LessonResource::class] ?? 0)->toBe(2);
+    expect(array_count_values($classes)[LessonResource::class] ?? 0)->toBe(1);
 });
 
 test('registeredResourceClasses omits CreditCategoryResource when credits disabled', function () {

--- a/tests/Unit/LmsResourcesConfigTest.php
+++ b/tests/Unit/LmsResourcesConfigTest.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+use Tapp\FilamentLms\Lms;
+use Tapp\FilamentLms\Resources\CourseResource;
+use Tapp\FilamentLms\Resources\CreditCategoryResource;
+use Tapp\FilamentLms\Resources\LessonResource;
+
+test('registeredResourceClasses includes package CourseResource by default', function () {
+    config(['filament-lms.resources' => []]);
+
+    expect(Lms::registeredResourceClasses())->toContain(CourseResource::class);
+});
+
+test('registeredResourceClasses respects CourseResource override from config', function () {
+    config(['filament-lms.resources' => [
+        'CourseResource' => LessonResource::class,
+    ]]);
+
+    $classes = Lms::registeredResourceClasses();
+
+    expect($classes)->not->toContain(CourseResource::class);
+    expect($classes)->toContain(LessonResource::class);
+    expect(array_count_values($classes)[LessonResource::class] ?? 0)->toBe(2);
+});
+
+test('registeredResourceClasses omits CreditCategoryResource when credits disabled', function () {
+    config([
+        'filament-lms.credits_enabled' => false,
+        'filament-lms.resources' => [],
+    ]);
+
+    expect(Lms::registeredResourceClasses())->not->toContain(CreditCategoryResource::class);
+});
+
+test('registeredResourceClasses includes CreditCategoryResource when credits enabled', function () {
+    config([
+        'filament-lms.credits_enabled' => true,
+        'filament-lms.resources' => [],
+    ]);
+
+    expect(Lms::registeredResourceClasses())->toContain(CreditCategoryResource::class);
+});


### PR DESCRIPTION
# Details

Add configurable resources

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes how Filament resources are registered and introduces runtime validation/exception paths that could break panel boot if misconfigured.
> 
> **Overview**
> Adds a new `filament-lms.resources` config map to let consuming apps override which Filament `Resource` classes the LMS plugin registers.
> 
> Updates `Lms::register()` to use a new `registeredResourceClasses()` helper that merges defaults with overrides, conditionally includes `CreditCategoryResource` based on `credits_enabled`, de-dupes classes, and throws `InvalidArgumentException` for invalid/missing/non-`Resource` classes.
> 
> Adds unit tests (and Pest `Unit` binding) to verify default inclusion, override behavior, and credits-enabled gating.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7a805b71483f905d4a815c9ee26740e08128aec1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->