### PR TITLE
Enhance CoursesRelationManager for user course assignment

### DIFF
--- a/config/filament-lms.php
+++ b/config/filament-lms.php
@@ -44,6 +44,12 @@ return [
         'email',
     ],
 
+    // Course search columns for relation managers
+    'course_search_columns' => [
+        'name',
+        'external_id',
+    ],
+
     // User name columns for the course progress report. Use ['first_name', 'last_name'] when the
     // users table has first_name and last_name, or ['name'] when it has a single name column.
     'report_user_name_columns' => ['first_name', 'last_name'],

--- a/src/RelationManagers/CourseUsersRelationManager.php
+++ b/src/RelationManagers/CourseUsersRelationManager.php
@@ -55,10 +55,12 @@ class CourseUsersRelationManager extends RelationManager
                     ->label('Email')
                     ->searchable()
                     ->sortable(),
-                Tables\Columns\TextColumn::make('created_at')
+                Tables\Columns\TextColumn::make('pivot.created_at')
                     ->label('Assigned At')
                     ->dateTime()
-                    ->sortable()
+                    ->sortable(query: function (Builder $query, string $direction): Builder {
+                        return $query->orderBy('lms_course_user.created_at', $direction);
+                    })
                     ->toggleable(isToggledHiddenByDefault: true),
             ])
             ->filters([

--- a/src/RelationManagers/CoursesRelationManager.php
+++ b/src/RelationManagers/CoursesRelationManager.php
@@ -4,22 +4,39 @@ namespace Tapp\FilamentLms\RelationManagers;
 
 use Filament\Actions\ActionGroup;
 use Filament\Actions\AttachAction;
+use Filament\Actions\BulkActionGroup;
 use Filament\Actions\DetachAction;
+use Filament\Actions\DetachBulkAction;
 use Filament\Resources\RelationManagers\RelationManager;
 use Filament\Tables\Columns\TextColumn;
 use Filament\Tables\Enums\RecordActionsPosition;
 use Filament\Tables\Table;
+use Illuminate\Database\Eloquent\Builder;
+use Tapp\FilamentLms\Models\Course;
 
 class CoursesRelationManager extends RelationManager
 {
     protected static string $relationship = 'courses';
+
+    protected static ?string $title = 'Assigned Courses';
+
+    protected static ?string $modelLabel = 'Course';
+
+    protected static ?string $pluralModelLabel = 'Courses';
 
     public function table(Table $table): Table
     {
         return $table
             ->recordTitleAttribute('name')
             ->columns([
-                TextColumn::make('name')->searchable()->sortable(),
+                TextColumn::make('name')
+                    ->searchable()
+                    ->sortable(),
+                TextColumn::make('external_id')
+                    ->label('External ID')
+                    ->searchable()
+                    ->sortable()
+                    ->toggleable(isToggledHiddenByDefault: true),
                 TextColumn::make('progress')
                     ->label('Progress')
                     ->getStateUsing(function ($record) {
@@ -32,14 +49,65 @@ class CoursesRelationManager extends RelationManager
 
                         return 'N/A';
                     }),
+                TextColumn::make('created_at')
+                    ->label('Assigned At')
+                    ->dateTime()
+                    ->sortable()
+                    ->toggleable(isToggledHiddenByDefault: true),
             ])
             ->headerActions([
-                AttachAction::make()->label('Add Course')->preloadRecordSelect(),
+                AttachAction::make()
+                    ->label('Attach')
+                    ->preloadRecordSelect()
+                    ->recordSelectSearchColumns($this->getCourseSearchColumns())
+                    ->recordSelectOptionsQuery(function (Builder $query) {
+                        $ownerRecord = $this->getOwnerRecord();
+                        if (method_exists($ownerRecord, 'courses')) {
+                            // @phpstan-ignore-next-line - courses() method is provided by FilamentLmsUser trait
+                            $existingCourseIds = $ownerRecord->courses()->pluck('course_id');
+
+                            return $query->whereNotIn('lms_courses.id', $existingCourseIds);
+                        }
+
+                        return $query;
+                    })
+                    ->schema(fn (AttachAction $action): array => [
+                        $action->getRecordSelect(),
+                    ]),
             ])
             ->recordActions([
                 ActionGroup::make([
-                    DetachAction::make()->label('Remove'),
+                    DetachAction::make(),
                 ]),
-            ], position: RecordActionsPosition::BeforeColumns);
+            ], position: RecordActionsPosition::BeforeColumns)
+            ->toolbarActions([
+                BulkActionGroup::make([
+                    DetachBulkAction::make(),
+                ]),
+            ]);
+    }
+
+    /**
+     * Get the searchable columns for the course model.
+     * This method can be overridden or configured.
+     *
+     * @return list<string>
+     */
+    protected function getCourseSearchColumns(): array
+    {
+        $configColumns = config('filament-lms.course_search_columns');
+        if ($configColumns && is_array($configColumns)) {
+            return $configColumns;
+        }
+
+        $course = new Course;
+
+        $columns = ['name'];
+
+        if ($course->getConnection()->getSchemaBuilder()->hasColumn($course->getTable(), 'external_id')) {
+            $columns[] = 'external_id';
+        }
+
+        return $columns;
     }
 }

--- a/src/RelationManagers/CoursesRelationManager.php
+++ b/src/RelationManagers/CoursesRelationManager.php
@@ -49,10 +49,12 @@ class CoursesRelationManager extends RelationManager
 
                         return 'N/A';
                     }),
-                TextColumn::make('created_at')
+                TextColumn::make('pivot.created_at')
                     ->label('Assigned At')
                     ->dateTime()
-                    ->sortable()
+                    ->sortable(query: function (Builder $query, string $direction): Builder {
+                        return $query->orderBy('lms_course_user.created_at', $direction);
+                    })
                     ->toggleable(isToggledHiddenByDefault: true),
             ])
             ->headerActions([

--- a/tests/Feature/CoursesRelationManagerTest.php
+++ b/tests/Feature/CoursesRelationManagerTest.php
@@ -1,0 +1,84 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Facades\DB;
+use Tapp\FilamentLms\Models\Course;
+use Tapp\FilamentLms\RelationManagers\CoursesRelationManager;
+use Tapp\FilamentLms\Tests\TestUser;
+
+test('courses relation manager is configured for the courses relationship', function (): void {
+    $reflection = new ReflectionClass(CoursesRelationManager::class);
+
+    expect(CoursesRelationManager::getRelationshipName())->toBe('courses')
+        ->and($reflection->getStaticPropertyValue('title'))->toBe('Assigned Courses')
+        ->and($reflection->getStaticPropertyValue('modelLabel'))->toBe('Course');
+});
+
+test('user can attach and detach courses via the courses relationship', function (): void {
+    $user = TestUser::create([
+        'name' => 'Test User',
+        'email' => 'test@example.com',
+        'password' => bcrypt('password'),
+    ]);
+
+    $course = Course::factory()->create();
+
+    $user->courses()->attach($course->id);
+
+    expect($user->courses()->pluck('lms_courses.id')->all())->toBe([$course->id]);
+
+    $user->courses()->detach($course->id);
+
+    expect($user->courses()->count())->toBe(0);
+});
+
+test('attaching the same course twice does not create duplicate pivot rows', function (): void {
+    $user = TestUser::create([
+        'name' => 'Test User',
+        'email' => 'duplicate@example.com',
+        'password' => bcrypt('password'),
+    ]);
+
+    $course = Course::factory()->create();
+
+    $user->courses()->syncWithoutDetaching([$course->id]);
+    $user->courses()->syncWithoutDetaching([$course->id]);
+
+    expect(DB::table('lms_course_user')
+        ->where('user_id', $user->id)
+        ->where('course_id', $course->id)
+        ->count())->toBe(1);
+});
+
+test('attach query excludes courses already assigned to the user', function (): void {
+    $user = TestUser::create([
+        'name' => 'Test User',
+        'email' => 'exclude@example.com',
+        'password' => bcrypt('password'),
+    ]);
+
+    $assignedCourse = Course::factory()->create(['name' => 'Assigned Course']);
+    $availableCourse = Course::factory()->create(['name' => 'Available Course']);
+
+    $user->courses()->attach($assignedCourse->id);
+
+    $existingCourseIds = $user->courses()->pluck('course_id');
+
+    $attachableCourseIds = Course::query()
+        ->whereNotIn('lms_courses.id', $existingCourseIds)
+        ->pluck('id')
+        ->all();
+
+    expect($attachableCourseIds)->toContain($availableCourse->id)
+        ->and($attachableCourseIds)->not->toContain($assignedCourse->id);
+});
+
+test('course search columns can be configured', function (): void {
+    config()->set('filament-lms.course_search_columns', ['name']);
+
+    $relationManager = new CoursesRelationManager;
+    $method = new ReflectionMethod($relationManager, 'getCourseSearchColumns');
+
+    expect($method->invoke($relationManager))->toBe(['name']);
+});

--- a/tests/Feature/CoursesRelationManagerTest.php
+++ b/tests/Feature/CoursesRelationManagerTest.php
@@ -74,6 +74,40 @@ test('attach query excludes courses already assigned to the user', function (): 
         ->and($attachableCourseIds)->not->toContain($assignedCourse->id);
 });
 
+test('courses relationship pivot created_at reflects assignment not course creation', function (): void {
+    $user = TestUser::create([
+        'name' => 'Test User',
+        'email' => 'assigned-at@example.com',
+        'password' => bcrypt('password'),
+    ]);
+
+    $courseCreatedAt = now()->subDays(30);
+    $assignedAt = now()->subDays(2);
+
+    $course = Course::factory()->create();
+    $course->forceFill([
+        'created_at' => $courseCreatedAt,
+        'updated_at' => $courseCreatedAt,
+    ])->save();
+
+    $user->courses()->attach($course->id);
+
+    DB::table('lms_course_user')
+        ->where('user_id', $user->id)
+        ->where('course_id', $course->id)
+        ->update([
+            'created_at' => $assignedAt,
+            'updated_at' => $assignedAt,
+        ]);
+
+    $attachedCourse = $user->courses()->first();
+
+    expect($attachedCourse->created_at->format('Y-m-d H:i:s'))
+        ->toBe($courseCreatedAt->format('Y-m-d H:i:s'))
+        ->and($attachedCourse->pivot->created_at->format('Y-m-d H:i:s'))
+        ->toBe($assignedAt->format('Y-m-d H:i:s'));
+});
+
 test('course search columns can be configured', function (): void {
     config()->set('filament-lms.course_search_columns', ['name']);
 


### PR DESCRIPTION
## Summary
- Brings `CoursesRelationManager` to parity with `CourseUsersRelationManager` (title, labels, search columns, bulk detach, assigned-at column)
- Adds `course_search_columns` config key for attach search customization
- Adds Pest tests for attach/detach/exclude behavior

## Test plan
- [x] `./vendor/bin/pest tests/Feature/CoursesRelationManagerTest.php` passes in package
- [x] Consuming app wires `CoursesRelationManager` on `UserResource` and verifies Assigned Courses tab on user edit page


Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Admin-only Filament relation manager and config changes; no auth, enrollment API, or learner-facing behavior beyond clearer assignment metadata in the admin UI.
> 
> **Overview**
> **`CoursesRelationManager`** on user edit is brought in line with **`CourseUsersRelationManager`**: tab title/labels, **External ID** and **Assigned At** (`pivot.created_at` with correct pivot sort), configurable attach search, attach picker that hides already-assigned courses, and bulk detach.
> 
> New **`filament-lms.course_search_columns`** (`name`, `external_id`) mirrors **`user_search_columns`**; **`getCourseSearchColumns()`** falls back to schema detection when config is unset.
> 
> **`CourseUsersRelationManager`** fixes **Assigned At** to use **`pivot.created_at`** instead of the user’s **`created_at`**.
> 
> Pest coverage in **`CoursesRelationManagerTest`** for attach/detach, duplicate pivot prevention, attach exclusion, pivot vs course timestamps, and config-driven search columns.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 66c1262615a07206e79ba508c6ad9c26bb8b53f0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->