### PR TITLE
Course evaluation

### DIFF
--- a/README.md
+++ b/README.md
@@ -532,11 +532,10 @@ In `config/filament-lms.php`:
 ```php
 'evaluations' => [
     'enabled' => true,
-    'template_form_slug' => 'course-evaluation-feedback',
 ],
 ```
 
-The `template_form_slug` value is a convention for referencing your feedback form in application code or docs. Create a form with that slug in Form Builder, or use any form and attach it to the evaluation step.
+Create a feedback form in Form Builder, then attach it to the evaluation course's form step.
 
 ### Admin setup
 

--- a/README.md
+++ b/README.md
@@ -531,12 +531,10 @@ In `config/filament-lms.php`:
 
 ```php
 'evaluations' => [
-    'enabled' => env('LMS_EVALUATIONS_ENABLED', true),
+    'enabled' => true,
     'template_form_slug' => 'course-evaluation-feedback',
 ],
 ```
-
-Or set `LMS_EVALUATIONS_ENABLED=true` in your `.env`.
 
 The `template_form_slug` value is a convention for referencing your feedback form in application code or docs. Create a form with that slug in Form Builder, or use any form and attach it to the evaluation step.
 

--- a/README.md
+++ b/README.md
@@ -552,6 +552,7 @@ Important:
 - Set the evaluation link on the **training** course, not on the evaluation course. Linking the evaluation course back to the training course will hide the training course from the dashboard.
 - Only **private** courses can be selected as evaluation targets.
 - An evaluation course cannot itself have an evaluation course linked to it.
+- The same evaluation course can be linked from multiple training courses. Each training course still requires its own evaluation submission before that course is marked complete or its certificate is issued.
 
 ### Learner experience
 

--- a/README.md
+++ b/README.md
@@ -513,6 +513,63 @@ class User extends Authenticatable
 
 This allows you to implement any business rules you need for course visibility, while still leveraging the default logic from the trait if desired.
 
+## Course Evaluations
+
+Course evaluations let you require learners to complete a feedback form after finishing a training course and before the primary course is marked complete or a certificate is issued.
+
+This uses a **linked evaluation course** model: the training course points to a separate private evaluation course via `evaluation_course_id`. Learners are auto-assigned to the evaluation course when they finish the training content.
+
+### Prerequisites
+
+- [Filament Form Builder](https://github.com/TappNetwork/Filament-Form-Builder) installed with its migrations published
+- Package migrations published and run (including `add_evaluation_course_id_to_lms_courses_table`)
+- A feedback form created in Form Builder (via the admin UI or an application-specific migration)
+
+### Enable evaluations
+
+In `config/filament-lms.php`:
+
+```php
+'evaluations' => [
+    'enabled' => env('LMS_EVALUATIONS_ENABLED', true),
+    'template_form_slug' => 'course-evaluation-feedback',
+],
+```
+
+Or set `LMS_EVALUATIONS_ENABLED=true` in your `.env`.
+
+The `template_form_slug` value is a convention for referencing your feedback form in application code or docs. Create a form with that slug in Form Builder, or use any form and attach it to the evaluation step.
+
+### Admin setup
+
+Create **two courses**:
+
+| Course | Settings |
+|--------|----------|
+| **Training course** (e.g. "Workplace Safety") | Public or private as needed. Set **Evaluation course** to the evaluation course below. |
+| **Evaluation course** (e.g. "Workplace Safety Evaluation") | Must be **private**. Leave **Evaluation course** empty. Add one lesson with a **Form** step using your feedback form. |
+
+Important:
+
+- Set the evaluation link on the **training** course, not on the evaluation course. Linking the evaluation course back to the training course will hide the training course from the dashboard.
+- Only **private** courses can be selected as evaluation targets.
+- An evaluation course cannot itself have an evaluation course linked to it.
+
+### Learner experience
+
+1. Learner completes all steps on the training course.
+2. If an evaluation is required, they see a **Complete Evaluation** prompt instead of the certificate.
+3. They are auto-enrolled on the private evaluation course (no manual assignment needed for public training courses).
+4. After submitting the evaluation form, they are redirected to the training course certificate page.
+5. After completion, learners can review their submission via **View Evaluation** on the certificate page.
+
+Evaluation form steps do not show a **Next** button — **Submit** completes the step and advances automatically.
+
+### Public vs private training courses
+
+- **Public training courses:** learners do not need to be assigned to the training course. They are auto-assigned to the evaluation course when training is complete.
+- **Private training courses:** learners must be assigned to the training course as usual. The evaluation course is still auto-assigned when they finish.
+
 ## Step Access Control
 
 ### Customizing Step Access

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         "maatwebsite/excel": "^4.0",
         "spatie/browsershot": "^5.0",
         "spatie/eloquent-sortable": "^5.0",
-        "tapp/filament-form-builder": "^4.0"
+        "tapp/filament-form-builder": "^4.3.5"
     },
     "suggest": {
         "tapp/filament-library": "Required for Library file / Library link step materials (set filament-lms.integrations.filament_library.enabled for the admin material picker)."

--- a/config/filament-lms.php
+++ b/config/filament-lms.php
@@ -206,7 +206,7 @@ return [
     |
     */
     'evaluations' => [
-        'enabled' => env('LMS_EVALUATIONS_ENABLED', false),
+        'enabled' => false,
         'template_form_slug' => 'course-evaluation-feedback',
     ],
 ];

--- a/config/filament-lms.php
+++ b/config/filament-lms.php
@@ -193,4 +193,20 @@ return [
 
     // Optional path to Node binary for Articulate slide JSON extraction
     'node_binary' => null,
+
+    /*
+    |--------------------------------------------------------------------------
+    | Course evaluations
+    |--------------------------------------------------------------------------
+    |
+    | When enabled, primary courses may link to a required evaluation course
+    | via evaluation_course_id. Learners are auto-assigned after completing
+    | the primary course and must finish the evaluation before the primary
+    | course is marked complete or a certificate is issued.
+    |
+    */
+    'evaluations' => [
+        'enabled' => env('LMS_EVALUATIONS_ENABLED', false),
+        'template_form_slug' => 'course-evaluation-feedback',
+    ],
 ];

--- a/config/filament-lms.php
+++ b/config/filament-lms.php
@@ -207,6 +207,5 @@ return [
     */
     'evaluations' => [
         'enabled' => false,
-        'template_form_slug' => 'course-evaluation-feedback',
     ],
 ];

--- a/database/migrations/add_evaluation_course_id_to_lms_courses_table.php.stub
+++ b/database/migrations/add_evaluation_course_id_to_lms_courses_table.php.stub
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('lms_courses', function (Blueprint $table) {
+            $table->foreignId('evaluation_course_id')
+                ->nullable()
+                ->after('completion_mode')
+                ->constrained('lms_courses')
+                ->nullOnDelete();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('lms_courses', function (Blueprint $table) {
+            $table->dropConstrainedForeignId('evaluation_course_id');
+        });
+    }
+};

--- a/database/migrations/add_evaluation_primary_course_id_to_lms_step_user_table.php.stub
+++ b/database/migrations/add_evaluation_primary_course_id_to_lms_step_user_table.php.stub
@@ -1,0 +1,26 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('lms_step_user', function (Blueprint $table) {
+            $table->foreignId('evaluation_primary_course_id')
+                ->nullable()
+                ->after('step_id')
+                ->constrained('lms_courses')
+                ->nullOnDelete();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('lms_step_user', function (Blueprint $table) {
+            $table->dropConstrainedForeignId('evaluation_primary_course_id');
+        });
+    }
+};

--- a/database/migrations/add_filament_form_user_id_to_lms_step_user_table.php.stub
+++ b/database/migrations/add_filament_form_user_id_to_lms_step_user_table.php.stub
@@ -1,0 +1,26 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('lms_step_user', function (Blueprint $table) {
+            $table->foreignId('filament_form_user_id')
+                ->nullable()
+                ->after('user_id')
+                ->constrained('filament_form_user')
+                ->nullOnDelete();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('lms_step_user', function (Blueprint $table) {
+            $table->dropConstrainedForeignId('filament_form_user_id');
+        });
+    }
+};

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -115,6 +115,12 @@ parameters:
 			path: src/Models/Course.php
 
 		-
+			message: '#^Call to an undefined method Illuminate\\Database\\Eloquent\\Relations\\HasManyThrough\:\:ordered\(\)\.$#'
+			identifier: method.notFound
+			count: 1
+			path: src/Services/CourseEvaluationService.php
+
+		-
 			message: '#^Call to an undefined method Illuminate\\Foundation\\Auth\\User\:\:canAccessStep\(\)\.$#'
 			identifier: method.notFound
 			count: 1

--- a/resources/views/livewire/form-step.blade.php
+++ b/resources/views/livewire/form-step.blade.php
@@ -2,7 +2,7 @@
     @if($entry)
         @livewire('tapp.filament-form-builder.livewire.filament-form-user.show', [$entry])
     @else
-        @livewire('tapp.filament-form-builder.livewire.filament-form.show', [$form, 'blockRedirect' => true])
+        @livewire('tapp.filament-form-builder.livewire.filament-form.show', [$form, 'blockRedirect' => true, 'allowMultipleSubmissions' => true])
     @endif
 
     @if(! $step->lesson->course->isEvaluationCourse())

--- a/resources/views/livewire/form-step.blade.php
+++ b/resources/views/livewire/form-step.blade.php
@@ -1,11 +1,13 @@
 <div>
+    @php($isEvaluationCourse = $step->lesson->course->isEvaluationCourse())
+
     @if($entry)
         @livewire('tapp.filament-form-builder.livewire.filament-form-user.show', [$entry])
     @else
-        @livewire('tapp.filament-form-builder.livewire.filament-form.show', [$form, 'blockRedirect' => true, 'allowMultipleSubmissions' => true])
+        @livewire('tapp.filament-form-builder.livewire.filament-form.show', [$form, 'blockRedirect' => true, 'allowMultipleSubmissions' => $isEvaluationCourse])
     @endif
 
-    @if(! $step->lesson->course->isEvaluationCourse())
+    @if(! $isEvaluationCourse)
         <x-filament-lms::next-button :disabled="!$step->is_optional && !$entry" />
     @endif
 </div>

--- a/resources/views/livewire/form-step.blade.php
+++ b/resources/views/livewire/form-step.blade.php
@@ -4,7 +4,7 @@
     @if($entry)
         @livewire('tapp.filament-form-builder.livewire.filament-form-user.show', [$entry])
     @else
-        @livewire('tapp.filament-form-builder.livewire.filament-form.show', [$form, 'blockRedirect' => true, 'allowMultipleSubmissions' => $isEvaluationCourse])
+        @livewire('tapp.filament-form-builder.livewire.filament-form.show', ['form' => $form, 'blockRedirect' => true, 'allowMultipleSubmissions' => $isEvaluationCourse])
     @endif
 
     @if(! $isEvaluationCourse)

--- a/resources/views/livewire/form-step.blade.php
+++ b/resources/views/livewire/form-step.blade.php
@@ -5,5 +5,7 @@
         @livewire('tapp.filament-form-builder.livewire.filament-form.show', [$form, 'blockRedirect' => true])
     @endif
 
-    <x-filament-lms::next-button :disabled="!$step->is_optional && !$entry" />
+    @if(! $step->lesson->course->isEvaluationCourse())
+        <x-filament-lms::next-button :disabled="!$step->is_optional && !$entry" />
+    @endif
 </div>

--- a/resources/views/livewire/form-step.blade.php
+++ b/resources/views/livewire/form-step.blade.php
@@ -1,13 +1,11 @@
 <div>
-    @php($isEvaluationCourse = $step->lesson->course->isEvaluationCourse())
-
     @if($entry)
         @livewire('tapp.filament-form-builder.livewire.filament-form-user.show', [$entry])
     @else
-        @livewire('tapp.filament-form-builder.livewire.filament-form.show', ['form' => $form, 'blockRedirect' => true, 'allowMultipleSubmissions' => $isEvaluationCourse])
+        @livewire('tapp.filament-form-builder.livewire.filament-form.show', $this->formComponentParameters())
     @endif
 
-    @if(! $isEvaluationCourse)
+    @if($this->shouldShowNextButton())
         <x-filament-lms::next-button :disabled="!$step->is_optional && !$entry" />
     @endif
 </div>

--- a/resources/views/pages/course-completed.blade.php
+++ b/resources/views/pages/course-completed.blade.php
@@ -14,7 +14,7 @@
                     View All Courses
                 </x-filament::button>
             </a>
-            <x-filament::button tag="a" href="{{ $evaluationCourse->linkToCurrentStep() }}">
+            <x-filament::button tag="a" href="{{ $evaluationUrl ?? $evaluationCourse->linkToCurrentStep() }}">
                 Complete Evaluation
             </x-filament::button>
         </div>

--- a/resources/views/pages/course-completed.blade.php
+++ b/resources/views/pages/course-completed.blade.php
@@ -1,5 +1,24 @@
 <x-filament::section class="m-8">
-    @if($qualifiedForCertificate)
+    @if($pendingEvaluation && $evaluationCourse)
+        <x-slot name="heading">
+            One more step for "{{ $course->name }}"
+        </x-slot>
+
+        <p class="text-gray-700 dark:text-gray-300 mb-4">
+            Please complete the course evaluation before receiving your certificate.
+        </p>
+
+        <div class="mt-4 flex gap-3">
+            <a href="{{ \Tapp\FilamentLms\Pages\Dashboard::getUrl() }}">
+                <x-filament::button color="gray">
+                    View All Courses
+                </x-filament::button>
+            </a>
+            <x-filament::button tag="a" href="{{ $evaluationCourse->linkToCurrentStep() }}">
+                Complete Evaluation
+            </x-filament::button>
+        </div>
+    @elseif($qualifiedForCertificate)
         <x-slot name="heading">
             Congratulations! You have completed "{{ $course->name }}"
         </x-slot>
@@ -9,12 +28,17 @@
 
         Download your certificate below.
 
-        <div class="mt-4 flex gap-3">
+        <div class="mt-4 flex flex-wrap gap-3">
             <a href="{{ \Tapp\FilamentLms\Pages\Dashboard::getUrl() }}">
                 <x-filament::button color="gray">
                     View All Courses
                 </x-filament::button>
             </a>
+            @if($course->hasEvaluation() && $course->evaluationCompletedByUser(auth()->id()) && $course->evaluationSubmissionUrl())
+                <x-filament::button tag="a" href="{{ $course->evaluationSubmissionUrl() }}" color="gray">
+                    View Evaluation
+                </x-filament::button>
+            @endif
             <x-filament::button tag="a" href="{{ route('filament-lms::certificates.download', [$course->id]) }}">
                 Download Certificate
             </x-filament::button>

--- a/resources/views/pages/step.blade.php
+++ b/resources/views/pages/step.blade.php
@@ -46,7 +46,7 @@
     @elseif ($step->material_type == 'video')
         <livewire:video-step :step="$step"/>
     @elseif ($step->material_type == 'form')
-        <livewire:form-step :step="$step"/>
+        <livewire:form-step :step="$step" :evaluation-primary-course-id="$evaluationPrimaryCourseId"/>
     @elseif ($step->material_type == 'document')
         <livewire:document-step :step="$step"/>
     @elseif ($step->material_type == 'link')

--- a/resources/views/pages/step.blade.php
+++ b/resources/views/pages/step.blade.php
@@ -44,7 +44,7 @@
             </x-filament::card>
         </div>
     @elseif ($step->material_type == 'video')
-        <livewire:video-step :step="$step"/>
+        <livewire:video-step :step="$step" :evaluation-primary-course-id="$evaluationPrimaryCourseId"/>
     @elseif ($step->material_type == 'form')
         <livewire:form-step :step="$step" :evaluation-primary-course-id="$evaluationPrimaryCourseId"/>
     @elseif ($step->material_type == 'document')
@@ -52,7 +52,7 @@
     @elseif ($step->material_type == 'link')
         <livewire:link-step :step="$step"/>
     @elseif ($step->material_type == 'test')
-        <livewire:test-step :step="$step"/>
+        <livewire:test-step :step="$step" :evaluation-primary-course-id="$evaluationPrimaryCourseId"/>
     @elseif ($step->material_type == 'image')
         <livewire:image-step :step="$step"/>
     @elseif ($step->material_type == 'library_file')

--- a/src/FilamentLmsServiceProvider.php
+++ b/src/FilamentLmsServiceProvider.php
@@ -63,6 +63,7 @@ class FilamentLmsServiceProvider extends PackageServiceProvider
                 'add_embedded_player_to_lms_courses_table',
                 'add_player_slide_id_to_lms_steps_table',
                 'add_evaluation_course_id_to_lms_courses_table',
+                'add_filament_form_user_id_to_lms_step_user_table',
             ])
             ->hasCommand(BackfillCourseCompletedAt::class)
             ->hasCommand(BackfillEmbeddedPlayerCourses::class)

--- a/src/FilamentLmsServiceProvider.php
+++ b/src/FilamentLmsServiceProvider.php
@@ -64,6 +64,7 @@ class FilamentLmsServiceProvider extends PackageServiceProvider
                 'add_player_slide_id_to_lms_steps_table',
                 'add_evaluation_course_id_to_lms_courses_table',
                 'add_filament_form_user_id_to_lms_step_user_table',
+                'add_evaluation_primary_course_id_to_lms_step_user_table',
             ])
             ->hasCommand(BackfillCourseCompletedAt::class)
             ->hasCommand(BackfillEmbeddedPlayerCourses::class)

--- a/src/FilamentLmsServiceProvider.php
+++ b/src/FilamentLmsServiceProvider.php
@@ -62,6 +62,7 @@ class FilamentLmsServiceProvider extends PackageServiceProvider
                 'add_scorm_package_columns_to_lms_documents_table',
                 'add_embedded_player_to_lms_courses_table',
                 'add_player_slide_id_to_lms_steps_table',
+                'add_evaluation_course_id_to_lms_courses_table',
             ])
             ->hasCommand(BackfillCourseCompletedAt::class)
             ->hasCommand(BackfillEmbeddedPlayerCourses::class)

--- a/src/Livewire/FormStep.php
+++ b/src/Livewire/FormStep.php
@@ -2,6 +2,7 @@
 
 namespace Tapp\FilamentLms\Livewire;
 
+use Illuminate\Support\Facades\Auth;
 use Livewire\Component;
 use Tapp\FilamentFormBuilder\Models\FilamentForm;
 use Tapp\FilamentFormBuilder\Models\FilamentFormUser;
@@ -24,12 +25,15 @@ class FormStep extends Component
 
     public ?FilamentFormUser $entry = null;
 
-    public function mount($step): void
+    public ?int $evaluationPrimaryCourseId = null;
+
+    public function mount($step, ?int $evaluationPrimaryCourseId = null): void
     {
         $this->step = $step;
         $this->form = $step->material;
         $this->seconds = $step->seconds ?? 0;
-        $this->entry = $step->formEntryForUser(auth()->id());
+        $this->evaluationPrimaryCourseId = $evaluationPrimaryCourseId;
+        $this->entry = $step->formEntryForUser(Auth::id(), $evaluationPrimaryCourseId);
     }
 
     public function render()
@@ -45,11 +49,16 @@ class FormStep extends Component
 
         $this->entry = $entry;
 
-        $this->step->complete();
+        $this->step->complete(evaluationPrimaryCourseId: $this->evaluationPrimaryCourseId);
 
         StepUser::query()
-            ->where('user_id', auth()->id())
+            ->where('user_id', Auth::id())
             ->where('step_id', $this->step->id)
+            ->when(
+                $this->evaluationPrimaryCourseId !== null,
+                fn ($query) => $query->where('evaluation_primary_course_id', $this->evaluationPrimaryCourseId),
+                fn ($query) => $query->whereNull('evaluation_primary_course_id'),
+            )
             ->update(['filament_form_user_id' => $entry->id]);
 
         if ($this->step->lesson->course->isEvaluationCourse()) {

--- a/src/Livewire/FormStep.php
+++ b/src/Livewire/FormStep.php
@@ -6,6 +6,7 @@ use Livewire\Component;
 use Tapp\FilamentFormBuilder\Models\FilamentForm;
 use Tapp\FilamentFormBuilder\Models\FilamentFormUser;
 use Tapp\FilamentLms\Models\Step;
+use Tapp\FilamentLms\Models\StepUser;
 
 class FormStep extends Component
 {
@@ -23,14 +24,12 @@ class FormStep extends Component
 
     public ?FilamentFormUser $entry = null;
 
-    public function mount($step)
+    public function mount($step): void
     {
         $this->step = $step;
         $this->form = $step->material;
         $this->seconds = $step->seconds ?? 0;
-        $this->entry = FilamentFormUser::where('filament_form_id', $this->form->id)
-            ->where('user_id', auth()->user()->id)
-            ->first();
+        $this->entry = $step->formEntryForUser(auth()->id());
     }
 
     public function render()
@@ -38,11 +37,20 @@ class FormStep extends Component
         return view('filament-lms::livewire.form-step');
     }
 
-    public function entrySaved(FilamentFormUser $entry): void
+    public function entrySaved(int|FilamentFormUser $entry): void
     {
+        if (is_int($entry)) {
+            $entry = FilamentFormUser::query()->findOrFail($entry);
+        }
+
         $this->entry = $entry;
 
         $this->step->complete();
+
+        StepUser::query()
+            ->where('user_id', auth()->id())
+            ->where('step_id', $this->step->id)
+            ->update(['filament_form_user_id' => $entry->id]);
 
         if ($this->step->lesson->course->isEvaluationCourse()) {
             $this->dispatch('complete-step');

--- a/src/Livewire/FormStep.php
+++ b/src/Livewire/FormStep.php
@@ -27,12 +27,15 @@ class FormStep extends Component
 
     public ?int $evaluationPrimaryCourseId = null;
 
+    public bool $isEvaluationCourse = false;
+
     public function mount($step, ?int $evaluationPrimaryCourseId = null): void
     {
         $this->step = $step;
         $this->form = $step->material;
         $this->seconds = $step->seconds ?? 0;
         $this->evaluationPrimaryCourseId = $evaluationPrimaryCourseId;
+        $this->isEvaluationCourse = $step->lesson->course->isEvaluationCourse();
         $this->entry = $step->formEntryForUser(Auth::id(), $evaluationPrimaryCourseId);
 
         $this->resetErrorBag();
@@ -41,6 +44,23 @@ class FormStep extends Component
     public function render()
     {
         return view('filament-lms::livewire.form-step');
+    }
+
+    /**
+     * @return array{form: FilamentForm, blockRedirect: bool, allowMultipleSubmissions: bool}
+     */
+    public function formComponentParameters(): array
+    {
+        return [
+            'form' => $this->form,
+            'blockRedirect' => true,
+            'allowMultipleSubmissions' => $this->isEvaluationCourse,
+        ];
+    }
+
+    public function shouldShowNextButton(): bool
+    {
+        return ! $this->isEvaluationCourse;
     }
 
     public function entrySaved(int|FilamentFormUser $entry): void
@@ -63,7 +83,7 @@ class FormStep extends Component
             )
             ->update(['filament_form_user_id' => $entry->id]);
 
-        if ($this->step->lesson->course->isEvaluationCourse()) {
+        if ($this->isEvaluationCourse) {
             $this->dispatch('complete-step', completeStep: false);
         }
     }

--- a/src/Livewire/FormStep.php
+++ b/src/Livewire/FormStep.php
@@ -38,10 +38,14 @@ class FormStep extends Component
         return view('filament-lms::livewire.form-step');
     }
 
-    public function entrySaved(FilamentFormUser $entry)
+    public function entrySaved(FilamentFormUser $entry): void
     {
         $this->entry = $entry;
 
         $this->step->complete();
+
+        if ($this->step->lesson->course->isEvaluationCourse()) {
+            $this->dispatch('complete-step');
+        }
     }
 }

--- a/src/Livewire/FormStep.php
+++ b/src/Livewire/FormStep.php
@@ -34,6 +34,8 @@ class FormStep extends Component
         $this->seconds = $step->seconds ?? 0;
         $this->evaluationPrimaryCourseId = $evaluationPrimaryCourseId;
         $this->entry = $step->formEntryForUser(Auth::id(), $evaluationPrimaryCourseId);
+
+        $this->resetErrorBag();
     }
 
     public function render()

--- a/src/Livewire/FormStep.php
+++ b/src/Livewire/FormStep.php
@@ -53,7 +53,7 @@ class FormStep extends Component
             ->update(['filament_form_user_id' => $entry->id]);
 
         if ($this->step->lesson->course->isEvaluationCourse()) {
-            $this->dispatch('complete-step');
+            $this->dispatch('complete-step', completeStep: false);
         }
     }
 }

--- a/src/Livewire/TestStep.php
+++ b/src/Livewire/TestStep.php
@@ -24,8 +24,11 @@ class TestStep extends Component
 
     protected $listeners = ['entrySaved'];
 
-    public function mount($step)
+    public ?int $evaluationPrimaryCourseId = null;
+
+    public function mount($step, ?int $evaluationPrimaryCourseId = null)
     {
+        $this->evaluationPrimaryCourseId = $evaluationPrimaryCourseId;
         $this->step = $step;
         $this->step->load(['retryStep.lesson.course', 'lesson.course']);
         $this->test = $step->material;
@@ -65,7 +68,7 @@ class TestStep extends Component
         // Only complete the step if test passed (or if perfect score is not required)
         if ($this->testPassed || ! $this->step->require_perfect_score) {
             $this->testCompleted = true;
-            $this->step->complete();
+            $this->step->complete(evaluationPrimaryCourseId: $this->evaluationPrimaryCourseId);
         } else {
             $this->testCompleted = false;
         }

--- a/src/Livewire/VideoStep.php
+++ b/src/Livewire/VideoStep.php
@@ -17,12 +17,15 @@ class VideoStep extends Component
 
     public bool $videoCompleted;
 
-    public function mount($step)
+    public ?int $evaluationPrimaryCourseId = null;
+
+    public function mount($step, ?int $evaluationPrimaryCourseId = null)
     {
         $this->step = $step;
         $this->video = $step->material;
         $this->seconds = $step->seconds ?? 0;
         $this->videoCompleted = (bool) $step->completed_at;
+        $this->evaluationPrimaryCourseId = $evaluationPrimaryCourseId;
     }
 
     #[On('video-progress')]
@@ -36,7 +39,7 @@ class VideoStep extends Component
     {
         $this->videoCompleted = true;
 
-        $this->step->complete();
+        $this->step->complete(evaluationPrimaryCourseId: $this->evaluationPrimaryCourseId);
     }
 
     public function markExternalOpened(): void

--- a/src/LmsPanelProvider.php
+++ b/src/LmsPanelProvider.php
@@ -31,6 +31,7 @@ use Tapp\FilamentLms\Models\Lesson;
 use Tapp\FilamentLms\Pages\CourseCompleted;
 use Tapp\FilamentLms\Pages\Dashboard;
 use Tapp\FilamentLms\Pages\Step;
+use Tapp\FilamentLms\Services\CourseEvaluationService;
 
 class LmsPanelProvider extends PanelProvider
 {
@@ -159,23 +160,29 @@ class LmsPanelProvider extends PanelProvider
                 return $builder;
             }
 
-            $navigationGroups = $course->lessons->map(function ($lesson) {
+            $evaluationService = app(CourseEvaluationService::class);
+            $evaluationPrimaryCourseId = $evaluationService->evaluationPrimaryCourseIdFromRequest();
+            $stepUrlParameters = $evaluationPrimaryCourseId !== null && $evaluationService->isEvaluationCourse($course)
+                ? ['primaryCourse' => $evaluationPrimaryCourseId]
+                : [];
+
+            $navigationGroups = $course->lessons->map(function ($lesson) use ($stepUrlParameters) {
                 /** @var Lesson $lesson */
                 return NavigationGroup::make($lesson->name)
                     ->collapsed(fn (): bool => ! $lesson->isActive())
                     // ->collapsible(true)
-                    ->items($lesson->steps->map(function ($step) {
+                    ->items($lesson->steps->map(function ($step) use ($stepUrlParameters) {
                         /** @var Models\Step $step */
                         return NavigationItem::make($step->name)
                             ->icon(fn (): string => $step->completed_at ? 'heroicon-o-check-circle' : '')
                             ->isActiveWhen(fn (): bool => $step->isActive())
-                            ->url(function () use ($step): string {
+                            ->url(function () use ($step, $stepUrlParameters): string {
                                 $user = auth()->user();
                                 if (! $user instanceof FilamentLmsUserInterface) {
                                     return '';
                                 }
 
-                                return $user->canAccessStep($step) ? $step->url : '';
+                                return $user->canAccessStep($step) ? Step::getUrlForStep($step, $stepUrlParameters) : '';
                             });
                     })->toArray());
             })->toArray();

--- a/src/Models/Course.php
+++ b/src/Models/Course.php
@@ -49,6 +49,7 @@ use Tapp\FilamentLms\Traits\HasMediaUrl;
  * @property int|null $evaluation_course_id
  * @property Carbon $created_at
  * @property Carbon $updated_at
+ * @property-read Course|null $evaluationCourse
  * @property-read \Illuminate\Database\Eloquent\Collection|Lesson[] $lessons
  * @property-read \Illuminate\Database\Eloquent\Collection|Step[] $steps
  */
@@ -119,6 +120,9 @@ final class Course extends Model implements HasMedia
             });
     }
 
+    /**
+     * @return BelongsTo<Course, $this>
+     */
     public function evaluationCourse(): BelongsTo
     {
         return $this->belongsTo(self::class, 'evaluation_course_id');
@@ -150,6 +154,7 @@ final class Course extends Model implements HasMedia
             return null;
         }
 
+        /** @var Course|null $evaluationCourse */
         $evaluationCourse = $this->evaluationCourse;
 
         if ($evaluationCourse === null) {

--- a/src/Models/Course.php
+++ b/src/Models/Course.php
@@ -25,6 +25,7 @@ use Tapp\FilamentFormBuilder\Models\FilamentFormUser;
 use Tapp\FilamentLms\Contracts\FilamentLmsUserInterface;
 use Tapp\FilamentLms\Database\Factories\CourseFactory;
 use Tapp\FilamentLms\Enums\CompletionMode;
+use Tapp\FilamentLms\Events\CourseCompleted as CourseCompletedEvent;
 use Tapp\FilamentLms\Models\Traits\BelongsToTenant;
 use Tapp\FilamentLms\Pages\CourseCompleted;
 use Tapp\FilamentLms\Pages\Dashboard;
@@ -363,6 +364,12 @@ final class Course extends Model implements HasMedia
             } catch (UniqueConstraintViolationException) {
                 $this->users()->updateExistingPivot($userId, ['completed_at' => $completedAt]);
             }
+        }
+
+        $completedUser = $this->users()->where('user_id', $userId)->first();
+
+        if ($completedUser !== null) {
+            CourseCompletedEvent::dispatch($completedUser, $this);
         }
 
         if ($evaluationService->isEvaluationCourse($this)) {

--- a/src/Models/Course.php
+++ b/src/Models/Course.php
@@ -200,8 +200,10 @@ final class Course extends Model implements HasMedia
         return null;
     }
 
-    public function linkToCurrentStep(): string
+    public function linkToCurrentStep(?int $evaluationPrimaryCourseId = null): string
     {
+        $evaluationPrimaryCourseId = $this->resolveEvaluationPrimaryCourseIdForCurrentUser($evaluationPrimaryCourseId);
+
         if ($this->isEmbeddedPlayer()) {
             $launchStep = $this->launchStep();
 
@@ -219,11 +221,13 @@ final class Course extends Model implements HasMedia
         }
 
         // Get all completed steps for this user
-        $completedStepIds = StepUser::whereIn('step_id', $allSteps->pluck('id'))
-            ->where('user_id', Auth::user()->id)
-            ->whereNotNull('completed_at')
-            ->pluck('step_id')
-            ->toArray();
+        $user = Auth::user();
+
+        if (! $user instanceof Authenticatable) {
+            return Dashboard::getUrl();
+        }
+
+        $completedStepIds = $this->completedStepIdsForUser($allSteps, $user->id, $evaluationPrimaryCourseId);
 
         // Find the first step that hasn't been completed
         $firstIncompleteStep = $allSteps->first(function ($step) use ($completedStepIds) {
@@ -233,25 +237,29 @@ final class Course extends Model implements HasMedia
                 return false;
             }
 
-            return ! in_array($step->id, $completedStepIds) && $user->canAccessStep($step);
+            return ! $completedStepIds->contains($step->id) && $user->canAccessStep($step);
         });
 
         // If no incomplete step is available, check if course is complete
         if (! $firstIncompleteStep) {
             // @phpstan-ignore-next-line
-            if ($allSteps->every->completed_at) {
+            if ($completedStepIds->count() === $allSteps->count()) {
                 return $this->certificateUrl();
             }
             // If course is not complete but no step is available, find the first incomplete step
             $firstIncompleteStep = $allSteps->first(function ($step) use ($completedStepIds) {
-                return ! in_array($step->id, $completedStepIds);
+                return ! $completedStepIds->contains($step->id);
             });
         }
 
-        return $firstIncompleteStep ? StepPage::getUrl([$firstIncompleteStep->lesson->course->slug, $firstIncompleteStep->lesson->slug, $firstIncompleteStep->slug]) : Dashboard::getUrl();
+        return $firstIncompleteStep
+            ? StepPage::getUrlForStep($firstIncompleteStep, $evaluationPrimaryCourseId !== null
+                ? ['primaryCourse' => $evaluationPrimaryCourseId]
+                : [])
+            : Dashboard::getUrl();
     }
 
-    public function currentStep(?Authenticatable $user = null): ?Step
+    public function currentStep(?Authenticatable $user = null, ?int $evaluationPrimaryCourseId = null): ?Step
     {
         $user = $user ?: Auth::user();
         if (! $user) {
@@ -260,15 +268,11 @@ final class Course extends Model implements HasMedia
         $allSteps = $this->steps;
 
         // Get all completed steps for this user
-        $completedStepIds = StepUser::whereIn('step_id', $allSteps->pluck('id'))
-            ->where('user_id', $user->id)
-            ->whereNotNull('completed_at')
-            ->pluck('step_id')
-            ->toArray();
+        $completedStepIds = $this->completedStepIdsForUser($allSteps, $user->id, $evaluationPrimaryCourseId);
 
         // Find the first step that hasn't been completed
         $firstIncompleteStep = $allSteps->first(function ($step) use ($completedStepIds) {
-            return ! in_array($step->id, $completedStepIds);
+            return ! $completedStepIds->contains($step->id);
         });
 
         return $firstIncompleteStep ?: $allSteps->first();
@@ -338,7 +342,13 @@ final class Course extends Model implements HasMedia
             return;
         }
 
-        if (! $evaluationService->courseMeetsCompletionRequirements($this, $userId)) {
+        if ($evaluationService->isEvaluationCourse($this)) {
+            $evaluationService->finalizePrimaryCoursesAfterEvaluation($this, $userId);
+
+            if ($evaluationService->completedPrimaryCourseForEvaluation($this, $userId) === null) {
+                return;
+            }
+        } elseif (! $evaluationService->courseMeetsCompletionRequirements($this, $userId)) {
             return;
         }
 
@@ -411,7 +421,7 @@ final class Course extends Model implements HasMedia
         return $this->getCompletionPercentageForUser(Auth::id());
     }
 
-    public function getCompletionPercentageForUser($userId): float
+    public function getCompletionPercentageForUser($userId, ?int $evaluationPrimaryCourseId = null): float
     {
         // Use eager-loaded steps when available to avoid N+1 queries on dashboard
         $steps = $this->relationLoaded('steps') ? $this->steps : $this->steps()->get();
@@ -425,6 +435,7 @@ final class Course extends Model implements HasMedia
         if (
             Auth::check()
             && (string) $userId === (string) Auth::id()
+            && $evaluationPrimaryCourseId === null
             && $steps->first()->relationLoaded('progress')
         ) {
             $completedCount = $steps->filter(fn (Step $step) => $step->progress?->completed_at !== null)->count();
@@ -433,10 +444,7 @@ final class Course extends Model implements HasMedia
         }
 
         // Fallback: query for completed steps
-        $completedStepUsers = StepUser::whereIn('step_id', $steps->pluck('id'))
-            ->where('user_id', $userId)
-            ->whereNotNull('completed_at')
-            ->get();
+        $completedStepUsers = $this->completedStepIdsForUser($steps, $userId, $evaluationPrimaryCourseId);
 
         return $completedStepUsers->count() / $steps->count() * 100;
     }
@@ -499,7 +507,7 @@ final class Course extends Model implements HasMedia
      * Check if all steps are completed by the user (regardless of test percentage requirement).
      * This is useful for determining if a user has finished all steps but may not have met the test percentage requirement.
      */
-    public function allStepsCompletedByUser(int|string $userId): bool
+    public function allStepsCompletedByUser(int|string $userId, ?int $evaluationPrimaryCourseId = null): bool
     {
         $steps = $this->steps()->get();
 
@@ -507,11 +515,7 @@ final class Course extends Model implements HasMedia
             return false;
         }
 
-        $completedStepIds = StepUser::whereIn('step_id', $steps->pluck('id'))
-            ->where('user_id', $userId)
-            ->whereNotNull('completed_at')
-            ->pluck('step_id')
-            ->unique();
+        $completedStepIds = $this->completedStepIdsForUser($steps, $userId, $evaluationPrimaryCourseId);
 
         return $completedStepIds->count() === $steps->count();
     }
@@ -643,5 +647,46 @@ final class Course extends Model implements HasMedia
         }
 
         return (float) $grade;
+    }
+
+    /**
+     * @param  Collection<int, Step>  $steps
+     * @return Collection<int, int>
+     */
+    private function completedStepIdsForUser(Collection $steps, int|string $userId, ?int $evaluationPrimaryCourseId = null): Collection
+    {
+        return StepUser::whereIn('step_id', $steps->pluck('id'))
+            ->where('user_id', $userId)
+            ->when(
+                $evaluationPrimaryCourseId !== null,
+                fn ($query) => $query->where('evaluation_primary_course_id', $evaluationPrimaryCourseId),
+                fn ($query) => $query->whereNull('evaluation_primary_course_id'),
+            )
+            ->whereNotNull('completed_at')
+            ->pluck('step_id')
+            ->unique()
+            ->values();
+    }
+
+    private function resolveEvaluationPrimaryCourseIdForCurrentUser(?int $evaluationPrimaryCourseId): ?int
+    {
+        if ($evaluationPrimaryCourseId !== null || ! $this->isEvaluationCourse() || ! Auth::check()) {
+            return $evaluationPrimaryCourseId;
+        }
+
+        $user = Auth::user();
+
+        if (! $user instanceof Authenticatable || (method_exists($user, 'isLmsAdmin') && $user->isLmsAdmin())) {
+            return null;
+        }
+
+        $evaluationService = app(CourseEvaluationService::class);
+        $primaryCourse = $evaluationService->activePrimaryCourseForEvaluation($this, $user);
+
+        if ($primaryCourse === null || $evaluationService->evaluationCompletedByUser($primaryCourse, $user->id)) {
+            return null;
+        }
+
+        return $primaryCourse->id;
     }
 }

--- a/src/Models/Course.php
+++ b/src/Models/Course.php
@@ -418,7 +418,12 @@ final class Course extends Model implements HasMedia
             return 0;
         }
 
-        return $this->getCompletionPercentageForUser(Auth::id());
+        $evaluationPrimaryCourseId = app(CourseEvaluationService::class)->evaluationPrimaryCourseIdFromRequest();
+
+        return $this->getCompletionPercentageForUser(
+            Auth::id(),
+            $this->resolveEvaluationPrimaryCourseIdForCurrentUser($evaluationPrimaryCourseId),
+        );
     }
 
     public function getCompletionPercentageForUser($userId, ?int $evaluationPrimaryCourseId = null): float
@@ -670,7 +675,11 @@ final class Course extends Model implements HasMedia
 
     private function resolveEvaluationPrimaryCourseIdForCurrentUser(?int $evaluationPrimaryCourseId): ?int
     {
-        if ($evaluationPrimaryCourseId !== null || ! $this->isEvaluationCourse() || ! Auth::check()) {
+        if (! $this->isEvaluationCourse() || ! Auth::check()) {
+            return null;
+        }
+
+        if ($evaluationPrimaryCourseId !== null) {
             return $evaluationPrimaryCourseId;
         }
 

--- a/src/Models/Course.php
+++ b/src/Models/Course.php
@@ -150,20 +150,7 @@ final class Course extends Model implements HasMedia
 
     public function evaluationSubmissionUrl(): ?string
     {
-        if (! $this->hasEvaluation()) {
-            return null;
-        }
-
-        /** @var Course|null $evaluationCourse */
-        $evaluationCourse = $this->evaluationCourse;
-
-        if ($evaluationCourse === null) {
-            return null;
-        }
-
-        $step = $evaluationCourse->steps()->first();
-
-        return $step !== null ? StepPage::getUrlForStep($step) : null;
+        return app(CourseEvaluationService::class)->evaluationUrlForPrimaryCourse($this);
     }
 
     public function lessons(): HasMany
@@ -341,11 +328,15 @@ final class Course extends Model implements HasMedia
         $enrolledUser = $this->users()->where('user_id', $userId)->first();
         $pivot = $enrolledUser?->getRelationValue('pivot');
         $existing = $pivot instanceof Pivot ? $pivot->getAttribute('completed_at') : null;
+        $evaluationService = app(CourseEvaluationService::class);
+
         if ($existing !== null) {
+            if ($evaluationService->isEvaluationCourse($this)) {
+                $evaluationService->finalizePrimaryCoursesAfterEvaluation($this, $userId);
+            }
+
             return;
         }
-
-        $evaluationService = app(CourseEvaluationService::class);
 
         if (! $evaluationService->courseMeetsCompletionRequirements($this, $userId)) {
             return;
@@ -516,12 +507,13 @@ final class Course extends Model implements HasMedia
             return false;
         }
 
-        $completedStepUsers = StepUser::whereIn('step_id', $steps->pluck('id'))
+        $completedStepIds = StepUser::whereIn('step_id', $steps->pluck('id'))
             ->where('user_id', $userId)
             ->whereNotNull('completed_at')
-            ->get();
+            ->pluck('step_id')
+            ->unique();
 
-        return $completedStepUsers->count() === $steps->count();
+        return $completedStepIds->count() === $steps->count();
     }
 
     /**

--- a/src/Models/Course.php
+++ b/src/Models/Course.php
@@ -339,21 +339,11 @@ final class Course extends Model implements HasMedia
             return;
         }
 
-        if (! $this->allStepsCompletedByUser($userId)) {
+        $evaluationService = app(CourseEvaluationService::class);
+
+        if (! $evaluationService->courseMeetsCompletionRequirements($this, $userId)) {
             return;
         }
-
-        if ($this->required_test_percentage !== null) {
-            $testSteps = $this->getOrderedTestSteps();
-            if ($testSteps->isNotEmpty()) {
-                $overall = $this->getOverallTestPercentageForUser($userId);
-                if ($overall < (float) $this->required_test_percentage) {
-                    return;
-                }
-            }
-        }
-
-        $evaluationService = app(CourseEvaluationService::class);
 
         if ($evaluationService->hasEvaluation($this)) {
             $this->ensureEvaluationAssigned($userId);

--- a/src/Models/Course.php
+++ b/src/Models/Course.php
@@ -10,6 +10,7 @@ use Exception;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\Relations\HasManyThrough;
@@ -28,6 +29,7 @@ use Tapp\FilamentLms\Models\Traits\BelongsToTenant;
 use Tapp\FilamentLms\Pages\CourseCompleted;
 use Tapp\FilamentLms\Pages\Dashboard;
 use Tapp\FilamentLms\Pages\Step as StepPage;
+use Tapp\FilamentLms\Services\CourseEvaluationService;
 use Tapp\FilamentLms\Traits\HasMediaUrl;
 
 /**
@@ -43,6 +45,7 @@ use Tapp\FilamentLms\Traits\HasMediaUrl;
  * @property bool $is_private
  * @property bool $embedded_player
  * @property CompletionMode|string $completion_mode
+ * @property int|null $evaluation_course_id
  * @property Carbon $created_at
  * @property Carbon $updated_at
  * @property-read \Illuminate\Database\Eloquent\Collection|Lesson[] $lessons
@@ -105,7 +108,56 @@ final class Course extends Model implements HasMedia
                 });
         })
         // Only include courses that have at least one step
-            ->whereHas('steps');
+            ->whereHas('steps')
+            ->when(config('filament-lms.evaluations.enabled', false), function (Builder $query): void {
+                $evaluationCourseIds = app(CourseEvaluationService::class)->lockedEvaluationCourseIds();
+
+                if ($evaluationCourseIds->isNotEmpty()) {
+                    $query->whereNotIn('lms_courses.id', $evaluationCourseIds);
+                }
+            });
+    }
+
+    public function evaluationCourse(): BelongsTo
+    {
+        return $this->belongsTo(self::class, 'evaluation_course_id');
+    }
+
+    public function hasEvaluation(): bool
+    {
+        return app(CourseEvaluationService::class)->hasEvaluation($this);
+    }
+
+    public function isEvaluationCourse(): bool
+    {
+        return app(CourseEvaluationService::class)->isEvaluationCourse($this);
+    }
+
+    public function evaluationCompletedByUser(int|string $userId): bool
+    {
+        return app(CourseEvaluationService::class)->evaluationCompletedByUser($this, $userId);
+    }
+
+    public function ensureEvaluationAssigned(int|string $userId): void
+    {
+        app(CourseEvaluationService::class)->ensureEvaluationAssigned($this, $userId);
+    }
+
+    public function evaluationSubmissionUrl(): ?string
+    {
+        if (! $this->hasEvaluation()) {
+            return null;
+        }
+
+        $evaluationCourse = $this->evaluationCourse;
+
+        if ($evaluationCourse === null) {
+            return null;
+        }
+
+        $step = $evaluationCourse->steps()->first();
+
+        return $step !== null ? StepPage::getUrlForStep($step) : null;
     }
 
     public function lessons(): HasMany
@@ -301,18 +353,30 @@ final class Course extends Model implements HasMedia
             }
         }
 
+        $evaluationService = app(CourseEvaluationService::class);
+
+        if ($evaluationService->hasEvaluation($this)) {
+            $this->ensureEvaluationAssigned($userId);
+
+            if (! $this->evaluationCompletedByUser($userId)) {
+                return;
+            }
+        }
+
         $completedAt = now();
 
         if ($this->users()->where('user_id', $userId)->exists()) {
             $this->users()->updateExistingPivot($userId, ['completed_at' => $completedAt]);
-
-            return;
+        } else {
+            try {
+                $this->users()->attach($userId, ['completed_at' => $completedAt]);
+            } catch (UniqueConstraintViolationException) {
+                $this->users()->updateExistingPivot($userId, ['completed_at' => $completedAt]);
+            }
         }
 
-        try {
-            $this->users()->attach($userId, ['completed_at' => $completedAt]);
-        } catch (UniqueConstraintViolationException) {
-            $this->users()->updateExistingPivot($userId, ['completed_at' => $completedAt]);
+        if ($evaluationService->isEvaluationCourse($this)) {
+            $evaluationService->finalizePrimaryCoursesAfterEvaluation($this, $userId);
         }
     }
 
@@ -465,6 +529,15 @@ final class Course extends Model implements HasMedia
     {
         if (! $user) {
             return false;
+        }
+
+        if ($this->isEvaluationCourse()) {
+            if ($user->isLmsAdmin()) {
+                return true;
+            }
+
+            return app(CourseEvaluationService::class)->isEvaluationUnlockedForUser($this, $user)
+                && ($this->users()->where('user_id', $user->id)->exists() || ! $this->is_private);
         }
 
         // Public courses (not private) - accessible to everyone

--- a/src/Models/Step.php
+++ b/src/Models/Step.php
@@ -15,6 +15,8 @@ use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Str;
 use Spatie\EloquentSortable\Sortable;
 use Spatie\EloquentSortable\SortableTrait;
+use Tapp\FilamentFormBuilder\Models\FilamentForm;
+use Tapp\FilamentFormBuilder\Models\FilamentFormUser;
 use Tapp\FilamentLms\Contracts\FilamentLmsUserInterface;
 use Tapp\FilamentLms\Database\Factories\StepFactory;
 use Tapp\FilamentLms\Events\CourseCompleted;
@@ -403,5 +405,43 @@ class Step extends Model implements Sortable
     public function getSecondsAttribute()
     {
         return $this->progress?->seconds ?? 0;
+    }
+
+    public function formEntryForUser(int|string $userId): ?FilamentFormUser
+    {
+        if ($this->material_type !== 'form') {
+            return null;
+        }
+
+        $this->loadMissing('material');
+
+        if (! $this->material instanceof FilamentForm) {
+            return null;
+        }
+
+        $stepUser = StepUser::query()
+            ->where('user_id', $userId)
+            ->where('step_id', $this->id)
+            ->whereNotNull('completed_at')
+            ->first();
+
+        if ($stepUser === null) {
+            return null;
+        }
+
+        if ($stepUser->filament_form_user_id !== null) {
+            return FilamentFormUser::query()
+                ->whereKey($stepUser->filament_form_user_id)
+                ->where('user_id', $userId)
+                ->where('filament_form_id', $this->material->id)
+                ->first();
+        }
+
+        return FilamentFormUser::query()
+            ->where('filament_form_id', $this->material->id)
+            ->where('user_id', $userId)
+            ->where('created_at', '<=', $stepUser->completed_at)
+            ->orderByDesc('created_at')
+            ->first();
     }
 }

--- a/src/Models/Step.php
+++ b/src/Models/Step.php
@@ -208,14 +208,20 @@ class Step extends Model implements Sortable
         }
     }
 
-    public function complete($user = null)
+    public function complete($user = null, ?int $evaluationPrimaryCourseId = null)
     {
         // @phpstan-ignore-next-line
         $user = $user ?: Auth::user();
 
-        $userStep = StepUser::where('user_id', $user->id)
+        $userStepQuery = StepUser::where('user_id', $user->id)
             ->where('step_id', $this->id)
-            ->first();
+            ->when(
+                $evaluationPrimaryCourseId !== null,
+                fn ($query) => $query->where('evaluation_primary_course_id', $evaluationPrimaryCourseId),
+                fn ($query) => $query->whereNull('evaluation_primary_course_id'),
+            );
+
+        $userStep = $userStepQuery->first();
 
         $nextStep = $this->next_step;
 
@@ -224,6 +230,7 @@ class Step extends Model implements Sortable
             StepUser::create([
                 'user_id' => $user->id,
                 'step_id' => $this->id,
+                'evaluation_primary_course_id' => $evaluationPrimaryCourseId,
                 'completed_at' => now(),
             ]);
 
@@ -247,6 +254,7 @@ class Step extends Model implements Sortable
             StepUser::firstOrCreate([
                 'user_id' => $user->id,
                 'step_id' => $nextStep->id,
+                'evaluation_primary_course_id' => $evaluationPrimaryCourseId,
             ]);
 
             $this->lesson->course->maybeSetCompletedAtForUser($user->id);
@@ -405,7 +413,7 @@ class Step extends Model implements Sortable
         return $this->progress?->seconds ?? 0;
     }
 
-    public function formEntryForUser(int|string $userId): ?FilamentFormUser
+    public function formEntryForUser(int|string $userId, ?int $evaluationPrimaryCourseId = null): ?FilamentFormUser
     {
         if ($this->material_type !== 'form') {
             return null;
@@ -420,6 +428,11 @@ class Step extends Model implements Sortable
         $stepUser = StepUser::query()
             ->where('user_id', $userId)
             ->where('step_id', $this->id)
+            ->when(
+                $evaluationPrimaryCourseId !== null,
+                fn ($query) => $query->where('evaluation_primary_course_id', $evaluationPrimaryCourseId),
+                fn ($query) => $query->whereNull('evaluation_primary_course_id'),
+            )
             ->whereNotNull('completed_at')
             ->first();
 

--- a/src/Models/Step.php
+++ b/src/Models/Step.php
@@ -19,7 +19,6 @@ use Tapp\FilamentFormBuilder\Models\FilamentForm;
 use Tapp\FilamentFormBuilder\Models\FilamentFormUser;
 use Tapp\FilamentLms\Contracts\FilamentLmsUserInterface;
 use Tapp\FilamentLms\Database\Factories\StepFactory;
-use Tapp\FilamentLms\Events\CourseCompleted;
 use Tapp\FilamentLms\Events\CourseStarted;
 use Tapp\FilamentLms\Events\StepCompleted;
 use Tapp\FilamentLms\Models\Traits\BelongsToTenant;
@@ -254,7 +253,6 @@ class Step extends Model implements Sortable
 
             return $nextStep;
         } else {
-            CourseCompleted::dispatch($user, $this->lesson->course);
             $this->lesson->course->maybeSetCompletedAtForUser($user->id);
         }
     }

--- a/src/Models/Step.php
+++ b/src/Models/Step.php
@@ -23,6 +23,7 @@ use Tapp\FilamentLms\Events\CourseStarted;
 use Tapp\FilamentLms\Events\StepCompleted;
 use Tapp\FilamentLms\Models\Traits\BelongsToTenant;
 use Tapp\FilamentLms\Pages\Step as StepPage;
+use Tapp\FilamentLms\Services\CourseEvaluationService;
 
 /**
  * @property int $id
@@ -354,12 +355,18 @@ class Step extends Model implements Sortable
     {
         // @phpstan-ignore-next-line
         $currentUserId = Auth::check() ? Auth::user()->id : null;
+        $evaluationPrimaryCourseId = app(CourseEvaluationService::class)->evaluationPrimaryCourseIdFromRequest();
 
         return $this->hasOne(StepUser::class)->ofMany([
             // TODO is this started_at => max needed?
             'created_at' => 'max',
-        ], function ($query) use ($currentUserId) {
-            $query->where('user_id', '=', $currentUserId);
+        ], function ($query) use ($currentUserId, $evaluationPrimaryCourseId) {
+            $query->where('user_id', '=', $currentUserId)
+                ->when(
+                    $evaluationPrimaryCourseId !== null,
+                    fn ($query) => $query->where('evaluation_primary_course_id', $evaluationPrimaryCourseId),
+                    fn ($query) => $query->whereNull('evaluation_primary_course_id'),
+                );
         });
     }
 

--- a/src/Models/StepUser.php
+++ b/src/Models/StepUser.php
@@ -10,6 +10,7 @@ use Illuminate\Support\Carbon;
 use Tapp\FilamentLms\Models\Traits\BelongsToTenant;
 
 /**
+ * @property int|null $evaluation_primary_course_id
  * @property int|null $filament_form_user_id
  * @property string|null $completed_at
  * @property Carbon|null $created_at

--- a/src/Models/StepUser.php
+++ b/src/Models/StepUser.php
@@ -10,6 +10,7 @@ use Illuminate\Support\Carbon;
 use Tapp\FilamentLms\Models\Traits\BelongsToTenant;
 
 /**
+ * @property int|null $filament_form_user_id
  * @property string|null $completed_at
  * @property Carbon|null $created_at
  * @property int|null $seconds

--- a/src/Pages/CourseCompleted.php
+++ b/src/Pages/CourseCompleted.php
@@ -81,8 +81,11 @@ final class CourseCompleted extends Page
         }
 
         if ($evaluationService->hasPendingEvaluationForUser($this->course, $userId)) {
+            /** @var Course|null $evaluationCourse */
+            $evaluationCourse = $this->course->evaluationCourse;
+
             $this->pendingEvaluation = true;
-            $this->evaluationCourse = $this->course->evaluationCourse;
+            $this->evaluationCourse = $evaluationCourse;
             $this->course->ensureEvaluationAssigned($userId);
             $this->qualifiedForCertificate = false;
 

--- a/src/Pages/CourseCompleted.php
+++ b/src/Pages/CourseCompleted.php
@@ -26,6 +26,8 @@ final class CourseCompleted extends Page
 
     public ?Course $evaluationCourse = null;
 
+    public ?string $evaluationUrl = null;
+
     public ?float $overallPercent = null;
 
     public ?int $requiredPercent = null;
@@ -86,6 +88,7 @@ final class CourseCompleted extends Page
 
             $this->pendingEvaluation = true;
             $this->evaluationCourse = $evaluationCourse;
+            $this->evaluationUrl = $this->course->evaluationSubmissionUrl();
             $this->course->ensureEvaluationAssigned($userId);
             $this->qualifiedForCertificate = false;
 

--- a/src/Pages/CourseCompleted.php
+++ b/src/Pages/CourseCompleted.php
@@ -20,6 +20,10 @@ final class CourseCompleted extends Page
 
     public bool $qualifiedForCertificate = true;
 
+    public bool $pendingEvaluation = false;
+
+    public ?Course $evaluationCourse = null;
+
     public ?float $overallPercent = null;
 
     public ?int $requiredPercent = null;
@@ -54,6 +58,17 @@ final class CourseCompleted extends Page
             }
 
             return redirect()->to($currentStepUrl);
+        }
+
+        if ($this->course->hasEvaluation() && ! $this->course->evaluationCompletedByUser(auth()->id())) {
+            $this->pendingEvaluation = true;
+            $this->evaluationCourse = $this->course->evaluationCourse;
+            $this->course->ensureEvaluationAssigned(auth()->id());
+            $this->qualifiedForCertificate = false;
+
+            $this->registerCourseLayout();
+
+            return;
         }
 
         if ($this->course->required_test_percentage !== null) {

--- a/src/Pages/CourseCompleted.php
+++ b/src/Pages/CourseCompleted.php
@@ -80,7 +80,7 @@ final class CourseCompleted extends Page
             return redirect()->to(Dashboard::getUrl());
         }
 
-        if ($this->course->hasEvaluation() && ! $this->course->evaluationCompletedByUser($userId)) {
+        if ($evaluationService->hasPendingEvaluationForUser($this->course, $userId)) {
             $this->pendingEvaluation = true;
             $this->evaluationCourse = $this->course->evaluationCourse;
             $this->course->ensureEvaluationAssigned($userId);

--- a/src/Pages/CourseCompleted.php
+++ b/src/Pages/CourseCompleted.php
@@ -7,6 +7,7 @@ namespace Tapp\FilamentLms\Pages;
 use BackedEnum;
 use Exception;
 use Filament\Pages\Page;
+use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Support\Facades\Auth;
 use Tapp\FilamentFormBuilder\Models\FilamentFormUser;
 use Tapp\FilamentLms\Concerns\CourseLayout;
@@ -48,13 +49,26 @@ final class CourseCompleted extends Page
     {
         $this->course = Course::where('slug', $courseSlug)->firstOrFail();
         $evaluationService = app(CourseEvaluationService::class);
-        $userId = Auth::id();
+        $user = Auth::user();
 
-        if ($userId === null) {
+        if (! $user instanceof Authenticatable) {
             return redirect()->to(Dashboard::getUrl());
         }
 
+        $userId = $user->id;
+
         if ($evaluationService->isEvaluationCourse($this->course)) {
+            $activePrimaryCourse = $evaluationService->activePrimaryCourseForEvaluation($this->course, $user);
+
+            if (
+                $activePrimaryCourse !== null
+                && ! $evaluationService->evaluationCompletedByUser($activePrimaryCourse, $userId)
+            ) {
+                return redirect()->to(
+                    $evaluationService->evaluationUrlForPrimaryCourse($activePrimaryCourse) ?? Dashboard::getUrl(),
+                );
+            }
+
             $primaryCourse = $evaluationService->completedPrimaryCourseForEvaluation($this->course, $userId);
 
             if ($primaryCourse !== null) {

--- a/src/Pages/CourseCompleted.php
+++ b/src/Pages/CourseCompleted.php
@@ -7,10 +7,12 @@ namespace Tapp\FilamentLms\Pages;
 use BackedEnum;
 use Exception;
 use Filament\Pages\Page;
+use Illuminate\Support\Facades\Auth;
 use Tapp\FilamentFormBuilder\Models\FilamentFormUser;
 use Tapp\FilamentLms\Concerns\CourseLayout;
 use Tapp\FilamentLms\Models\Course;
 use Tapp\FilamentLms\Models\Test;
+use Tapp\FilamentLms\Services\CourseEvaluationService;
 
 final class CourseCompleted extends Page
 {
@@ -43,6 +45,20 @@ final class CourseCompleted extends Page
     public function mount($courseSlug)
     {
         $this->course = Course::where('slug', $courseSlug)->firstOrFail();
+        $evaluationService = app(CourseEvaluationService::class);
+        $userId = Auth::id();
+
+        if ($userId === null) {
+            return redirect()->to(Dashboard::getUrl());
+        }
+
+        if ($evaluationService->isEvaluationCourse($this->course)) {
+            $primaryCourse = $evaluationService->completedPrimaryCourseForEvaluation($this->course, $userId);
+
+            if ($primaryCourse !== null) {
+                return redirect()->to(self::getUrl([$primaryCourse->slug]));
+            }
+        }
 
         // If course has no steps, redirect to dashboard
         if (! $this->course->steps()->exists()) {
@@ -51,7 +67,7 @@ final class CourseCompleted extends Page
 
         // Only redirect when the user has not completed all steps. Allow viewing this page when all steps
         // are done even if required_test_percentage is not met (we show retake/certificate state below).
-        if (! $this->course->allStepsCompletedByUser(auth()->id())) {
+        if (! $this->course->allStepsCompletedByUser($userId)) {
             $currentStepUrl = $this->course->linkToCurrentStep();
             if (empty($currentStepUrl)) {
                 return redirect()->to(Dashboard::getUrl());
@@ -60,10 +76,14 @@ final class CourseCompleted extends Page
             return redirect()->to($currentStepUrl);
         }
 
-        if ($this->course->hasEvaluation() && ! $this->course->evaluationCompletedByUser(auth()->id())) {
+        if ($evaluationService->isEvaluationCourse($this->course)) {
+            return redirect()->to(Dashboard::getUrl());
+        }
+
+        if ($this->course->hasEvaluation() && ! $this->course->evaluationCompletedByUser($userId)) {
             $this->pendingEvaluation = true;
             $this->evaluationCourse = $this->course->evaluationCourse;
-            $this->course->ensureEvaluationAssigned(auth()->id());
+            $this->course->ensureEvaluationAssigned($userId);
             $this->qualifiedForCertificate = false;
 
             $this->registerCourseLayout();
@@ -75,7 +95,7 @@ final class CourseCompleted extends Page
             $testSteps = $this->course->getOrderedTestSteps();
             // Only check test percentage if there are test steps
             if ($testSteps->isNotEmpty()) {
-                $overall = $this->course->getOverallTestPercentageForUser(auth()->id());
+                $overall = $this->course->getOverallTestPercentageForUser($userId);
                 if ($overall < (float) $this->course->required_test_percentage) {
                     $this->qualifiedForCertificate = false;
                     $this->overallPercent = $overall;
@@ -88,11 +108,11 @@ final class CourseCompleted extends Page
         $this->testStepDetails = $this->getTestStepDetails();
 
         // Backfill completed_at if user qualifies but it was never set (e.g. course had required_test_percentage but no test steps).
-        $this->course->maybeSetCompletedAtForUser(auth()->id());
+        $this->course->maybeSetCompletedAtForUser($userId);
 
         // Only show certificate UI when the user has actually completed the course (completed_at set).
         // Prevents 403 on download when e.g. required_test_percentage is set but course has no test steps.
-        if ($this->course->completedByUserAt(auth()->id()) === null) {
+        if ($this->course->completedByUserAt($userId) === null) {
             $this->qualifiedForCertificate = false;
         }
 

--- a/src/Pages/Step.php
+++ b/src/Pages/Step.php
@@ -172,12 +172,13 @@ class Step extends Page
             && $user instanceof FilamentLmsUserInterface
         ) {
             $primaryCourse = app(CourseEvaluationService::class)
-                ->primaryCoursesFor($this->course)
-                ->first(fn (Course $primary): bool => $primary->allStepsCompletedByUser($user->id));
+                ->completedPrimaryCourseForEvaluation($this->course, $user->id);
 
             if ($primaryCourse !== null) {
                 return redirect()->to(CourseCompleted::getUrl([$primaryCourse->slug]));
             }
+
+            return redirect()->to(Dashboard::getUrl());
         }
 
         return redirect()->to(CourseCompleted::getUrl([$this->course->slug]));

--- a/src/Pages/Step.php
+++ b/src/Pages/Step.php
@@ -6,6 +6,7 @@ use Filament\Actions\Action;
 use Filament\Notifications\Notification;
 use Filament\Pages\Page;
 use Filament\Support\Enums\Width;
+use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Log;
 use Livewire\Attributes\On;
@@ -320,7 +321,7 @@ class Step extends Page
         }
     }
 
-    protected function embeddedCourseExitUrl(FilamentLmsUserInterface $user): string
+    protected function embeddedCourseExitUrl(Authenticatable&FilamentLmsUserInterface $user): string
     {
         $evaluationService = app(CourseEvaluationService::class);
 

--- a/src/Pages/Step.php
+++ b/src/Pages/Step.php
@@ -34,6 +34,8 @@ class Step extends Page
 
     public StepModel $step;
 
+    public ?int $evaluationPrimaryCourseId = null;
+
     public function mount($courseSlug, $lessonSlug, $stepSlug)
     {
         $this->course = Course::where('slug', $courseSlug)->firstOrFail();
@@ -62,8 +64,36 @@ class Step extends Page
             return redirect()->to($this->course->linkToCurrentStep());
         }
 
+        $evaluationService = app(CourseEvaluationService::class);
+        $isLmsAdmin = method_exists($user, 'isLmsAdmin') && $user->isLmsAdmin();
+
+        if ($evaluationService->isEvaluationCourse($this->course) && ! $isLmsAdmin) {
+            $primaryCourseId = request()->query('primaryCourse');
+            $primaryCourse = $evaluationService->activePrimaryCourseForEvaluation(
+                $this->course,
+                $user,
+                is_numeric($primaryCourseId) ? (int) $primaryCourseId : null,
+            );
+
+            if ($primaryCourse === null) {
+                return redirect()->to(Dashboard::getUrl());
+            }
+
+            $this->evaluationPrimaryCourseId = $primaryCourse->id;
+
+            if (! $evaluationService->evaluationStepAvailableForPrimary($this->step, $user->id, $primaryCourse->id)) {
+                $currentStepUrl = $evaluationService->evaluationUrlForPrimaryCourse($primaryCourse);
+
+                return redirect()->to($currentStepUrl ?? Dashboard::getUrl());
+            }
+        }
+
         $canAccess = $user->canAccessStep($this->step);
-        $currentStepUrl = $this->course->linkToCurrentStep();
+        $currentStepUrl = $this->evaluationPrimaryCourseId !== null
+            ? app(CourseEvaluationService::class)->evaluationUrlForPrimaryCourse(
+                Course::query()->findOrFail($this->evaluationPrimaryCourseId),
+            )
+            : $this->course->linkToCurrentStep();
         $requestedStepUrl = static::getUrlForStep($this->step);
 
         Log::info('Step page access check', [
@@ -131,7 +161,7 @@ class Step extends Page
         if (Auth::check()) {
             $user = Auth::user();
             // @phpstan-ignore-next-line
-            if ($user && $user->canEditStep($this->step)) {
+            if ($user && method_exists($user, 'canEditStep') && $user->canEditStep($this->step)) {
                 $actions[] = Action::make('edit')
                     ->label('Edit')
                     ->color('primary')
@@ -147,7 +177,9 @@ class Step extends Page
     public function complete(bool $completeStep = true)
     {
         // Form steps may already complete the model before dispatching this event.
-        $nextStep = $completeStep ? $this->step->complete() : $this->step->next_step;
+        $nextStep = $completeStep
+            ? $this->step->complete(evaluationPrimaryCourseId: $this->evaluationPrimaryCourseId)
+            : $this->step->next_step;
 
         $user = Auth::user();
         if (
@@ -156,14 +188,16 @@ class Step extends Page
             && app(CourseEvaluationService::class)->hasPendingEvaluationForUser($this->course, $user->id)
         ) {
             $this->course->ensureEvaluationAssigned($user->id);
-            /** @var Course|null $evaluationCourse */
-            $evaluationCourse = $this->course->evaluationCourse;
 
-            return redirect()->to($evaluationCourse?->linkToCurrentStep() ?? Dashboard::getUrl());
+            return redirect()->to(
+                app(CourseEvaluationService::class)->evaluationUrlForPrimaryCourse($this->course) ?? Dashboard::getUrl(),
+            );
         }
 
         if (! $this->step->last_step && $nextStep) {
-            return redirect()->to(Step::getUrlForStep($nextStep));
+            return redirect()->to(Step::getUrlForStep($nextStep, $this->evaluationPrimaryCourseId !== null
+                ? ['primaryCourse' => $this->evaluationPrimaryCourseId]
+                : []));
         }
 
         if (
@@ -172,7 +206,7 @@ class Step extends Page
             && $user instanceof FilamentLmsUserInterface
         ) {
             $primaryCourse = app(CourseEvaluationService::class)
-                ->completedPrimaryCourseForEvaluation($this->course, $user->id);
+                ->completedPrimaryCourseForEvaluation($this->course, $user->id, $this->evaluationPrimaryCourseId);
 
             if ($primaryCourse !== null) {
                 return redirect()->to(CourseCompleted::getUrl([$primaryCourse->slug]));
@@ -184,9 +218,14 @@ class Step extends Page
         return redirect()->to(CourseCompleted::getUrl([$this->course->slug]));
     }
 
-    public static function getUrlForStep(StepModel $step)
+    public static function getUrlForStep(StepModel $step, array $parameters = [])
     {
-        return static::getUrl([$step->lesson->course->slug, $step->lesson->slug, $step->slug]);
+        return static::getUrl([
+            $step->lesson->course->slug,
+            $step->lesson->slug,
+            $step->slug,
+            ...$parameters,
+        ]);
     }
 
     public function getMaxContentWidth(): Width

--- a/src/Pages/Step.php
+++ b/src/Pages/Step.php
@@ -15,6 +15,7 @@ use Tapp\FilamentLms\Enums\CompletionMode;
 use Tapp\FilamentLms\Models\Course;
 use Tapp\FilamentLms\Models\Lesson;
 use Tapp\FilamentLms\Models\Step as StepModel;
+use Tapp\FilamentLms\Services\CourseEvaluationService;
 use Tapp\FilamentLms\Services\ScormProgressService;
 
 class Step extends Page
@@ -148,8 +149,35 @@ class Step extends Page
         // Use the Model's complete() method which handles all events and progress tracking
         $nextStep = $this->step->complete();
 
+        $user = Auth::user();
+        if (
+            $this->step->last_step
+            && $user instanceof FilamentLmsUserInterface
+            && $this->course->hasEvaluation()
+            && ! $this->course->evaluationCompletedByUser($user->id)
+            && $this->course->evaluationCourse !== null
+        ) {
+            $this->course->ensureEvaluationAssigned($user->id);
+
+            return redirect()->to($this->course->evaluationCourse->linkToCurrentStep());
+        }
+
         if (! $this->step->last_step && $nextStep) {
             return redirect()->to(Step::getUrlForStep($nextStep));
+        }
+
+        if (
+            $this->step->last_step
+            && $this->course->isEvaluationCourse()
+            && $user instanceof FilamentLmsUserInterface
+        ) {
+            $primaryCourse = app(CourseEvaluationService::class)
+                ->primaryCoursesFor($this->course)
+                ->first(fn (Course $primary): bool => $primary->allStepsCompletedByUser($user->id));
+
+            if ($primaryCourse !== null) {
+                return redirect()->to(CourseCompleted::getUrl([$primaryCourse->slug]));
+            }
         }
 
         return redirect()->to(CourseCompleted::getUrl([$this->course->slug]));

--- a/src/Pages/Step.php
+++ b/src/Pages/Step.php
@@ -88,13 +88,17 @@ class Step extends Page
             }
         }
 
-        $canAccess = $user->canAccessStep($this->step);
+        $isPrimaryScopedEvaluation = $this->evaluationPrimaryCourseId !== null;
+        $stepUrlParameters = $isPrimaryScopedEvaluation
+            ? ['primaryCourse' => $this->evaluationPrimaryCourseId]
+            : [];
+        $canAccess = $isPrimaryScopedEvaluation || $user->canAccessStep($this->step);
         $currentStepUrl = $this->evaluationPrimaryCourseId !== null
             ? app(CourseEvaluationService::class)->evaluationUrlForPrimaryCourse(
                 Course::query()->findOrFail($this->evaluationPrimaryCourseId),
             )
             : $this->course->linkToCurrentStep();
-        $requestedStepUrl = static::getUrlForStep($this->step);
+        $requestedStepUrl = static::getUrlForStep($this->step, $stepUrlParameters);
 
         Log::info('Step page access check', [
             'user_id' => $user->id,
@@ -103,7 +107,7 @@ class Step extends Page
             'can_access' => $canAccess,
             'requested_step_url' => $requestedStepUrl,
             'current_step_url' => $currentStepUrl,
-            'step_available' => $this->step->available,
+            'step_available' => $canAccess,
         ]);
 
         if (! $canAccess) {
@@ -220,6 +224,17 @@ class Step extends Page
 
     public static function getUrlForStep(StepModel $step, array $parameters = [])
     {
+        $evaluationService = app(CourseEvaluationService::class);
+        $evaluationPrimaryCourseId = $evaluationService->evaluationPrimaryCourseIdFromRequest();
+
+        if (
+            $evaluationPrimaryCourseId !== null
+            && ! array_key_exists('primaryCourse', $parameters)
+            && $evaluationService->isEvaluationCourse($step->lesson->course)
+        ) {
+            $parameters['primaryCourse'] = $evaluationPrimaryCourseId;
+        }
+
         return static::getUrl([
             $step->lesson->course->slug,
             $step->lesson->slug,

--- a/src/Pages/Step.php
+++ b/src/Pages/Step.php
@@ -153,9 +153,7 @@ class Step extends Page
         if (
             $this->step->last_step
             && $user instanceof FilamentLmsUserInterface
-            && $this->course->hasEvaluation()
-            && ! $this->course->evaluationCompletedByUser($user->id)
-            && $this->course->evaluationCourse !== null
+            && app(CourseEvaluationService::class)->hasPendingEvaluationForUser($this->course, $user->id)
         ) {
             $this->course->ensureEvaluationAssigned($user->id);
 

--- a/src/Pages/Step.php
+++ b/src/Pages/Step.php
@@ -144,10 +144,10 @@ class Step extends Page
     }
 
     #[On('complete-step')]
-    public function complete()
+    public function complete(bool $completeStep = true)
     {
-        // Use the Model's complete() method which handles all events and progress tracking
-        $nextStep = $this->step->complete();
+        // Form steps may already complete the model before dispatching this event.
+        $nextStep = $completeStep ? $this->step->complete() : $this->step->next_step;
 
         $user = Auth::user();
         if (

--- a/src/Pages/Step.php
+++ b/src/Pages/Step.php
@@ -82,6 +82,10 @@ class Step extends Page
 
             $this->evaluationPrimaryCourseId = $primaryCourse->id;
 
+            // Keep progress lookups, completion percentages, and navigation links in sync
+            // with the primary course resolved above, even when it wasn't in the query string.
+            request()->query->set('primaryCourse', (string) $primaryCourse->id);
+
             if (! $evaluationService->evaluationStepAvailableForPrimary($this->step, $user->id, $primaryCourse->id)) {
                 $currentStepUrl = $evaluationService->evaluationUrlForPrimaryCourse($primaryCourse);
 

--- a/src/Pages/Step.php
+++ b/src/Pages/Step.php
@@ -134,13 +134,17 @@ class Step extends Page
         $actions = [];
 
         if ($this->course->isEmbeddedPlayer()) {
+            $user = Auth::user();
+            $evaluationService = app(CourseEvaluationService::class);
+            $pendingEvaluation = $user instanceof FilamentLmsUserInterface
+                && $evaluationService->hasPendingEvaluationForUser($this->course, $user->id);
+
             $exitCourse = Action::make('exitCourse')
-                ->label('Exit Course')
+                ->label($pendingEvaluation ? 'Complete Evaluation' : 'Exit Course')
                 ->color('gray')
                 ->action(fn () => $this->exitCourse());
 
             if ($this->shouldRegisterHtml5Bridge()) {
-                $user = Auth::user();
                 $progressService = app(ScormProgressService::class);
                 $needsCompletionConfirm = $user !== null
                     && ! $progressService->courseCompletedByUser($this->course, $user);
@@ -150,6 +154,11 @@ class Step extends Page
                         ->requiresConfirmation()
                         ->modalHeading('Exit course')
                         ->modalDescription('Mark this course as complete before returning to your courses?');
+                } elseif ($pendingEvaluation) {
+                    $exitCourse
+                        ->requiresConfirmation()
+                        ->modalHeading('Complete evaluation')
+                        ->modalDescription('You have finished the course content. Continue to the course evaluation?');
                 }
             }
 
@@ -277,7 +286,7 @@ class Step extends Page
             }
         }
 
-        $this->redirect(Dashboard::getUrl());
+        $this->redirect($this->embeddedCourseExitUrl($user));
     }
 
     #[On('scorm-course-complete')]
@@ -289,6 +298,55 @@ class Step extends Page
         }
 
         app(ScormProgressService::class)->completeAllEligibleSteps($this->course, $user);
+
+        $evaluationService = app(CourseEvaluationService::class);
+
+        if ($evaluationService->hasPendingEvaluationForUser($this->course, $user->id)) {
+            $this->course->ensureEvaluationAssigned($user->id);
+
+            $evaluationUrl = $evaluationService->evaluationUrlForPrimaryCourse($this->course);
+
+            if ($evaluationUrl !== null) {
+                $this->redirect($evaluationUrl);
+
+                return;
+            }
+
+            Notification::make()
+                ->title('Evaluation is not available yet')
+                ->body('The linked evaluation course does not have a form step configured. Please contact your administrator.')
+                ->warning()
+                ->send();
+        }
+    }
+
+    protected function embeddedCourseExitUrl(FilamentLmsUserInterface $user): string
+    {
+        $evaluationService = app(CourseEvaluationService::class);
+
+        if ($evaluationService->hasPendingEvaluationForUser($this->course, $user->id)) {
+            $this->course->ensureEvaluationAssigned($user->id);
+
+            $evaluationUrl = $evaluationService->evaluationUrlForPrimaryCourse($this->course);
+
+            if ($evaluationUrl !== null) {
+                return $evaluationUrl;
+            }
+
+            Notification::make()
+                ->title('Evaluation is not available yet')
+                ->body('The linked evaluation course does not have a form step configured. Please contact your administrator.')
+                ->warning()
+                ->send();
+
+            return Dashboard::getUrl();
+        }
+
+        if ($this->course->allStepsCompletedByUser($user->id)) {
+            return CourseCompleted::getUrl([$this->course->slug]);
+        }
+
+        return Dashboard::getUrl();
     }
 
     public function shouldRegisterScormBridge(): bool

--- a/src/Pages/Step.php
+++ b/src/Pages/Step.php
@@ -156,8 +156,10 @@ class Step extends Page
             && app(CourseEvaluationService::class)->hasPendingEvaluationForUser($this->course, $user->id)
         ) {
             $this->course->ensureEvaluationAssigned($user->id);
+            /** @var Course|null $evaluationCourse */
+            $evaluationCourse = $this->course->evaluationCourse;
 
-            return redirect()->to($this->course->evaluationCourse->linkToCurrentStep());
+            return redirect()->to($evaluationCourse?->linkToCurrentStep() ?? Dashboard::getUrl());
         }
 
         if (! $this->step->last_step && $nextStep) {

--- a/src/Resources/CourseResource.php
+++ b/src/Resources/CourseResource.php
@@ -13,6 +13,7 @@ use Filament\Forms\Components\SpatieMediaLibraryFileUpload;
 use Filament\Forms\Components\Textarea;
 use Filament\Forms\Components\TextInput;
 use Filament\Resources\Resource;
+use Filament\Schemas\Components\Utilities\Get;
 use Filament\Schemas\Components\Utilities\Set;
 use Filament\Schemas\Schema;
 use Filament\Tables\Columns\TextColumn;
@@ -31,6 +32,7 @@ use Tapp\FilamentLms\Resources\CourseResource\Pages\CreateCourse;
 use Tapp\FilamentLms\Resources\CourseResource\Pages\EditCourse;
 use Tapp\FilamentLms\Resources\CourseResource\Pages\ListCourses;
 use Tapp\FilamentLms\Resources\CourseResource\RelationManagers\LessonsRelationManager;
+use Tapp\FilamentLms\Services\CourseEvaluationService;
 
 class CourseResource extends Resource
 {
@@ -139,6 +141,49 @@ class CourseResource extends Resource
                 Checkbox::make('is_private')
                     ->label('Private Course')
                     ->helperText('Private courses are only visible to assigned users and LMS admins'),
+                Select::make('evaluation_course_id')
+                    ->label('Evaluation course')
+                    ->relationship(
+                        'evaluationCourse',
+                        'name',
+                        modifyQueryUsing: function (Builder $query, Get $get, $livewire): void {
+                            $recordId = $livewire->record?->id;
+                            if ($recordId !== null) {
+                                $query->where('id', '!=', $recordId);
+                            }
+
+                            $query->whereNull('evaluation_course_id')
+                                ->where('is_private', true);
+                        },
+                    )
+                    ->searchable()
+                    ->preload()
+                    ->nullable()
+                    ->visible(function (?Course $record): bool {
+                        if (! config('filament-lms.evaluations.enabled', false)) {
+                            return false;
+                        }
+
+                        if ($record === null) {
+                            return true;
+                        }
+
+                        return ! app(CourseEvaluationService::class)->isEvaluationCourse($record);
+                    })
+                    ->rules([
+                        fn (?Course $record): \Closure => function (string $attribute, mixed $value, \Closure $fail) use ($record): void {
+                            if ($value === null || $record === null) {
+                                return;
+                            }
+
+                            $evaluationCourse = Course::query()->find($value);
+
+                            if (! app(CourseEvaluationService::class)->canLinkEvaluationCourse($record, $evaluationCourse)) {
+                                $fail('Choose an evaluation-only course that is not already linked as a training course.');
+                            }
+                        },
+                    ])
+                    ->helperText('Set this on the training course and select its evaluation course — not the other way around.'),
 
                 Repeater::make('courseCreditCategories')
                     ->relationship()

--- a/src/Resources/CourseResource.php
+++ b/src/Resources/CourseResource.php
@@ -176,14 +176,9 @@ class CourseResource extends Resource
                                 return;
                             }
 
-                            $evaluationCourse = Course::query()->find($value);
                             $service = app(CourseEvaluationService::class);
 
-                            $canLink = $record === null
-                                ? $service->canSelectEvaluationCourse($evaluationCourse)
-                                : $service->canLinkEvaluationCourse($record, $evaluationCourse);
-
-                            if (! $canLink) {
+                            if (! $service->canUseEvaluationCourseId($record, $value)) {
                                 $fail('Choose an evaluation-only course that is not already linked as a training course.');
                             }
                         },

--- a/src/Resources/CourseResource.php
+++ b/src/Resources/CourseResource.php
@@ -172,13 +172,18 @@ class CourseResource extends Resource
                     })
                     ->rules([
                         fn (?Course $record): \Closure => function (string $attribute, mixed $value, \Closure $fail) use ($record): void {
-                            if ($value === null || $record === null) {
+                            if ($value === null) {
                                 return;
                             }
 
                             $evaluationCourse = Course::query()->find($value);
+                            $service = app(CourseEvaluationService::class);
 
-                            if (! app(CourseEvaluationService::class)->canLinkEvaluationCourse($record, $evaluationCourse)) {
+                            $canLink = $record === null
+                                ? $service->canSelectEvaluationCourse($evaluationCourse)
+                                : $service->canLinkEvaluationCourse($record, $evaluationCourse);
+
+                            if (! $canLink) {
                                 $fail('Choose an evaluation-only course that is not already linked as a training course.');
                             }
                         },

--- a/src/Services/CourseEvaluationService.php
+++ b/src/Services/CourseEvaluationService.php
@@ -1,0 +1,193 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tapp\FilamentLms\Services;
+
+use Illuminate\Foundation\Auth\User as Authenticatable;
+use Illuminate\Support\Collection;
+use Illuminate\UniqueConstraintViolationException;
+use Tapp\FilamentLms\Models\Course;
+
+final class CourseEvaluationService
+{
+    public function evaluationsEnabled(): bool
+    {
+        return (bool) config('filament-lms.evaluations.enabled', false);
+    }
+
+    public function hasEvaluation(Course $course): bool
+    {
+        return $this->evaluationsEnabled()
+            && $course->evaluation_course_id !== null;
+    }
+
+    public function isEvaluationCourse(Course $course): bool
+    {
+        if (! $this->evaluationsEnabled()) {
+            return false;
+        }
+
+        return Course::query()
+            ->where('evaluation_course_id', $course->id)
+            ->exists();
+    }
+
+    /**
+     * @return Collection<int, Course>
+     */
+    public function primaryCoursesFor(Course $evaluationCourse): Collection
+    {
+        return Course::query()
+            ->where('evaluation_course_id', $evaluationCourse->id)
+            ->get();
+    }
+
+    public function evaluationCompletedByUser(Course $primaryCourse, int|string $userId): bool
+    {
+        if (! $this->hasEvaluation($primaryCourse)) {
+            return true;
+        }
+
+        $evaluationCourse = $primaryCourse->evaluationCourse;
+
+        if ($evaluationCourse === null) {
+            return true;
+        }
+
+        return $evaluationCourse->allStepsCompletedByUser($userId);
+    }
+
+    public function ensureEvaluationAssigned(Course $primaryCourse, int|string $userId): void
+    {
+        if (! $this->hasEvaluation($primaryCourse)) {
+            return;
+        }
+
+        $evaluationCourse = $primaryCourse->evaluationCourse;
+
+        if ($evaluationCourse === null) {
+            return;
+        }
+
+        if ($evaluationCourse->users()->where('user_id', $userId)->exists()) {
+            return;
+        }
+
+        try {
+            $evaluationCourse->users()->attach($userId);
+        } catch (UniqueConstraintViolationException) {
+            // Already assigned by a concurrent request.
+        }
+    }
+
+    public function isPrimaryTrainingCompletedForUser(Course $primary, Authenticatable $user): bool
+    {
+        if (! $primary->allStepsCompletedByUser($user->id)) {
+            return false;
+        }
+
+        if (! $primary->is_private) {
+            return true;
+        }
+
+        return $primary->users()->where('user_id', $user->id)->exists();
+    }
+
+    public function isEvaluationUnlockedForUser(Course $evaluationCourse, Authenticatable $user): bool
+    {
+        if (! $this->isEvaluationCourse($evaluationCourse)) {
+            return true;
+        }
+
+        return $this->primaryCoursesFor($evaluationCourse)
+            ->contains(fn (Course $primary): bool => $this->isPrimaryTrainingCompletedForUser($primary, $user));
+    }
+
+    public function finalizePrimaryCoursesAfterEvaluation(Course $evaluationCourse, int|string $userId): void
+    {
+        if (! $this->isEvaluationCourse($evaluationCourse)) {
+            return;
+        }
+
+        foreach ($this->primaryCoursesFor($evaluationCourse) as $primaryCourse) {
+            if (! $primaryCourse->allStepsCompletedByUser($userId)) {
+                continue;
+            }
+
+            $primaryCourse->maybeSetCompletedAtForUser($userId);
+        }
+    }
+
+    /**
+     * @return Collection<int, int>
+     */
+    public function unlockedEvaluationCourseIdsForUser(Authenticatable $user): Collection
+    {
+        if (! $this->evaluationsEnabled()) {
+            return collect();
+        }
+
+        $evaluationCourseIds = Course::query()
+            ->whereNotNull('evaluation_course_id')
+            ->pluck('evaluation_course_id')
+            ->unique()
+            ->values();
+
+        return $evaluationCourseIds->filter(function (int $evaluationCourseId) use ($user): bool {
+            $evaluationCourse = Course::query()->find($evaluationCourseId);
+
+            if ($evaluationCourse === null) {
+                return false;
+            }
+
+            return $this->isEvaluationUnlockedForUser($evaluationCourse, $user);
+        })->values();
+    }
+
+    /**
+     * @return Collection<int, int>
+     */
+    public function lockedEvaluationCourseIds(): Collection
+    {
+        if (! $this->evaluationsEnabled()) {
+            return collect();
+        }
+
+        return Course::query()
+            ->whereNotNull('evaluation_course_id')
+            ->pluck('evaluation_course_id')
+            ->unique()
+            ->values();
+    }
+
+    public function isValidEvaluationTarget(?Course $course): bool
+    {
+        if ($course === null) {
+            return false;
+        }
+
+        return $course->evaluation_course_id === null;
+    }
+
+    public function canLinkEvaluationCourse(Course $primaryCourse, ?Course $evaluationCourse): bool
+    {
+        if ($evaluationCourse === null) {
+            return true;
+        }
+
+        if ($primaryCourse->is($evaluationCourse)) {
+            return false;
+        }
+
+        if ($this->isEvaluationCourse($primaryCourse)) {
+            return false;
+        }
+
+        if (! $evaluationCourse->is_private) {
+            return false;
+        }
+
+        return $this->isValidEvaluationTarget($evaluationCourse);
+    }
+}

--- a/src/Services/CourseEvaluationService.php
+++ b/src/Services/CourseEvaluationService.php
@@ -225,6 +225,29 @@ final class CourseEvaluationService
             ?? $eligiblePrimaryCourses->first();
     }
 
+    public function evaluationPrimaryCourseIdFromRequest(): ?int
+    {
+        $primaryCourseId = request()->query('primaryCourse');
+
+        if (! is_numeric($primaryCourseId)) {
+            return null;
+        }
+
+        $courseSlug = request()->route('courseSlug');
+
+        if ($courseSlug === null) {
+            return (int) $primaryCourseId;
+        }
+
+        $course = Course::query()
+            ->where('slug', $courseSlug)
+            ->first();
+
+        return $course !== null && $this->isEvaluationCourse($course)
+            ? (int) $primaryCourseId
+            : null;
+    }
+
     public function evaluationStepAvailableForPrimary(Step $step, int|string $userId, int $primaryCourseId): bool
     {
         if ($step->lesson->course->evaluation_course_id !== null) {

--- a/src/Services/CourseEvaluationService.php
+++ b/src/Services/CourseEvaluationService.php
@@ -4,9 +4,9 @@ declare(strict_types=1);
 
 namespace Tapp\FilamentLms\Services;
 
+use Illuminate\Database\UniqueConstraintViolationException;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Support\Collection;
-use Illuminate\UniqueConstraintViolationException;
 use Tapp\FilamentLms\Models\Course;
 
 final class CourseEvaluationService
@@ -75,7 +75,7 @@ final class CourseEvaluationService
     public function hasPendingEvaluationForUser(Course $primaryCourse, int|string $userId): bool
     {
         return $this->hasEvaluation($primaryCourse)
-            && $primaryCourse->evaluationCourse !== null
+            && $this->evaluationCourseFor($primaryCourse) !== null
             && $this->courseMeetsCompletionRequirements($primaryCourse, $userId)
             && ! $this->evaluationCompletedByUser($primaryCourse, $userId);
     }
@@ -86,7 +86,7 @@ final class CourseEvaluationService
             return true;
         }
 
-        $evaluationCourse = $primaryCourse->evaluationCourse;
+        $evaluationCourse = $this->evaluationCourseFor($primaryCourse);
 
         if ($evaluationCourse === null) {
             return true;
@@ -105,7 +105,7 @@ final class CourseEvaluationService
             return;
         }
 
-        $evaluationCourse = $primaryCourse->evaluationCourse;
+        $evaluationCourse = $this->evaluationCourseFor($primaryCourse);
 
         if ($evaluationCourse === null) {
             return;
@@ -256,5 +256,13 @@ final class CourseEvaluationService
         }
 
         return $this->canSelectEvaluationCourse($evaluationCourse);
+    }
+
+    private function evaluationCourseFor(Course $primaryCourse): ?Course
+    {
+        /** @var Course|null $evaluationCourse */
+        $evaluationCourse = $primaryCourse->evaluationCourse;
+
+        return $evaluationCourse;
     }
 }

--- a/src/Services/CourseEvaluationService.php
+++ b/src/Services/CourseEvaluationService.php
@@ -236,7 +236,7 @@ final class CourseEvaluationService
         $courseSlug = request()->route('courseSlug');
 
         if ($courseSlug === null) {
-            return (int) $primaryCourseId;
+            return null;
         }
 
         $course = Course::query()
@@ -250,10 +250,6 @@ final class CourseEvaluationService
 
     public function evaluationStepAvailableForPrimary(Step $step, int|string $userId, int $primaryCourseId): bool
     {
-        if ($step->lesson->course->evaluation_course_id !== null) {
-            return true;
-        }
-
         $previousStepIds = $step->lesson->course->steps()
             ->where(function ($query) use ($step): void {
                 $query->where('lms_lessons.order', '<', $step->lesson->order)

--- a/src/Services/CourseEvaluationService.php
+++ b/src/Services/CourseEvaluationService.php
@@ -43,6 +43,16 @@ final class CourseEvaluationService
             ->get();
     }
 
+    public function completedPrimaryCourseForEvaluation(Course $evaluationCourse, int|string $userId): ?Course
+    {
+        if (! $this->isEvaluationCourse($evaluationCourse)) {
+            return null;
+        }
+
+        return $this->primaryCoursesFor($evaluationCourse)
+            ->first(fn (Course $primary): bool => $primary->allStepsCompletedByUser($userId));
+    }
+
     public function evaluationCompletedByUser(Course $primaryCourse, int|string $userId): bool
     {
         if (! $this->hasEvaluation($primaryCourse)) {

--- a/src/Services/CourseEvaluationService.php
+++ b/src/Services/CourseEvaluationService.php
@@ -224,6 +224,23 @@ final class CourseEvaluationService
         return $this->isValidEvaluationTarget($evaluationCourse);
     }
 
+    public function canUseEvaluationCourseId(?Course $primaryCourse, mixed $evaluationCourseId): bool
+    {
+        if ($evaluationCourseId === null) {
+            return true;
+        }
+
+        $evaluationCourse = Course::query()->find($evaluationCourseId);
+
+        if ($evaluationCourse === null) {
+            return false;
+        }
+
+        return $primaryCourse === null
+            ? $this->canSelectEvaluationCourse($evaluationCourse)
+            : $this->canLinkEvaluationCourse($primaryCourse, $evaluationCourse);
+    }
+
     public function canLinkEvaluationCourse(Course $primaryCourse, ?Course $evaluationCourse): bool
     {
         if ($evaluationCourse === null) {

--- a/src/Services/CourseEvaluationService.php
+++ b/src/Services/CourseEvaluationService.php
@@ -7,7 +7,11 @@ namespace Tapp\FilamentLms\Services;
 use Illuminate\Database\UniqueConstraintViolationException;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\Auth;
 use Tapp\FilamentLms\Models\Course;
+use Tapp\FilamentLms\Models\Step;
+use Tapp\FilamentLms\Models\StepUser;
+use Tapp\FilamentLms\Pages\Step as StepPage;
 
 final class CourseEvaluationService
 {
@@ -43,14 +47,26 @@ final class CourseEvaluationService
             ->get();
     }
 
-    public function completedPrimaryCourseForEvaluation(Course $evaluationCourse, int|string $userId): ?Course
+    public function completedPrimaryCourseForEvaluation(Course $evaluationCourse, int|string $userId, ?int $primaryCourseId = null): ?Course
     {
         if (! $this->isEvaluationCourse($evaluationCourse)) {
             return null;
         }
 
+        if ($primaryCourseId !== null) {
+            $primaryCourse = $this->primaryCoursesFor($evaluationCourse)
+                ->first(fn (Course $primary): bool => $primary->id === $primaryCourseId);
+
+            return $primaryCourse !== null
+                && $this->courseMeetsCompletionRequirements($primaryCourse, $userId)
+                && $this->evaluationCompletedByUser($primaryCourse, $userId)
+                ? $primaryCourse
+                : null;
+        }
+
         return $this->primaryCoursesFor($evaluationCourse)
-            ->first(fn (Course $primary): bool => $this->courseMeetsCompletionRequirements($primary, $userId));
+            ->first(fn (Course $primary): bool => $this->courseMeetsCompletionRequirements($primary, $userId)
+                && $this->evaluationCompletedByUser($primary, $userId));
     }
 
     public function courseMeetsCompletionRequirements(Course $course, int|string $userId): bool
@@ -92,7 +108,39 @@ final class CourseEvaluationService
             return true;
         }
 
-        return $evaluationCourse->allStepsCompletedByUser($userId);
+        return $this->evaluationStepsCompletedByUser($evaluationCourse, $userId, $primaryCourse->id);
+    }
+
+    public function evaluationUrlForPrimaryCourse(Course $primaryCourse): ?string
+    {
+        if (! $this->hasEvaluation($primaryCourse)) {
+            return null;
+        }
+
+        $evaluationCourse = $this->evaluationCourseFor($primaryCourse);
+
+        if ($evaluationCourse === null) {
+            return null;
+        }
+
+        $steps = $evaluationCourse->steps()->ordered()->get();
+
+        if ($steps->isEmpty()) {
+            return null;
+        }
+
+        $completedStepIds = $this->completedEvaluationStepIdsForPrimary(
+            $evaluationCourse,
+            Auth::id(),
+            $primaryCourse->id,
+        );
+
+        $step = $steps->first(fn (Step $step): bool => ! $completedStepIds->contains($step->id))
+            ?? $steps->first();
+
+        return $step instanceof Step
+            ? StepPage::getUrlForStep($step, ['primaryCourse' => $primaryCourse->id])
+            : null;
     }
 
     public function ensureEvaluationAssigned(Course $primaryCourse, int|string $userId): void
@@ -143,6 +191,56 @@ final class CourseEvaluationService
 
         return $this->primaryCoursesFor($evaluationCourse)
             ->contains(fn (Course $primary): bool => $this->isPrimaryTrainingCompletedForUser($primary, $user));
+    }
+
+    public function activePrimaryCourseForEvaluation(Course $evaluationCourse, Authenticatable $user, ?int $primaryCourseId = null): ?Course
+    {
+        if (! $this->isEvaluationCourse($evaluationCourse)) {
+            return null;
+        }
+
+        $eligiblePrimaryCourses = $this->primaryCoursesFor($evaluationCourse)
+            ->filter(fn (Course $primary): bool => $this->isPrimaryTrainingCompletedForUser($primary, $user));
+
+        if ($primaryCourseId !== null) {
+            return $eligiblePrimaryCourses
+                ->first(fn (Course $primary): bool => $primary->id === $primaryCourseId);
+        }
+
+        return $eligiblePrimaryCourses
+            ->first(fn (Course $primary): bool => ! $this->evaluationCompletedByUser($primary, $user->id))
+            ?? $eligiblePrimaryCourses->first();
+    }
+
+    public function evaluationStepAvailableForPrimary(Step $step, int|string $userId, int $primaryCourseId): bool
+    {
+        if ($step->lesson->course->evaluation_course_id !== null) {
+            return true;
+        }
+
+        $previousStepIds = $step->lesson->course->steps()
+            ->where(function ($query) use ($step): void {
+                $query->where('lms_lessons.order', '<', $step->lesson->order)
+                    ->orWhere(function ($query) use ($step): void {
+                        $query->where('lms_lessons.order', '=', $step->lesson->order)
+                            ->where('lms_steps.order', '<', $step->order);
+                    });
+            })
+            ->pluck('lms_steps.id');
+
+        if ($previousStepIds->isEmpty()) {
+            return true;
+        }
+
+        $completedPreviousStepIds = StepUser::query()
+            ->whereIn('step_id', $previousStepIds)
+            ->where('user_id', $userId)
+            ->where('evaluation_primary_course_id', $primaryCourseId)
+            ->whereNotNull('completed_at')
+            ->pluck('step_id')
+            ->unique();
+
+        return $completedPreviousStepIds->count() === $previousStepIds->count();
     }
 
     public function finalizePrimaryCoursesAfterEvaluation(Course $evaluationCourse, int|string $userId): void
@@ -264,5 +362,39 @@ final class CourseEvaluationService
         $evaluationCourse = $primaryCourse->evaluationCourse;
 
         return $evaluationCourse;
+    }
+
+    private function evaluationStepsCompletedByUser(Course $evaluationCourse, int|string $userId, int $primaryCourseId): bool
+    {
+        $stepIds = $evaluationCourse->steps()->pluck('lms_steps.id');
+
+        if ($stepIds->isEmpty()) {
+            return false;
+        }
+
+        return $this->completedEvaluationStepIdsForPrimary(
+            $evaluationCourse,
+            $userId,
+            $primaryCourseId,
+        )->count() === $stepIds->count();
+    }
+
+    /**
+     * @return Collection<int, int>
+     */
+    private function completedEvaluationStepIdsForPrimary(Course $evaluationCourse, int|string|null $userId, int $primaryCourseId): Collection
+    {
+        if ($userId === null) {
+            return collect();
+        }
+
+        return StepUser::query()
+            ->whereIn('step_id', $evaluationCourse->steps()->pluck('lms_steps.id'))
+            ->where('user_id', $userId)
+            ->where('evaluation_primary_course_id', $primaryCourseId)
+            ->whereNotNull('completed_at')
+            ->pluck('step_id')
+            ->unique()
+            ->values();
     }
 }

--- a/src/Services/CourseEvaluationService.php
+++ b/src/Services/CourseEvaluationService.php
@@ -50,7 +50,34 @@ final class CourseEvaluationService
         }
 
         return $this->primaryCoursesFor($evaluationCourse)
-            ->first(fn (Course $primary): bool => $primary->allStepsCompletedByUser($userId));
+            ->first(fn (Course $primary): bool => $this->courseMeetsCompletionRequirements($primary, $userId));
+    }
+
+    public function courseMeetsCompletionRequirements(Course $course, int|string $userId): bool
+    {
+        if (! $course->allStepsCompletedByUser($userId)) {
+            return false;
+        }
+
+        if ($course->required_test_percentage === null) {
+            return true;
+        }
+
+        $testSteps = $course->getOrderedTestSteps();
+
+        if ($testSteps->isEmpty()) {
+            return true;
+        }
+
+        return $course->getOverallTestPercentageForUser($userId) >= (float) $course->required_test_percentage;
+    }
+
+    public function hasPendingEvaluationForUser(Course $primaryCourse, int|string $userId): bool
+    {
+        return $this->hasEvaluation($primaryCourse)
+            && $primaryCourse->evaluationCourse !== null
+            && $this->courseMeetsCompletionRequirements($primaryCourse, $userId)
+            && ! $this->evaluationCompletedByUser($primaryCourse, $userId);
     }
 
     public function evaluationCompletedByUser(Course $primaryCourse, int|string $userId): bool
@@ -74,6 +101,10 @@ final class CourseEvaluationService
             return;
         }
 
+        if (! $this->courseMeetsCompletionRequirements($primaryCourse, $userId)) {
+            return;
+        }
+
         $evaluationCourse = $primaryCourse->evaluationCourse;
 
         if ($evaluationCourse === null) {
@@ -93,7 +124,7 @@ final class CourseEvaluationService
 
     public function isPrimaryTrainingCompletedForUser(Course $primary, Authenticatable $user): bool
     {
-        if (! $primary->allStepsCompletedByUser($user->id)) {
+        if (! $this->courseMeetsCompletionRequirements($primary, $user->id)) {
             return false;
         }
 
@@ -121,7 +152,7 @@ final class CourseEvaluationService
         }
 
         foreach ($this->primaryCoursesFor($evaluationCourse) as $primaryCourse) {
-            if (! $primaryCourse->allStepsCompletedByUser($userId)) {
+            if (! $this->courseMeetsCompletionRequirements($primaryCourse, $userId)) {
                 continue;
             }
 

--- a/src/Services/CourseEvaluationService.php
+++ b/src/Services/CourseEvaluationService.php
@@ -170,6 +170,19 @@ final class CourseEvaluationService
         return $course->evaluation_course_id === null;
     }
 
+    public function canSelectEvaluationCourse(?Course $evaluationCourse): bool
+    {
+        if ($evaluationCourse === null) {
+            return true;
+        }
+
+        if (! $evaluationCourse->is_private) {
+            return false;
+        }
+
+        return $this->isValidEvaluationTarget($evaluationCourse);
+    }
+
     public function canLinkEvaluationCourse(Course $primaryCourse, ?Course $evaluationCourse): bool
     {
         if ($evaluationCourse === null) {
@@ -184,10 +197,6 @@ final class CourseEvaluationService
             return false;
         }
 
-        if (! $evaluationCourse->is_private) {
-            return false;
-        }
-
-        return $this->isValidEvaluationTarget($evaluationCourse);
+        return $this->canSelectEvaluationCourse($evaluationCourse);
     }
 }

--- a/src/Services/CourseEvaluationService.php
+++ b/src/Services/CourseEvaluationService.php
@@ -53,8 +53,10 @@ final class CourseEvaluationService
             return null;
         }
 
+        $primaryCourses = $this->primaryCoursesFor($evaluationCourse);
+
         if ($primaryCourseId !== null) {
-            $primaryCourse = $this->primaryCoursesFor($evaluationCourse)
+            $primaryCourse = $primaryCourses
                 ->first(fn (Course $primary): bool => $primary->id === $primaryCourseId);
 
             return $primaryCourse !== null
@@ -64,9 +66,20 @@ final class CourseEvaluationService
                 : null;
         }
 
-        return $this->primaryCoursesFor($evaluationCourse)
-            ->first(fn (Course $primary): bool => $this->courseMeetsCompletionRequirements($primary, $userId)
-                && $this->evaluationCompletedByUser($primary, $userId));
+        foreach ($this->completedEvaluationPrimaryCourseIdsByRecency($evaluationCourse, $userId) as $completedPrimaryCourseId) {
+            $primaryCourse = $primaryCourses
+                ->first(fn (Course $primary): bool => $primary->id === $completedPrimaryCourseId);
+
+            if (
+                $primaryCourse !== null
+                && $this->courseMeetsCompletionRequirements($primaryCourse, $userId)
+                && $this->evaluationCompletedByUser($primaryCourse, $userId)
+            ) {
+                return $primaryCourse;
+            }
+        }
+
+        return null;
     }
 
     public function courseMeetsCompletionRequirements(Course $course, int|string $userId): bool
@@ -377,6 +390,29 @@ final class CourseEvaluationService
             $userId,
             $primaryCourseId,
         )->count() === $stepIds->count();
+    }
+
+    /**
+     * @return Collection<int, int>
+     */
+    private function completedEvaluationPrimaryCourseIdsByRecency(Course $evaluationCourse, int|string $userId): Collection
+    {
+        $stepIds = $evaluationCourse->steps()->pluck('lms_steps.id');
+
+        if ($stepIds->isEmpty()) {
+            return collect();
+        }
+
+        return StepUser::query()
+            ->whereIn('step_id', $stepIds)
+            ->where('user_id', $userId)
+            ->whereNotNull('evaluation_primary_course_id')
+            ->whereNotNull('completed_at')
+            ->orderByDesc('completed_at')
+            ->orderByDesc('id')
+            ->pluck('evaluation_primary_course_id')
+            ->unique()
+            ->values();
     }
 
     /**

--- a/src/Traits/FilamentLmsUser.php
+++ b/src/Traits/FilamentLmsUser.php
@@ -8,6 +8,7 @@ use Illuminate\Support\Facades\DB;
 use Tapp\FilamentLms\Contracts\FilamentLmsUserInterface;
 use Tapp\FilamentLms\Models\Course;
 use Tapp\FilamentLms\Models\Step;
+use Tapp\FilamentLms\Services\CourseEvaluationService;
 
 /**
  * Trait for User models to provide LMS functionality.
@@ -81,6 +82,17 @@ trait FilamentLmsUser
     public function canAccessStep(Step $step): bool
     {
         $course = $step->lesson->course;
+
+        if ($course->isEvaluationCourse() && config('filament-lms.evaluations.enabled', false)) {
+            if ($this->isLmsAdmin()) {
+                return $step->checkPreviousStepsCompleted();
+            }
+
+            if (! app(CourseEvaluationService::class)->isEvaluationUnlockedForUser($course, $this)) {
+                return false;
+            }
+        }
+
         if ($course->isEmbeddedPlayer()) {
             $launchStep = $course->launchStep();
 

--- a/tests/Feature/CourseEvaluationTest.php
+++ b/tests/Feature/CourseEvaluationTest.php
@@ -19,10 +19,15 @@ use Tapp\FilamentLms\Models\StepUser;
 use Tapp\FilamentLms\Pages\CourseCompleted;
 use Tapp\FilamentLms\Pages\Step as StepPage;
 use Tapp\FilamentLms\Services\CourseEvaluationService;
+use Tapp\FilamentLms\Tests\TestFilamentFormShow;
+use Tapp\FilamentLms\Tests\TestFilamentFormUserShow;
 use Tapp\FilamentLms\Tests\TestUser;
 
 beforeEach(function () {
     config(['filament-lms.evaluations.enabled' => true]);
+
+    Livewire::component('tapp.filament-form-builder.livewire.filament-form.show', TestFilamentFormShow::class);
+    Livewire::component('tapp.filament-form-builder.livewire.filament-form-user.show', TestFilamentFormUserShow::class);
 });
 
 test('evaluation link validation rejects public courses and backwards configuration', function () {

--- a/tests/Feature/CourseEvaluationTest.php
+++ b/tests/Feature/CourseEvaluationTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Tapp\FilamentLms\Tests\Feature;
 
+use Illuminate\Http\RedirectResponse;
 use Livewire\Livewire;
 use Tapp\FilamentFormBuilder\Models\FilamentForm;
 use Tapp\FilamentFormBuilder\Models\FilamentFormField;
@@ -188,7 +189,7 @@ test('completed page for evaluation course redirects to primary course certifica
     $response = app(CourseCompleted::class)->mount($evaluationCourse->slug);
 
     expect($response)
-        ->toBeInstanceOf(\Illuminate\Http\RedirectResponse::class)
+        ->toBeInstanceOf(RedirectResponse::class)
         ->and($response->getTargetUrl())->toBe(CourseCompleted::getUrl([$primaryCourse->slug]));
 });
 

--- a/tests/Feature/CourseEvaluationTest.php
+++ b/tests/Feature/CourseEvaluationTest.php
@@ -7,6 +7,7 @@ namespace Tapp\FilamentLms\Tests\Feature;
 use Tapp\FilamentFormBuilder\Models\FilamentForm;
 use Tapp\FilamentFormBuilder\Models\FilamentFormField;
 use Tapp\FilamentFormBuilder\Models\FilamentFormUser;
+use Tapp\FilamentLms\Livewire\FormStep;
 use Tapp\FilamentLms\Models\Course;
 use Tapp\FilamentLms\Models\Lesson;
 use Tapp\FilamentLms\Models\Step;
@@ -247,7 +248,7 @@ test('evaluation form step hides next button and advances after submit', functio
 
     $this->actingAs($user);
 
-    Livewire\Livewire::test(\Tapp\FilamentLms\Livewire\FormStep::class, ['step' => $evaluationStep])
+    Livewire\Livewire::test(FormStep::class, ['step' => $evaluationStep])
         ->assertDontSee('Next');
 
     $entry = FilamentFormUser::create([
@@ -258,7 +259,7 @@ test('evaluation form step hides next button and advances after submit', functio
         ],
     ]);
 
-    Livewire\Livewire::test(\Tapp\FilamentLms\Livewire\FormStep::class, ['step' => $evaluationStep])
+    Livewire\Livewire::test(FormStep::class, ['step' => $evaluationStep])
         ->call('entrySaved', $entry)
         ->assertDispatched('complete-step');
 });

--- a/tests/Feature/CourseEvaluationTest.php
+++ b/tests/Feature/CourseEvaluationTest.php
@@ -31,6 +31,30 @@ use Tapp\FilamentLms\Tests\TestUser;
 
 class CourseEvaluationLmsUser extends TestUser implements FilamentLmsUserInterface {}
 
+/**
+ * Simulate a request to a step/course page, binding a `courseSlug` route
+ * parameter the way the real Step and CourseCompleted routes do, so
+ * evaluationPrimaryCourseIdFromRequest() can verify the current course.
+ */
+function fakeRequestForCourse(?int $primaryCourseId, string $courseSlug): void
+{
+    $request = Request::create('/', 'GET', $primaryCourseId !== null ? [
+        'primaryCourse' => (string) $primaryCourseId,
+    ] : []);
+
+    $request->setRouteResolver(fn () => new class($courseSlug)
+    {
+        public function __construct(private readonly string $courseSlug) {}
+
+        public function parameter($name, $default = null)
+        {
+            return $name === 'courseSlug' ? $this->courseSlug : $default;
+        }
+    });
+
+    app()->instance('request', $request);
+}
+
 beforeEach(function () {
     config(['filament-lms.evaluations.enabled' => true]);
 
@@ -260,16 +284,12 @@ test('shared evaluation progress stays scoped to the active primary course', fun
 
     $this->actingAs($user);
 
-    app()->instance('request', Request::create('/', 'GET', [
-        'primaryCourse' => (string) $secondPrimary->id,
-    ]));
+    fakeRequestForCourse($secondPrimary->id, $evaluationCourse->slug);
 
     expect($evaluationStep->fresh()->completed_at)->toBeNull()
         ->and((float) $evaluationCourse->fresh()->completion_percentage)->toBe(0.0);
 
-    app()->instance('request', Request::create('/', 'GET', [
-        'primaryCourse' => (string) $firstPrimary->id,
-    ]));
+    fakeRequestForCourse($firstPrimary->id, $evaluationCourse->slug);
 
     expect($evaluationStep->fresh()->completed_at)->not->toBeNull()
         ->and((float) $evaluationCourse->fresh()->completion_percentage)->toBe(100.0);
@@ -351,9 +371,7 @@ test('evaluation step urls preserve requested primary course context', function 
     ]);
 
     $this->actingAs($user);
-    app()->instance('request', Request::create('/', 'GET', [
-        'primaryCourse' => (string) $secondPrimary->id,
-    ]));
+    fakeRequestForCourse($secondPrimary->id, $evaluationCourse->slug);
 
     $expectedEvaluationUrl = StepPage::getUrl([
         $evaluationCourse->slug,
@@ -452,9 +470,7 @@ test('step page uses primary scoped evaluation progress for access checks', func
     ]);
 
     Auth::login($user);
-    app()->instance('request', Request::create('/', 'GET', [
-        'primaryCourse' => (string) $secondPrimary->id,
-    ]));
+    fakeRequestForCourse($secondPrimary->id, $evaluationCourse->slug);
 
     $evaluationService = app(CourseEvaluationService::class);
 

--- a/tests/Feature/CourseEvaluationTest.php
+++ b/tests/Feature/CourseEvaluationTest.php
@@ -9,10 +9,12 @@ use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Event;
 use Livewire\Livewire;
+use ReflectionMethod;
 use Tapp\FilamentFormBuilder\Models\FilamentForm;
 use Tapp\FilamentFormBuilder\Models\FilamentFormField;
 use Tapp\FilamentFormBuilder\Models\FilamentFormUser;
 use Tapp\FilamentLms\Contracts\FilamentLmsUserInterface;
+use Tapp\FilamentLms\Enums\CompletionMode;
 use Tapp\FilamentLms\Events\CourseCompleted as CourseCompletedEvent;
 use Tapp\FilamentLms\Livewire\FormStep;
 use Tapp\FilamentLms\Models\Course;
@@ -20,6 +22,7 @@ use Tapp\FilamentLms\Models\Lesson;
 use Tapp\FilamentLms\Models\Step;
 use Tapp\FilamentLms\Models\StepUser;
 use Tapp\FilamentLms\Pages\CourseCompleted;
+use Tapp\FilamentLms\Pages\Dashboard;
 use Tapp\FilamentLms\Pages\Step as StepPage;
 use Tapp\FilamentLms\Services\CourseEvaluationService;
 use Tapp\FilamentLms\Tests\TestFilamentFormShow;
@@ -1034,4 +1037,145 @@ test('form steps scope submissions per step when the same form is reused', funct
         ->and($testStep->fresh()->formEntryForUser($user->id)?->id)->toBe($testEntry->id)
         ->and($webdevEntry->fresh()->entry[0]['answer'])->toBe('Agree')
         ->and($testEntry->fresh()->entry[0]['answer'])->toBe('Disagree');
+});
+
+test('embedded scorm exit course redirects to evaluation when training content is complete', function () {
+    $user = CourseEvaluationLmsUser::create([
+        'name' => 'Scorm Exit User',
+        'email' => 'scorm-exit-evaluation@example.com',
+        'password' => bcrypt('password'),
+    ]);
+
+    $evaluationCourse = Course::factory()->create(['is_private' => true]);
+    $evaluationLesson = Lesson::factory()->create(['course_id' => $evaluationCourse->id]);
+    Step::factory()->create([
+        'lesson_id' => $evaluationLesson->id,
+        'slug' => 'evaluation',
+    ]);
+
+    $primaryCourse = Course::factory()->create([
+        'slug' => 'scorm-primary-training',
+        'embedded_player' => true,
+        'completion_mode' => CompletionMode::Scorm12,
+        'evaluation_course_id' => $evaluationCourse->id,
+        'is_private' => true,
+    ]);
+    $primaryCourse->users()->attach($user->id);
+
+    $lesson = Lesson::factory()->create([
+        'course_id' => $primaryCourse->id,
+        'slug' => 'lesson-one',
+    ]);
+    $step = Step::factory()->create([
+        'lesson_id' => $lesson->id,
+        'slug' => 'launch',
+        'order' => 0,
+        'material_type' => null,
+        'material_id' => null,
+    ]);
+
+    StepUser::create([
+        'user_id' => $user->id,
+        'step_id' => $step->id,
+        'completed_at' => now(),
+    ]);
+
+    $expectedUrl = app(CourseEvaluationService::class)->evaluationUrlForPrimaryCourse($primaryCourse->fresh());
+
+    $page = app(StepPage::class);
+    $page->course = $primaryCourse->fresh();
+
+    $method = new ReflectionMethod(StepPage::class, 'embeddedCourseExitUrl');
+    $url = $method->invoke($page, $user);
+
+    expect($url)->toBe($expectedUrl);
+
+    $method->invoke($page, $user);
+
+    expect($evaluationCourse->users()->where('user_id', $user->id)->exists())->toBeTrue();
+});
+
+test('embedded scorm exit course returns to dashboard when training is incomplete', function () {
+    $user = CourseEvaluationLmsUser::create([
+        'name' => 'Scorm Incomplete Exit User',
+        'email' => 'scorm-incomplete-exit@example.com',
+        'password' => bcrypt('password'),
+    ]);
+
+    $primaryCourse = Course::factory()->create([
+        'slug' => 'scorm-incomplete-training',
+        'embedded_player' => true,
+        'completion_mode' => CompletionMode::Scorm12,
+        'is_private' => true,
+    ]);
+    $primaryCourse->users()->attach($user->id);
+
+    $lesson = Lesson::factory()->create([
+        'course_id' => $primaryCourse->id,
+        'slug' => 'lesson-one',
+    ]);
+    $step = Step::factory()->create([
+        'lesson_id' => $lesson->id,
+        'slug' => 'launch',
+        'order' => 0,
+        'material_type' => null,
+        'material_id' => null,
+    ]);
+
+    $page = app(StepPage::class);
+    $page->course = $primaryCourse->fresh();
+
+    $method = new ReflectionMethod(StepPage::class, 'embeddedCourseExitUrl');
+    $url = $method->invoke($page, $user);
+
+    expect($url)->toBe(Dashboard::getUrl());
+});
+
+test('embedded scorm exit course redirects to course completed when evaluation is finished', function () {
+    $user = CourseEvaluationLmsUser::create([
+        'name' => 'Scorm Completed Exit User',
+        'email' => 'scorm-completed-exit@example.com',
+        'password' => bcrypt('password'),
+    ]);
+
+    $evaluationCourse = Course::factory()->create(['is_private' => true]);
+    $evaluationLesson = Lesson::factory()->create(['course_id' => $evaluationCourse->id]);
+    $evaluationStep = Step::factory()->create(['lesson_id' => $evaluationLesson->id]);
+
+    $primaryCourse = Course::factory()->create([
+        'slug' => 'scorm-finished-training',
+        'embedded_player' => true,
+        'completion_mode' => CompletionMode::Scorm12,
+        'evaluation_course_id' => $evaluationCourse->id,
+        'is_private' => true,
+    ]);
+    $primaryCourse->users()->attach($user->id);
+
+    $lesson = Lesson::factory()->create([
+        'course_id' => $primaryCourse->id,
+        'slug' => 'lesson-one',
+    ]);
+    $step = Step::factory()->create([
+        'lesson_id' => $lesson->id,
+        'slug' => 'launch',
+        'order' => 0,
+        'material_type' => null,
+        'material_id' => null,
+    ]);
+
+    StepUser::create([
+        'user_id' => $user->id,
+        'step_id' => $step->id,
+        'completed_at' => now(),
+    ]);
+
+    $evaluationStep->complete($user, $primaryCourse->id);
+
+    $page = app(StepPage::class);
+    $page->course = $primaryCourse->fresh();
+
+    $method = new ReflectionMethod(StepPage::class, 'embeddedCourseExitUrl');
+    $url = $method->invoke($page, $user);
+
+    expect($url)->toBe(CourseCompleted::getUrl([$primaryCourse->slug]));
 });

--- a/tests/Feature/CourseEvaluationTest.php
+++ b/tests/Feature/CourseEvaluationTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Tapp\FilamentLms\Tests\Feature;
 
+use Livewire\Livewire;
 use Tapp\FilamentFormBuilder\Models\FilamentForm;
 use Tapp\FilamentFormBuilder\Models\FilamentFormField;
 use Tapp\FilamentFormBuilder\Models\FilamentFormUser;
@@ -12,6 +13,7 @@ use Tapp\FilamentLms\Models\Course;
 use Tapp\FilamentLms\Models\Lesson;
 use Tapp\FilamentLms\Models\Step;
 use Tapp\FilamentLms\Models\StepUser;
+use Tapp\FilamentLms\Pages\CourseCompleted;
 use Tapp\FilamentLms\Services\CourseEvaluationService;
 use Tapp\FilamentLms\Tests\TestUser;
 
@@ -135,6 +137,59 @@ test('primary course completion is deferred until evaluation is completed', func
 
     expect($primaryCourse->fresh()->completedByUserAt($user->id))->not->toBeNull()
         ->and($evaluationCourse->fresh()->completedByUserAt($user->id))->not->toBeNull();
+});
+
+test('completed page for evaluation course redirects to primary course certificate page', function () {
+    $user = TestUser::create([
+        'name' => 'Evaluation Certificate User',
+        'email' => 'evaluation-certificate@example.com',
+        'password' => bcrypt('password'),
+    ]);
+
+    $evaluationCourse = Course::factory()->create([
+        'name' => 'Certificate Evaluation',
+        'slug' => 'certificate-evaluation',
+        'external_id' => 'certificate_evaluation',
+        'is_private' => true,
+    ]);
+    $evaluationLesson = Lesson::factory()->create(['course_id' => $evaluationCourse->id]);
+    $evaluationStep = Step::factory()->create(['lesson_id' => $evaluationLesson->id]);
+
+    $primaryCourse = Course::factory()->create([
+        'name' => 'Certificate Training',
+        'slug' => 'certificate-training',
+        'external_id' => 'certificate_training',
+        'evaluation_course_id' => $evaluationCourse->id,
+        'is_private' => true,
+    ]);
+    $primaryCourse->users()->attach($user->id);
+
+    $primaryLesson = Lesson::factory()->create(['course_id' => $primaryCourse->id]);
+    $primaryStep = Step::factory()->create(['lesson_id' => $primaryLesson->id]);
+
+    StepUser::create([
+        'user_id' => $user->id,
+        'step_id' => $primaryStep->id,
+        'completed_at' => now(),
+    ]);
+
+    $primaryCourse->maybeSetCompletedAtForUser($user->id);
+
+    StepUser::create([
+        'user_id' => $user->id,
+        'step_id' => $evaluationStep->id,
+        'completed_at' => now(),
+    ]);
+
+    $evaluationCourse->maybeSetCompletedAtForUser($user->id);
+
+    $this->actingAs($user);
+
+    $response = app(CourseCompleted::class)->mount($evaluationCourse->slug);
+
+    expect($response)
+        ->toBeInstanceOf(\Illuminate\Http\RedirectResponse::class)
+        ->and($response->getTargetUrl())->toBe(CourseCompleted::getUrl([$primaryCourse->slug]));
 });
 
 test('evaluation course is never shown on the dashboard', function () {
@@ -276,7 +331,7 @@ test('evaluation form step hides next button and advances after submit', functio
 
     $this->actingAs($user);
 
-    Livewire\Livewire::test(FormStep::class, ['step' => $evaluationStep])
+    Livewire::test(FormStep::class, ['step' => $evaluationStep])
         ->assertDontSee('Next');
 
     $entry = FilamentFormUser::create([
@@ -287,7 +342,7 @@ test('evaluation form step hides next button and advances after submit', functio
         ],
     ]);
 
-    Livewire\Livewire::test(FormStep::class, ['step' => $evaluationStep])
+    Livewire::test(FormStep::class, ['step' => $evaluationStep])
         ->call('entrySaved', $entry)
         ->assertDispatched('complete-step');
 });
@@ -414,7 +469,7 @@ test('form steps scope submissions per step when the same form is reused', funct
 
     $this->actingAs($user);
 
-    Livewire\Livewire::test(FormStep::class, ['step' => $testStep])
+    Livewire::test(FormStep::class, ['step' => $testStep])
         ->assertSet('entry', null);
 
     $testEntry = FilamentFormUser::create([
@@ -425,7 +480,7 @@ test('form steps scope submissions per step when the same form is reused', funct
         ],
     ]);
 
-    Livewire\Livewire::test(FormStep::class, ['step' => $testStep])
+    Livewire::test(FormStep::class, ['step' => $testStep])
         ->call('entrySaved', $testEntry->id)
         ->assertSet('entry.id', $testEntry->id);
 

--- a/tests/Feature/CourseEvaluationTest.php
+++ b/tests/Feature/CourseEvaluationTest.php
@@ -300,6 +300,60 @@ test('user cannot access evaluation step before primary course is finished', fun
     expect($user->canAccessStep($evaluationStep))->toBeTrue();
 });
 
+test('required test percentage must be met before evaluation is unlocked', function () {
+    $user = TestUser::create([
+        'name' => 'Failed Test User',
+        'email' => 'failed-test-evaluation@example.com',
+        'password' => bcrypt('password'),
+    ]);
+
+    $evaluationCourse = Course::factory()->create(['is_private' => true]);
+    $evaluationLesson = Lesson::factory()->create(['course_id' => $evaluationCourse->id]);
+    $evaluationStep = Step::factory()->create(['lesson_id' => $evaluationLesson->id]);
+
+    $primaryCourse = Course::factory()->create([
+        'evaluation_course_id' => $evaluationCourse->id,
+        'is_private' => true,
+        'required_test_percentage' => 80,
+    ]);
+
+    $primaryCourse->users()->attach($user->id);
+
+    $primaryLesson = Lesson::factory()->create(['course_id' => $primaryCourse->id]);
+    $primaryStep = Step::factory()->create([
+        'lesson_id' => $primaryLesson->id,
+        'material_type' => 'test',
+        'material_id' => null,
+    ]);
+
+    StepUser::create([
+        'user_id' => $user->id,
+        'step_id' => $primaryStep->id,
+        'completed_at' => now(),
+    ]);
+
+    $service = app(CourseEvaluationService::class);
+
+    expect($primaryCourse->allStepsCompletedByUser($user->id))->toBeTrue()
+        ->and($primaryCourse->getOverallTestPercentageForUser($user->id))->toBe(0.0)
+        ->and($service->hasPendingEvaluationForUser($primaryCourse, $user->id))->toBeFalse()
+        ->and($user->canAccessStep($evaluationStep))->toBeFalse();
+
+    $primaryCourse->ensureEvaluationAssigned($user->id);
+
+    expect($evaluationCourse->users()->where('user_id', $user->id)->exists())->toBeFalse();
+
+    $this->actingAs($user);
+
+    $page = app(CourseCompleted::class);
+    $page->mount($primaryCourse->slug);
+
+    expect($page->pendingEvaluation)->toBeFalse()
+        ->and($page->qualifiedForCertificate)->toBeFalse()
+        ->and($page->overallPercent)->toBe(0.0)
+        ->and($page->requiredPercent)->toBe(80);
+});
+
 test('evaluation form step hides next button and advances after submit', function () {
     if (! class_exists(FilamentForm::class)) {
         $this->markTestSkipped('Filament Form Builder is not installed.');

--- a/tests/Feature/CourseEvaluationTest.php
+++ b/tests/Feature/CourseEvaluationTest.php
@@ -414,7 +414,7 @@ test('form steps scope submissions per step when the same form is reused', funct
 
     $this->actingAs($user);
 
-    Livewire\Livewire::test(\Tapp\FilamentLms\Livewire\FormStep::class, ['step' => $testStep])
+    Livewire\Livewire::test(FormStep::class, ['step' => $testStep])
         ->assertSet('entry', null);
 
     $testEntry = FilamentFormUser::create([
@@ -425,7 +425,7 @@ test('form steps scope submissions per step when the same form is reused', funct
         ],
     ]);
 
-    Livewire\Livewire::test(\Tapp\FilamentLms\Livewire\FormStep::class, ['step' => $testStep])
+    Livewire\Livewire::test(FormStep::class, ['step' => $testStep])
         ->call('entrySaved', $testEntry->id)
         ->assertSet('entry.id', $testEntry->id);
 

--- a/tests/Feature/CourseEvaluationTest.php
+++ b/tests/Feature/CourseEvaluationTest.php
@@ -335,3 +335,73 @@ test('completing evaluation form step marks evaluation course complete and final
     expect($primaryCourse->fresh()->completedByUserAt($user->id))->not->toBeNull()
         ->and($evaluationCourse->fresh()->completedByUserAt($user->id))->not->toBeNull();
 });
+
+test('form steps scope submissions per step when the same form is reused', function () {
+    if (! class_exists(FilamentForm::class)) {
+        $this->markTestSkipped('Filament Form Builder is not installed.');
+    }
+
+    $user = TestUser::create([
+        'name' => 'Shared Form User',
+        'email' => 'shared-form-evaluation@example.com',
+        'password' => bcrypt('password'),
+    ]);
+
+    $form = FilamentForm::create([
+        'name' => 'Shared Evaluation Form',
+        'slug' => 'shared-evaluation-form',
+    ]);
+
+    $webdevEvaluation = Course::factory()->create(['is_private' => true, 'name' => 'Webdev Evaluation']);
+    $webdevLesson = Lesson::factory()->create(['course_id' => $webdevEvaluation->id]);
+    $webdevStep = Step::factory()->create([
+        'lesson_id' => $webdevLesson->id,
+        'material_type' => 'form',
+        'material_id' => $form->id,
+    ]);
+
+    $testEvaluation = Course::factory()->create(['is_private' => true, 'name' => 'Test Evaluation']);
+    $testLesson = Lesson::factory()->create(['course_id' => $testEvaluation->id]);
+    $testStep = Step::factory()->create([
+        'lesson_id' => $testLesson->id,
+        'material_type' => 'form',
+        'material_id' => $form->id,
+    ]);
+
+    $webdevEntry = FilamentFormUser::create([
+        'filament_form_id' => $form->id,
+        'user_id' => $user->id,
+        'entry' => [
+            ['field' => 'rating', 'type' => 'Radio', 'answer' => 'Agree'],
+        ],
+    ]);
+
+    StepUser::create([
+        'user_id' => $user->id,
+        'step_id' => $webdevStep->id,
+        'completed_at' => now()->subHour(),
+        'filament_form_user_id' => $webdevEntry->id,
+    ]);
+
+    $this->actingAs($user);
+
+    Livewire\Livewire::test(\Tapp\FilamentLms\Livewire\FormStep::class, ['step' => $testStep])
+        ->assertSet('entry', null);
+
+    $testEntry = FilamentFormUser::create([
+        'filament_form_id' => $form->id,
+        'user_id' => $user->id,
+        'entry' => [
+            ['field' => 'rating', 'type' => 'Radio', 'answer' => 'Disagree'],
+        ],
+    ]);
+
+    Livewire\Livewire::test(\Tapp\FilamentLms\Livewire\FormStep::class, ['step' => $testStep])
+        ->call('entrySaved', $testEntry->id)
+        ->assertSet('entry.id', $testEntry->id);
+
+    expect($webdevStep->fresh()->formEntryForUser($user->id)?->id)->toBe($webdevEntry->id)
+        ->and($testStep->fresh()->formEntryForUser($user->id)?->id)->toBe($testEntry->id)
+        ->and($webdevEntry->fresh()->entry[0]['answer'])->toBe('Agree')
+        ->and($testEntry->fresh()->entry[0]['answer'])->toBe('Disagree');
+});

--- a/tests/Feature/CourseEvaluationTest.php
+++ b/tests/Feature/CourseEvaluationTest.php
@@ -10,6 +10,7 @@ use Livewire\Livewire;
 use Tapp\FilamentFormBuilder\Models\FilamentForm;
 use Tapp\FilamentFormBuilder\Models\FilamentFormField;
 use Tapp\FilamentFormBuilder\Models\FilamentFormUser;
+use Tapp\FilamentLms\Contracts\FilamentLmsUserInterface;
 use Tapp\FilamentLms\Events\CourseCompleted as CourseCompletedEvent;
 use Tapp\FilamentLms\Livewire\FormStep;
 use Tapp\FilamentLms\Models\Course;
@@ -22,6 +23,8 @@ use Tapp\FilamentLms\Services\CourseEvaluationService;
 use Tapp\FilamentLms\Tests\TestFilamentFormShow;
 use Tapp\FilamentLms\Tests\TestFilamentFormUserShow;
 use Tapp\FilamentLms\Tests\TestUser;
+
+class CourseEvaluationLmsUser extends TestUser implements FilamentLmsUserInterface {}
 
 beforeEach(function () {
     config(['filament-lms.evaluations.enabled' => true]);
@@ -252,6 +255,20 @@ test('shared evaluation progress stays scoped to the active primary course', fun
 
     $this->actingAs($user);
 
+    app()->instance('request', \Illuminate\Http\Request::create('/', 'GET', [
+        'primaryCourse' => (string) $secondPrimary->id,
+    ]));
+
+    expect($evaluationStep->fresh()->completed_at)->toBeNull()
+        ->and((float) $evaluationCourse->fresh()->completion_percentage)->toBe(0.0);
+
+    app()->instance('request', \Illuminate\Http\Request::create('/', 'GET', [
+        'primaryCourse' => (string) $firstPrimary->id,
+    ]));
+
+    expect($evaluationStep->fresh()->completed_at)->not->toBeNull()
+        ->and((float) $evaluationCourse->fresh()->completion_percentage)->toBe(100.0);
+
     $expectedSecondEvaluationUrl = StepPage::getUrlForStep($evaluationStep, [
         'primaryCourse' => $secondPrimary->id,
     ]);
@@ -267,6 +284,184 @@ test('shared evaluation progress stays scoped to the active primary course', fun
     expect($response)
         ->toBeInstanceOf(RedirectResponse::class)
         ->and($response->getTargetUrl())->toBe($expectedSecondEvaluationUrl);
+});
+
+test('evaluation step urls preserve requested primary course context', function () {
+    $user = TestUser::create([
+        'name' => 'Evaluation Url User',
+        'email' => 'evaluation-url@example.com',
+        'password' => bcrypt('password'),
+    ]);
+
+    $evaluationCourse = Course::factory()->create([
+        'name' => 'Shared Url Evaluation',
+        'slug' => 'shared-url-evaluation',
+        'external_id' => 'shared_url_evaluation',
+        'is_private' => true,
+    ]);
+    $evaluationLesson = Lesson::factory()->create(['course_id' => $evaluationCourse->id]);
+    $evaluationStep = Step::factory()->create([
+        'lesson_id' => $evaluationLesson->id,
+        'name' => 'Shared Url Evaluation Step',
+        'slug' => 'shared-url-evaluation-step',
+    ]);
+
+    $firstPrimary = Course::factory()->create([
+        'name' => 'First Url Training',
+        'slug' => 'first-url-training',
+        'external_id' => 'first_url_training',
+        'evaluation_course_id' => $evaluationCourse->id,
+        'is_private' => true,
+    ]);
+    $firstPrimary->users()->attach($user->id);
+    $firstLesson = Lesson::factory()->create(['course_id' => $firstPrimary->id]);
+    $firstStep = Step::factory()->create([
+        'lesson_id' => $firstLesson->id,
+        'slug' => 'first-url-step',
+    ]);
+
+    $secondPrimary = Course::factory()->create([
+        'name' => 'Second Url Training',
+        'slug' => 'second-url-training',
+        'external_id' => 'second_url_training',
+        'evaluation_course_id' => $evaluationCourse->id,
+        'is_private' => true,
+    ]);
+    $secondPrimary->users()->attach($user->id);
+    $secondLesson = Lesson::factory()->create(['course_id' => $secondPrimary->id]);
+    $secondStep = Step::factory()->create([
+        'lesson_id' => $secondLesson->id,
+        'slug' => 'second-url-step',
+    ]);
+
+    StepUser::create([
+        'user_id' => $user->id,
+        'step_id' => $firstStep->id,
+        'completed_at' => now(),
+    ]);
+    StepUser::create([
+        'user_id' => $user->id,
+        'step_id' => $secondStep->id,
+        'completed_at' => now(),
+    ]);
+
+    $this->actingAs($user);
+    app()->instance('request', \Illuminate\Http\Request::create('/', 'GET', [
+        'primaryCourse' => (string) $secondPrimary->id,
+    ]));
+
+    $expectedEvaluationUrl = StepPage::getUrl([
+        $evaluationCourse->slug,
+        $evaluationLesson->slug,
+        $evaluationStep->slug,
+        'primaryCourse' => $secondPrimary->id,
+    ]);
+    $expectedPrimaryUrl = StepPage::getUrl([
+        $secondPrimary->slug,
+        $secondLesson->slug,
+        $secondStep->slug,
+    ]);
+
+    expect(app(CourseEvaluationService::class)->activePrimaryCourseForEvaluation($evaluationCourse, $user)?->id)->toBe($firstPrimary->id)
+        ->and(StepPage::getUrlForStep($evaluationStep))->toBe($expectedEvaluationUrl)
+        ->and($evaluationStep->fresh()->url)->toBe($expectedEvaluationUrl)
+        ->and(StepPage::getUrlForStep($secondStep))->toBe($expectedPrimaryUrl)
+        ->and($secondStep->fresh()->url)->toBe($expectedPrimaryUrl);
+});
+
+test('step page uses primary scoped evaluation progress for access checks', function () {
+    $user = CourseEvaluationLmsUser::create([
+        'name' => 'Scoped Step Access User',
+        'email' => 'scoped-step-access@example.com',
+        'password' => bcrypt('password'),
+    ]);
+
+    $evaluationCourse = Course::factory()->create([
+        'name' => 'Scoped Step Access Evaluation',
+        'slug' => 'scoped-step-access-evaluation',
+        'external_id' => 'scoped_step_access_evaluation',
+        'is_private' => true,
+    ]);
+    $evaluationLesson = Lesson::factory()->create([
+        'course_id' => $evaluationCourse->id,
+        'order' => 1,
+    ]);
+    $evaluationStepOne = Step::factory()->create([
+        'lesson_id' => $evaluationLesson->id,
+        'order' => 1,
+        'name' => 'Evaluation Step One',
+        'slug' => 'evaluation-step-one',
+    ]);
+    $evaluationStepTwo = Step::factory()->create([
+        'lesson_id' => $evaluationLesson->id,
+        'order' => 2,
+        'name' => 'Evaluation Step Two',
+        'slug' => 'evaluation-step-two',
+    ]);
+
+    $firstPrimary = Course::factory()->create([
+        'name' => 'First Step Access Training',
+        'slug' => 'first-step-access-training',
+        'external_id' => 'first_step_access_training',
+        'evaluation_course_id' => $evaluationCourse->id,
+        'is_private' => true,
+    ]);
+    $firstPrimary->users()->attach($user->id);
+    $firstLesson = Lesson::factory()->create(['course_id' => $firstPrimary->id]);
+    $firstStep = Step::factory()->create(['lesson_id' => $firstLesson->id]);
+
+    $secondPrimary = Course::factory()->create([
+        'name' => 'Second Step Access Training',
+        'slug' => 'second-step-access-training',
+        'external_id' => 'second_step_access_training',
+        'evaluation_course_id' => $evaluationCourse->id,
+        'is_private' => true,
+    ]);
+    $secondPrimary->users()->attach($user->id);
+    $secondLesson = Lesson::factory()->create(['course_id' => $secondPrimary->id]);
+    $secondStep = Step::factory()->create(['lesson_id' => $secondLesson->id]);
+
+    StepUser::create([
+        'user_id' => $user->id,
+        'step_id' => $firstStep->id,
+        'completed_at' => now(),
+    ]);
+    StepUser::create([
+        'user_id' => $user->id,
+        'step_id' => $secondStep->id,
+        'completed_at' => now(),
+    ]);
+    StepUser::create([
+        'user_id' => $user->id,
+        'step_id' => $evaluationStepOne->id,
+        'evaluation_primary_course_id' => $secondPrimary->id,
+        'completed_at' => now()->subMinute(),
+        'created_at' => now()->subMinute(),
+    ]);
+    StepUser::create([
+        'user_id' => $user->id,
+        'step_id' => $evaluationStepOne->id,
+        'evaluation_primary_course_id' => $firstPrimary->id,
+        'completed_at' => null,
+        'created_at' => now(),
+    ]);
+
+    \Illuminate\Support\Facades\Auth::login($user);
+    app()->instance('request', \Illuminate\Http\Request::create('/', 'GET', [
+        'primaryCourse' => (string) $secondPrimary->id,
+    ]));
+
+    $evaluationService = app(CourseEvaluationService::class);
+
+    expect($evaluationService->activePrimaryCourseForEvaluation($evaluationCourse, $user, $secondPrimary->id)?->id)->toBe($secondPrimary->id)
+        ->and($evaluationService->evaluationStepAvailableForPrimary($evaluationStepTwo, $user->id, $secondPrimary->id))->toBeTrue()
+        ->and($user->canAccessStep($evaluationStepTwo))->toBeTrue();
+
+    $page = app(StepPage::class);
+    $response = $page->mount($evaluationCourse->slug, $evaluationLesson->slug, $evaluationStepTwo->slug);
+
+    expect($response)->toBeNull()
+        ->and($page->evaluationPrimaryCourseId)->toBe($secondPrimary->id);
 });
 
 test('shared evaluation completed page redirect uses the most recently completed primary course', function () {

--- a/tests/Feature/CourseEvaluationTest.php
+++ b/tests/Feature/CourseEvaluationTest.php
@@ -191,6 +191,59 @@ test('shared evaluation course requires a separate evaluation completion for eac
         ->and($secondPrimary->fresh()->evaluationCompletedByUser($user->id))->toBeTrue();
 });
 
+test('shared evaluation completed page redirect uses the most recently completed primary course', function () {
+    $user = TestUser::create([
+        'name' => 'Shared Evaluation Redirect User',
+        'email' => 'shared-evaluation-redirect@example.com',
+        'password' => bcrypt('password'),
+    ]);
+
+    $evaluationCourse = Course::factory()->create([
+        'name' => 'Shared Redirect Evaluation',
+        'slug' => 'shared-redirect-evaluation',
+        'external_id' => 'shared_redirect_evaluation',
+        'is_private' => true,
+    ]);
+    $evaluationLesson = Lesson::factory()->create(['course_id' => $evaluationCourse->id]);
+    $evaluationStep = Step::factory()->create(['lesson_id' => $evaluationLesson->id]);
+
+    $firstPrimary = Course::factory()->create([
+        'name' => 'First Shared Redirect Training',
+        'slug' => 'first-shared-redirect-training',
+        'external_id' => 'first_shared_redirect_training',
+        'evaluation_course_id' => $evaluationCourse->id,
+        'is_private' => true,
+    ]);
+    $firstPrimary->users()->attach($user->id);
+    $firstLesson = Lesson::factory()->create(['course_id' => $firstPrimary->id]);
+    $firstStep = Step::factory()->create(['lesson_id' => $firstLesson->id]);
+
+    $secondPrimary = Course::factory()->create([
+        'name' => 'Second Shared Redirect Training',
+        'slug' => 'second-shared-redirect-training',
+        'external_id' => 'second_shared_redirect_training',
+        'evaluation_course_id' => $evaluationCourse->id,
+        'is_private' => true,
+    ]);
+    $secondPrimary->users()->attach($user->id);
+    $secondLesson = Lesson::factory()->create(['course_id' => $secondPrimary->id]);
+    $secondStep = Step::factory()->create(['lesson_id' => $secondLesson->id]);
+
+    $firstStep->complete($user);
+    $evaluationStep->complete($user, $firstPrimary->id);
+
+    $secondStep->complete($user);
+    $evaluationStep->complete($user, $secondPrimary->id);
+
+    $this->actingAs($user);
+
+    $response = app(CourseCompleted::class)->mount($evaluationCourse->slug);
+
+    expect($response)
+        ->toBeInstanceOf(RedirectResponse::class)
+        ->and($response->getTargetUrl())->toBe(CourseCompleted::getUrl([$secondPrimary->slug]));
+});
+
 test('completed page for evaluation course redirects to primary course certificate page', function () {
     $user = TestUser::create([
         'name' => 'Evaluation Certificate User',

--- a/tests/Feature/CourseEvaluationTest.php
+++ b/tests/Feature/CourseEvaluationTest.php
@@ -11,10 +11,38 @@ use Tapp\FilamentLms\Models\Course;
 use Tapp\FilamentLms\Models\Lesson;
 use Tapp\FilamentLms\Models\Step;
 use Tapp\FilamentLms\Models\StepUser;
+use Tapp\FilamentLms\Services\CourseEvaluationService;
 use Tapp\FilamentLms\Tests\TestUser;
 
 beforeEach(function () {
     config(['filament-lms.evaluations.enabled' => true]);
+});
+
+test('evaluation link validation rejects public courses and backwards configuration', function () {
+    $trainingCourse = Course::factory()->create(['is_private' => false]);
+    $evaluationCourse = Course::factory()->create(['is_private' => true]);
+
+    $service = app(CourseEvaluationService::class);
+
+    expect($service->canLinkEvaluationCourse($trainingCourse, $evaluationCourse))->toBeTrue()
+        ->and($service->canLinkEvaluationCourse($evaluationCourse, $trainingCourse))->toBeFalse()
+        ->and($service->canLinkEvaluationCourse($trainingCourse, $trainingCourse))->toBeFalse();
+});
+
+test('canSelectEvaluationCourse validates evaluation targets on create', function () {
+    $service = app(CourseEvaluationService::class);
+
+    $validTarget = Course::factory()->create(['is_private' => true]);
+    $publicCourse = Course::factory()->create(['is_private' => false]);
+    $nestedEvaluation = Course::factory()->create([
+        'is_private' => true,
+        'evaluation_course_id' => Course::factory()->create(['is_private' => true])->id,
+    ]);
+
+    expect($service->canSelectEvaluationCourse(null))->toBeTrue()
+        ->and($service->canSelectEvaluationCourse($validTarget))->toBeTrue()
+        ->and($service->canSelectEvaluationCourse($publicCourse))->toBeFalse()
+        ->and($service->canSelectEvaluationCourse($nestedEvaluation))->toBeFalse();
 });
 
 test('primary course completion is deferred until evaluation is completed', function () {

--- a/tests/Feature/CourseEvaluationTest.php
+++ b/tests/Feature/CourseEvaluationTest.php
@@ -17,6 +17,7 @@ use Tapp\FilamentLms\Models\Lesson;
 use Tapp\FilamentLms\Models\Step;
 use Tapp\FilamentLms\Models\StepUser;
 use Tapp\FilamentLms\Pages\CourseCompleted;
+use Tapp\FilamentLms\Pages\Step as StepPage;
 use Tapp\FilamentLms\Services\CourseEvaluationService;
 use Tapp\FilamentLms\Tests\TestUser;
 
@@ -453,6 +454,57 @@ test('completing evaluation form step marks evaluation course complete and final
 
     expect($primaryCourse->fresh()->completedByUserAt($user->id))->not->toBeNull()
         ->and($evaluationCourse->fresh()->completedByUserAt($user->id))->not->toBeNull();
+});
+
+test('evaluation redirect does not emit duplicate course completed events after form completion', function () {
+    $user = TestUser::create([
+        'name' => 'Duplicate Event User',
+        'email' => 'duplicate-event-evaluation@example.com',
+        'password' => bcrypt('password'),
+    ]);
+
+    $evaluationCourse = Course::factory()->create(['is_private' => true]);
+    $evaluationLesson = Lesson::factory()->create(['course_id' => $evaluationCourse->id]);
+    $evaluationStep = Step::factory()->create(['lesson_id' => $evaluationLesson->id]);
+
+    $primaryCourse = Course::factory()->create([
+        'evaluation_course_id' => $evaluationCourse->id,
+        'is_private' => true,
+    ]);
+
+    $primaryCourse->users()->attach($user->id);
+
+    $primaryLesson = Lesson::factory()->create(['course_id' => $primaryCourse->id]);
+    $primaryStep = Step::factory()->create(['lesson_id' => $primaryLesson->id]);
+
+    StepUser::create([
+        'user_id' => $user->id,
+        'step_id' => $primaryStep->id,
+        'completed_at' => now(),
+    ]);
+
+    $primaryCourse->maybeSetCompletedAtForUser($user->id);
+
+    $this->actingAs($user);
+
+    Event::fake([CourseCompletedEvent::class]);
+
+    $evaluationStep->complete($user);
+
+    Event::assertDispatchedTimes(CourseCompletedEvent::class, 2);
+
+    $page = app(StepPage::class);
+    $page->course = $evaluationCourse->fresh();
+    $page->course->loadProgress();
+    $page->lesson = $page->course->lessons->first();
+    $page->step = $page->lesson->steps->first();
+
+    $response = $page->complete(false);
+
+    expect($response)
+        ->toBeInstanceOf(RedirectResponse::class);
+
+    Event::assertDispatchedTimes(CourseCompletedEvent::class, 2);
 });
 
 test('form steps scope submissions per step when the same form is reused', function () {

--- a/tests/Feature/CourseEvaluationTest.php
+++ b/tests/Feature/CourseEvaluationTest.php
@@ -127,7 +127,7 @@ test('primary course completion is deferred until evaluation is completed', func
     expect($primaryCourse->fresh()->completedByUserAt($user->id))->toBeNull()
         ->and($evaluationCourse->users()->where('user_id', $user->id)->exists())->toBeTrue();
 
-    $evaluationStep->complete($user);
+    $evaluationStep->complete($user, $primaryCourse->id);
 
     Event::assertDispatched(CourseCompletedEvent::class, function (CourseCompletedEvent $event) use ($user, $primaryCourse): bool {
         return $event->user->is($user) && $event->course->is($primaryCourse);
@@ -135,6 +135,60 @@ test('primary course completion is deferred until evaluation is completed', func
 
     expect($primaryCourse->fresh()->completedByUserAt($user->id))->not->toBeNull()
         ->and($evaluationCourse->fresh()->completedByUserAt($user->id))->not->toBeNull();
+});
+
+test('shared evaluation course requires a separate evaluation completion for each primary course', function () {
+    $user = TestUser::create([
+        'name' => 'Shared Evaluation User',
+        'email' => 'shared-evaluation@example.com',
+        'password' => bcrypt('password'),
+    ]);
+
+    $evaluationCourse = Course::factory()->create(['is_private' => true]);
+    $evaluationLesson = Lesson::factory()->create(['course_id' => $evaluationCourse->id]);
+    $evaluationStep = Step::factory()->create(['lesson_id' => $evaluationLesson->id]);
+
+    $firstPrimary = Course::factory()->create([
+        'evaluation_course_id' => $evaluationCourse->id,
+        'is_private' => true,
+    ]);
+    $firstPrimary->users()->attach($user->id);
+    $firstLesson = Lesson::factory()->create(['course_id' => $firstPrimary->id]);
+    $firstStep = Step::factory()->create(['lesson_id' => $firstLesson->id]);
+
+    $secondPrimary = Course::factory()->create([
+        'evaluation_course_id' => $evaluationCourse->id,
+        'is_private' => true,
+    ]);
+    $secondPrimary->users()->attach($user->id);
+    $secondLesson = Lesson::factory()->create(['course_id' => $secondPrimary->id]);
+    $secondStep = Step::factory()->create(['lesson_id' => $secondLesson->id]);
+
+    Event::fake([CourseCompletedEvent::class]);
+
+    $firstStep->complete($user);
+    $evaluationStep->complete($user, $firstPrimary->id);
+
+    expect($firstPrimary->fresh()->completedByUserAt($user->id))->not->toBeNull()
+        ->and($firstPrimary->fresh()->evaluationCompletedByUser($user->id))->toBeTrue()
+        ->and($secondPrimary->fresh()->evaluationCompletedByUser($user->id))->toBeFalse();
+
+    $secondStep->complete($user);
+
+    Event::assertNotDispatched(CourseCompletedEvent::class, function (CourseCompletedEvent $event) use ($secondPrimary): bool {
+        return $event->course->is($secondPrimary);
+    });
+
+    expect($secondPrimary->fresh()->completedByUserAt($user->id))->toBeNull();
+
+    $evaluationStep->complete($user, $secondPrimary->id);
+
+    Event::assertDispatched(CourseCompletedEvent::class, function (CourseCompletedEvent $event) use ($user, $secondPrimary): bool {
+        return $event->user->is($user) && $event->course->is($secondPrimary);
+    });
+
+    expect($secondPrimary->fresh()->completedByUserAt($user->id))->not->toBeNull()
+        ->and($secondPrimary->fresh()->evaluationCompletedByUser($user->id))->toBeTrue();
 });
 
 test('completed page for evaluation course redirects to primary course certificate page', function () {
@@ -176,6 +230,7 @@ test('completed page for evaluation course redirects to primary course certifica
     StepUser::create([
         'user_id' => $user->id,
         'step_id' => $evaluationStep->id,
+        'evaluation_primary_course_id' => $primaryCourse->id,
         'completed_at' => now(),
     ]);
 
@@ -466,7 +521,7 @@ test('completing evaluation form step marks evaluation course complete and final
         ],
     ]);
 
-    $evaluationStep->complete($user);
+    $evaluationStep->complete($user, $primaryCourse->id);
 
     expect($primaryCourse->fresh()->completedByUserAt($user->id))->not->toBeNull()
         ->and($evaluationCourse->fresh()->completedByUserAt($user->id))->not->toBeNull();
@@ -505,7 +560,7 @@ test('evaluation redirect does not emit duplicate course completed events after 
 
     Event::fake([CourseCompletedEvent::class]);
 
-    $evaluationStep->complete($user);
+    $evaluationStep->complete($user, $primaryCourse->id);
 
     Event::assertDispatchedTimes(CourseCompletedEvent::class, 2);
 

--- a/tests/Feature/CourseEvaluationTest.php
+++ b/tests/Feature/CourseEvaluationTest.php
@@ -1,0 +1,337 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tapp\FilamentLms\Tests\Feature;
+
+use Tapp\FilamentFormBuilder\Models\FilamentForm;
+use Tapp\FilamentFormBuilder\Models\FilamentFormField;
+use Tapp\FilamentFormBuilder\Models\FilamentFormUser;
+use Tapp\FilamentLms\Models\Course;
+use Tapp\FilamentLms\Models\Lesson;
+use Tapp\FilamentLms\Models\Step;
+use Tapp\FilamentLms\Models\StepUser;
+use Tapp\FilamentLms\Tests\TestUser;
+
+beforeEach(function () {
+    config(['filament-lms.evaluations.enabled' => true]);
+});
+
+test('primary course completion is deferred until evaluation is completed', function () {
+    if (! class_exists(FilamentForm::class)) {
+        $this->markTestSkipped('Filament Form Builder is not installed.');
+    }
+
+    $user = TestUser::create([
+        'name' => 'Test User',
+        'email' => 'evaluation-test@example.com',
+        'password' => bcrypt('password'),
+    ]);
+
+    $form = FilamentForm::create([
+        'name' => 'Evaluation Form',
+        'slug' => 'evaluation-form',
+    ]);
+
+    FilamentFormField::create([
+        'filament_form_id' => $form->id,
+        'field' => 'feedback',
+        'label' => 'Feedback',
+        'type' => 'TEXTAREA',
+        'required' => true,
+        'order' => 1,
+    ]);
+
+    $evaluationCourse = Course::factory()->create([
+        'name' => 'Training Evaluation',
+        'slug' => 'training-evaluation',
+        'external_id' => 'training_evaluation',
+        'is_private' => true,
+    ]);
+
+    $evaluationLesson = Lesson::factory()->create([
+        'course_id' => $evaluationCourse->id,
+        'order' => 1,
+    ]);
+
+    Step::factory()->create([
+        'lesson_id' => $evaluationLesson->id,
+        'order' => 1,
+        'name' => 'Evaluation',
+        'slug' => 'evaluation',
+        'material_type' => 'form',
+        'material_id' => $form->id,
+    ]);
+
+    $primaryCourse = Course::factory()->create([
+        'name' => 'Primary Training',
+        'slug' => 'primary-training',
+        'external_id' => 'primary_training',
+        'evaluation_course_id' => $evaluationCourse->id,
+        'is_private' => true,
+    ]);
+
+    $primaryCourse->users()->attach($user->id);
+
+    $primaryLesson = Lesson::factory()->create([
+        'course_id' => $primaryCourse->id,
+        'order' => 1,
+    ]);
+
+    $primaryStep = Step::factory()->create([
+        'lesson_id' => $primaryLesson->id,
+        'order' => 1,
+        'name' => 'Lesson Step',
+        'slug' => 'lesson-step',
+    ]);
+
+    StepUser::create([
+        'user_id' => $user->id,
+        'step_id' => $primaryStep->id,
+        'completed_at' => now(),
+    ]);
+
+    $primaryCourse->maybeSetCompletedAtForUser($user->id);
+
+    expect($primaryCourse->fresh()->completedByUserAt($user->id))->toBeNull()
+        ->and($evaluationCourse->users()->where('user_id', $user->id)->exists())->toBeTrue();
+
+    StepUser::create([
+        'user_id' => $user->id,
+        'step_id' => $evaluationCourse->steps()->first()->id,
+        'completed_at' => now(),
+    ]);
+
+    $evaluationCourse->maybeSetCompletedAtForUser($user->id);
+
+    expect($primaryCourse->fresh()->completedByUserAt($user->id))->not->toBeNull()
+        ->and($evaluationCourse->fresh()->completedByUserAt($user->id))->not->toBeNull();
+});
+
+test('evaluation course is never shown on the dashboard', function () {
+    $user = TestUser::create([
+        'name' => 'Dashboard User',
+        'email' => 'dashboard-evaluation@example.com',
+        'password' => bcrypt('password'),
+    ]);
+
+    $evaluationCourse = Course::factory()->create([
+        'name' => 'Hidden Evaluation',
+        'slug' => 'hidden-evaluation',
+        'external_id' => 'hidden_evaluation',
+        'is_private' => true,
+    ]);
+
+    $evaluationLesson = Lesson::factory()->create(['course_id' => $evaluationCourse->id]);
+    Step::factory()->create(['lesson_id' => $evaluationLesson->id]);
+
+    $primaryCourse = Course::factory()->create([
+        'evaluation_course_id' => $evaluationCourse->id,
+        'is_private' => true,
+    ]);
+
+    $primaryCourse->users()->attach($user->id);
+    $evaluationCourse->users()->attach($user->id);
+
+    $primaryLesson = Lesson::factory()->create(['course_id' => $primaryCourse->id]);
+    $primaryStep = Step::factory()->create(['lesson_id' => $primaryLesson->id]);
+
+    expect(Course::accessibleTo($user)->pluck('id'))->not->toContain($evaluationCourse->id);
+
+    StepUser::create([
+        'user_id' => $user->id,
+        'step_id' => $primaryStep->id,
+        'completed_at' => now(),
+    ]);
+
+    expect(Course::accessibleTo($user)->pluck('id'))->not->toContain($evaluationCourse->id)
+        ->and(Course::accessibleTo($user)->pluck('id'))->toContain($primaryCourse->id);
+});
+
+test('public primary course unlocks evaluation without enrollment on the training course', function () {
+    $user = TestUser::create([
+        'name' => 'Public Primary User',
+        'email' => 'public-primary-evaluation@example.com',
+        'password' => bcrypt('password'),
+    ]);
+
+    $evaluationCourse = Course::factory()->create(['is_private' => true]);
+    $evaluationLesson = Lesson::factory()->create(['course_id' => $evaluationCourse->id]);
+    $evaluationStep = Step::factory()->create(['lesson_id' => $evaluationLesson->id]);
+
+    $primaryCourse = Course::factory()->create([
+        'evaluation_course_id' => $evaluationCourse->id,
+        'is_private' => false,
+    ]);
+
+    $primaryLesson = Lesson::factory()->create(['course_id' => $primaryCourse->id]);
+    $primaryStep = Step::factory()->create(['lesson_id' => $primaryLesson->id]);
+
+    expect($primaryCourse->users()->where('user_id', $user->id)->exists())->toBeFalse()
+        ->and($user->canAccessStep($evaluationStep))->toBeFalse();
+
+    StepUser::create([
+        'user_id' => $user->id,
+        'step_id' => $primaryStep->id,
+        'completed_at' => now(),
+    ]);
+
+    $primaryCourse->maybeSetCompletedAtForUser($user->id);
+
+    expect($user->canAccessStep($evaluationStep))->toBeTrue()
+        ->and($evaluationCourse->users()->where('user_id', $user->id)->exists())->toBeTrue()
+        ->and(Course::accessibleTo($user)->pluck('id'))->not->toContain($evaluationCourse->id);
+});
+
+test('user cannot access evaluation step before primary course is finished', function () {
+    $user = TestUser::create([
+        'name' => 'Locked User',
+        'email' => 'locked-evaluation@example.com',
+        'password' => bcrypt('password'),
+    ]);
+
+    $evaluationCourse = Course::factory()->create(['is_private' => true]);
+    $evaluationLesson = Lesson::factory()->create(['course_id' => $evaluationCourse->id]);
+    $evaluationStep = Step::factory()->create(['lesson_id' => $evaluationLesson->id]);
+
+    $primaryCourse = Course::factory()->create([
+        'evaluation_course_id' => $evaluationCourse->id,
+        'is_private' => true,
+    ]);
+
+    $primaryCourse->users()->attach($user->id);
+    $evaluationCourse->users()->attach($user->id);
+
+    expect($user->canAccessStep($evaluationStep))->toBeFalse();
+
+    $primaryLesson = Lesson::factory()->create(['course_id' => $primaryCourse->id]);
+    $primaryStep = Step::factory()->create(['lesson_id' => $primaryLesson->id]);
+
+    StepUser::create([
+        'user_id' => $user->id,
+        'step_id' => $primaryStep->id,
+        'completed_at' => now(),
+    ]);
+
+    expect($user->canAccessStep($evaluationStep))->toBeTrue();
+});
+
+test('evaluation form step hides next button and advances after submit', function () {
+    if (! class_exists(FilamentForm::class)) {
+        $this->markTestSkipped('Filament Form Builder is not installed.');
+    }
+
+    $user = TestUser::create([
+        'name' => 'Form Next User',
+        'email' => 'form-next-evaluation@example.com',
+        'password' => bcrypt('password'),
+    ]);
+
+    $form = FilamentForm::create([
+        'name' => 'Evaluation Form Next',
+        'slug' => 'form-evaluation-next',
+    ]);
+
+    $evaluationCourse = Course::factory()->create(['is_private' => true]);
+    $evaluationLesson = Lesson::factory()->create(['course_id' => $evaluationCourse->id]);
+    $evaluationStep = Step::factory()->create([
+        'lesson_id' => $evaluationLesson->id,
+        'material_type' => 'form',
+        'material_id' => $form->id,
+    ]);
+
+    Course::factory()->create([
+        'evaluation_course_id' => $evaluationCourse->id,
+        'is_private' => false,
+    ]);
+
+    $this->actingAs($user);
+
+    Livewire\Livewire::test(\Tapp\FilamentLms\Livewire\FormStep::class, ['step' => $evaluationStep])
+        ->assertDontSee('Next');
+
+    $entry = FilamentFormUser::create([
+        'filament_form_id' => $form->id,
+        'user_id' => $user->id,
+        'entry' => [
+            ['field' => 'feedback', 'type' => 'Textarea', 'answer' => 'Great course'],
+        ],
+    ]);
+
+    Livewire\Livewire::test(\Tapp\FilamentLms\Livewire\FormStep::class, ['step' => $evaluationStep])
+        ->call('entrySaved', $entry)
+        ->assertDispatched('complete-step');
+});
+
+test('primary course without evaluation has no evaluation submission url', function () {
+    $primaryCourse = Course::factory()->create();
+
+    expect($primaryCourse->evaluationSubmissionUrl())->toBeNull();
+});
+
+test('completing evaluation form step marks evaluation course complete and finalizes primary course', function () {
+    if (! class_exists(FilamentForm::class)) {
+        $this->markTestSkipped('Filament Form Builder is not installed.');
+    }
+
+    $user = TestUser::create([
+        'name' => 'Form User',
+        'email' => 'form-evaluation@example.com',
+        'password' => bcrypt('password'),
+    ]);
+
+    $form = FilamentForm::create([
+        'name' => 'Evaluation Form',
+        'slug' => 'form-evaluation',
+    ]);
+
+    FilamentFormField::create([
+        'filament_form_id' => $form->id,
+        'field' => 'feedback',
+        'label' => 'Feedback',
+        'type' => 'TEXTAREA',
+        'required' => true,
+        'order' => 1,
+    ]);
+
+    $evaluationCourse = Course::factory()->create(['is_private' => true]);
+    $evaluationLesson = Lesson::factory()->create(['course_id' => $evaluationCourse->id]);
+    $evaluationStep = Step::factory()->create([
+        'lesson_id' => $evaluationLesson->id,
+        'material_type' => 'form',
+        'material_id' => $form->id,
+    ]);
+
+    $primaryCourse = Course::factory()->create([
+        'evaluation_course_id' => $evaluationCourse->id,
+        'is_private' => true,
+    ]);
+
+    $primaryCourse->users()->attach($user->id);
+
+    $primaryLesson = Lesson::factory()->create(['course_id' => $primaryCourse->id]);
+    $primaryStep = Step::factory()->create(['lesson_id' => $primaryLesson->id]);
+
+    StepUser::create([
+        'user_id' => $user->id,
+        'step_id' => $primaryStep->id,
+        'completed_at' => now(),
+    ]);
+
+    $primaryCourse->maybeSetCompletedAtForUser($user->id);
+
+    $this->actingAs($user);
+
+    FilamentFormUser::create([
+        'filament_form_id' => $form->id,
+        'user_id' => $user->id,
+        'entry' => [
+            ['field' => 'feedback', 'type' => 'Textarea', 'answer' => 'Great course'],
+        ],
+    ]);
+
+    $evaluationStep->complete($user);
+
+    expect($primaryCourse->fresh()->completedByUserAt($user->id))->not->toBeNull()
+        ->and($evaluationCourse->fresh()->completedByUserAt($user->id))->not->toBeNull();
+});

--- a/tests/Feature/CourseEvaluationTest.php
+++ b/tests/Feature/CourseEvaluationTest.php
@@ -23,6 +23,8 @@ use Tapp\FilamentLms\Tests\TestFilamentFormShow;
 use Tapp\FilamentLms\Tests\TestFilamentFormUserShow;
 use Tapp\FilamentLms\Tests\TestUser;
 
+use function Livewire\store;
+
 beforeEach(function () {
     config(['filament-lms.evaluations.enabled' => true]);
 
@@ -577,17 +579,14 @@ test('only evaluation form steps allow multiple submissions', function () {
 
     $this->actingAs($user);
 
-    TestFilamentFormShow::resetLastAllowMultipleSubmissions();
+    $trainingComponent = app(FormStep::class);
+    $trainingComponent->mount($trainingStep);
 
-    Livewire::test(FormStep::class, ['step' => $trainingStep]);
+    $evaluationComponent = app(FormStep::class);
+    $evaluationComponent->mount($evaluationStep);
 
-    expect(TestFilamentFormShow::$lastAllowMultipleSubmissions)->toBeFalse();
-
-    TestFilamentFormShow::resetLastAllowMultipleSubmissions();
-
-    Livewire::test(FormStep::class, ['step' => $evaluationStep]);
-
-    expect(TestFilamentFormShow::$lastAllowMultipleSubmissions)->toBeTrue();
+    expect($trainingComponent->formComponentParameters()['allowMultipleSubmissions'])->toBeFalse()
+        ->and($evaluationComponent->formComponentParameters()['allowMultipleSubmissions'])->toBeTrue();
 });
 
 test('evaluation form step hides next button and advances after submit', function () {
@@ -621,8 +620,10 @@ test('evaluation form step hides next button and advances after submit', functio
 
     $this->actingAs($user);
 
-    Livewire::test(FormStep::class, ['step' => $evaluationStep])
-        ->assertDontSee('Next');
+    $component = app(FormStep::class);
+    $component->mount($evaluationStep);
+
+    expect($component->shouldShowNextButton())->toBeFalse();
 
     $entry = FilamentFormUser::create([
         'filament_form_id' => $form->id,
@@ -632,9 +633,12 @@ test('evaluation form step hides next button and advances after submit', functio
         ],
     ]);
 
-    Livewire::test(FormStep::class, ['step' => $evaluationStep])
-        ->call('entrySaved', $entry)
-        ->assertDispatched('complete-step');
+    $component->entrySaved($entry);
+
+    $dispatchedEvents = collect(store($component)->get('dispatched', []))
+        ->map(fn ($event) => $event->serialize()['name']);
+
+    expect($dispatchedEvents)->toContain('complete-step');
 });
 
 test('primary course without evaluation has no evaluation submission url', function () {
@@ -810,8 +814,10 @@ test('form steps scope submissions per step when the same form is reused', funct
 
     $this->actingAs($user);
 
-    Livewire::test(FormStep::class, ['step' => $testStep])
-        ->assertSet('entry', null);
+    $component = app(FormStep::class);
+    $component->mount($testStep);
+
+    expect($component->entry)->toBeNull();
 
     $testEntry = FilamentFormUser::create([
         'filament_form_id' => $form->id,
@@ -821,9 +827,9 @@ test('form steps scope submissions per step when the same form is reused', funct
         ],
     ]);
 
-    Livewire::test(FormStep::class, ['step' => $testStep])
-        ->call('entrySaved', $testEntry->id)
-        ->assertSet('entry.id', $testEntry->id);
+    $component->entrySaved($testEntry->id);
+
+    expect($component->entry?->id)->toBe($testEntry->id);
 
     expect($webdevStep->fresh()->formEntryForUser($user->id)?->id)->toBe($webdevEntry->id)
         ->and($testStep->fresh()->formEntryForUser($user->id)?->id)->toBe($testEntry->id)

--- a/tests/Feature/CourseEvaluationTest.php
+++ b/tests/Feature/CourseEvaluationTest.php
@@ -460,6 +460,58 @@ test('required test percentage must be met before evaluation is unlocked', funct
         ->and($page->requiredPercent)->toBe(80);
 });
 
+test('only evaluation form steps allow multiple submissions', function () {
+    if (! class_exists(FilamentForm::class)) {
+        $this->markTestSkipped('Filament Form Builder is not installed.');
+    }
+
+    $user = TestUser::create([
+        'name' => 'Multiple Submission User',
+        'email' => 'multiple-submission-evaluation@example.com',
+        'password' => bcrypt('password'),
+    ]);
+
+    $form = FilamentForm::create([
+        'name' => 'Multiple Submission Form',
+        'slug' => 'multiple-submission-form',
+    ]);
+
+    $trainingCourse = Course::factory()->create(['is_private' => false]);
+    $trainingLesson = Lesson::factory()->create(['course_id' => $trainingCourse->id]);
+    $trainingStep = Step::factory()->create([
+        'lesson_id' => $trainingLesson->id,
+        'material_type' => 'form',
+        'material_id' => $form->id,
+    ]);
+
+    $evaluationCourse = Course::factory()->create(['is_private' => true]);
+    $evaluationLesson = Lesson::factory()->create(['course_id' => $evaluationCourse->id]);
+    $evaluationStep = Step::factory()->create([
+        'lesson_id' => $evaluationLesson->id,
+        'material_type' => 'form',
+        'material_id' => $form->id,
+    ]);
+
+    Course::factory()->create([
+        'evaluation_course_id' => $evaluationCourse->id,
+        'is_private' => false,
+    ]);
+
+    $this->actingAs($user);
+
+    TestFilamentFormShow::resetLastAllowMultipleSubmissions();
+
+    Livewire::test(FormStep::class, ['step' => $trainingStep]);
+
+    expect(TestFilamentFormShow::$lastAllowMultipleSubmissions)->toBeFalse();
+
+    TestFilamentFormShow::resetLastAllowMultipleSubmissions();
+
+    Livewire::test(FormStep::class, ['step' => $evaluationStep]);
+
+    expect(TestFilamentFormShow::$lastAllowMultipleSubmissions)->toBeTrue();
+});
+
 test('evaluation form step hides next button and advances after submit', function () {
     if (! class_exists(FilamentForm::class)) {
         $this->markTestSkipped('Filament Form Builder is not installed.');

--- a/tests/Feature/CourseEvaluationTest.php
+++ b/tests/Feature/CourseEvaluationTest.php
@@ -191,6 +191,84 @@ test('shared evaluation course requires a separate evaluation completion for eac
         ->and($secondPrimary->fresh()->evaluationCompletedByUser($user->id))->toBeTrue();
 });
 
+test('shared evaluation progress stays scoped to the active primary course', function () {
+    $user = TestUser::create([
+        'name' => 'Scoped Evaluation User',
+        'email' => 'scoped-evaluation@example.com',
+        'password' => bcrypt('password'),
+    ]);
+
+    $evaluationCourse = Course::factory()->create([
+        'name' => 'Scoped Shared Evaluation',
+        'slug' => 'scoped-shared-evaluation',
+        'external_id' => 'scoped_shared_evaluation',
+        'is_private' => true,
+    ]);
+    $evaluationLesson = Lesson::factory()->create(['course_id' => $evaluationCourse->id]);
+    $evaluationStep = Step::factory()->create([
+        'lesson_id' => $evaluationLesson->id,
+        'name' => 'Scoped Evaluation Step',
+        'slug' => 'scoped-evaluation-step',
+    ]);
+
+    $firstPrimary = Course::factory()->create([
+        'name' => 'First Scoped Training',
+        'slug' => 'first-scoped-training',
+        'external_id' => 'first_scoped_training',
+        'evaluation_course_id' => $evaluationCourse->id,
+        'is_private' => true,
+    ]);
+    $firstPrimary->users()->attach($user->id);
+    $firstLesson = Lesson::factory()->create(['course_id' => $firstPrimary->id]);
+    $firstStep = Step::factory()->create(['lesson_id' => $firstLesson->id]);
+
+    $secondPrimary = Course::factory()->create([
+        'name' => 'Second Scoped Training',
+        'slug' => 'second-scoped-training',
+        'external_id' => 'second_scoped_training',
+        'evaluation_course_id' => $evaluationCourse->id,
+        'is_private' => true,
+    ]);
+    $secondPrimary->users()->attach($user->id);
+    $secondLesson = Lesson::factory()->create(['course_id' => $secondPrimary->id]);
+    $secondStep = Step::factory()->create(['lesson_id' => $secondLesson->id]);
+
+    StepUser::create([
+        'user_id' => $user->id,
+        'step_id' => $firstStep->id,
+        'completed_at' => now(),
+    ]);
+    StepUser::create([
+        'user_id' => $user->id,
+        'step_id' => $secondStep->id,
+        'completed_at' => now(),
+    ]);
+    StepUser::create([
+        'user_id' => $user->id,
+        'step_id' => $evaluationStep->id,
+        'evaluation_primary_course_id' => $firstPrimary->id,
+        'completed_at' => now(),
+    ]);
+
+    $this->actingAs($user);
+
+    $expectedSecondEvaluationUrl = StepPage::getUrlForStep($evaluationStep, [
+        'primaryCourse' => $secondPrimary->id,
+    ]);
+
+    expect($evaluationCourse->fresh()->allStepsCompletedByUser($user->id))->toBeFalse()
+        ->and($evaluationCourse->fresh()->allStepsCompletedByUser($user->id, $firstPrimary->id))->toBeTrue()
+        ->and($evaluationCourse->fresh()->allStepsCompletedByUser($user->id, $secondPrimary->id))->toBeFalse()
+        ->and($evaluationCourse->fresh()->linkToCurrentStep())->toBe($expectedSecondEvaluationUrl)
+        ->and($evaluationCourse->fresh()->linkToCurrentStep($secondPrimary->id))->toBe($expectedSecondEvaluationUrl);
+
+    $response = app(CourseCompleted::class)->mount($evaluationCourse->slug);
+
+    expect($response)
+        ->toBeInstanceOf(RedirectResponse::class)
+        ->and($response->getTargetUrl())->toBe($expectedSecondEvaluationUrl);
+});
+
 test('shared evaluation completed page redirect uses the most recently completed primary course', function () {
     $user = TestUser::create([
         'name' => 'Shared Evaluation Redirect User',

--- a/tests/Feature/CourseEvaluationTest.php
+++ b/tests/Feature/CourseEvaluationTest.php
@@ -52,6 +52,17 @@ test('canSelectEvaluationCourse validates evaluation targets on create', functio
         ->and($service->canSelectEvaluationCourse($nestedEvaluation))->toBeFalse();
 });
 
+test('evaluation link validation rejects missing course ids', function () {
+    $service = app(CourseEvaluationService::class);
+
+    $trainingCourse = Course::factory()->create(['is_private' => false]);
+    $missingCourseId = (int) Course::query()->max('id') + 1000;
+
+    expect($service->canUseEvaluationCourseId(null, null))->toBeTrue()
+        ->and($service->canUseEvaluationCourseId(null, $missingCourseId))->toBeFalse()
+        ->and($service->canUseEvaluationCourseId($trainingCourse, $missingCourseId))->toBeFalse();
+});
+
 test('primary course completion is deferred until evaluation is completed', function () {
     $user = TestUser::create([
         'name' => 'Test User',

--- a/tests/Feature/CourseEvaluationTest.php
+++ b/tests/Feature/CourseEvaluationTest.php
@@ -23,8 +23,6 @@ use Tapp\FilamentLms\Tests\TestFilamentFormShow;
 use Tapp\FilamentLms\Tests\TestFilamentFormUserShow;
 use Tapp\FilamentLms\Tests\TestUser;
 
-use function Livewire\store;
-
 beforeEach(function () {
     config(['filament-lms.evaluations.enabled' => true]);
 
@@ -635,10 +633,14 @@ test('evaluation form step hides next button and advances after submit', functio
 
     $component->entrySaved($entry);
 
-    $dispatchedEvents = collect(store($component)->get('dispatched', []))
-        ->map(fn ($event) => $event->serialize()['name']);
+    $stepUser = StepUser::query()
+        ->where('user_id', $user->id)
+        ->where('step_id', $evaluationStep->id)
+        ->first();
 
-    expect($dispatchedEvents)->toContain('complete-step');
+    expect($component->entry?->id)->toBe($entry->id)
+        ->and($stepUser?->completed_at)->not->toBeNull()
+        ->and($stepUser?->filament_form_user_id)->toBe($entry->id);
 });
 
 test('primary course without evaluation has no evaluation submission url', function () {

--- a/tests/Feature/CourseEvaluationTest.php
+++ b/tests/Feature/CourseEvaluationTest.php
@@ -1195,3 +1195,60 @@ test('embedded scorm exit course redirects to course completed when evaluation i
 
     expect($url)->toBe(CourseCompleted::getUrl([$primaryCourse->slug]));
 });
+
+test('step page mount resolves and syncs the implicit primary course for progress lookups', function () {
+    $user = CourseEvaluationLmsUser::create([
+        'name' => 'Implicit Primary User',
+        'email' => 'implicit-primary@example.com',
+        'password' => bcrypt('password'),
+    ]);
+
+    $evaluationCourse = Course::factory()->create([
+        'name' => 'Implicit Primary Evaluation',
+        'slug' => 'implicit-primary-evaluation',
+        'external_id' => 'implicit_primary_evaluation',
+        'is_private' => true,
+    ]);
+    $evaluationLesson = Lesson::factory()->create(['course_id' => $evaluationCourse->id]);
+    $evaluationStep = Step::factory()->create([
+        'lesson_id' => $evaluationLesson->id,
+        'slug' => 'implicit-primary-evaluation-step',
+    ]);
+
+    $completedPrimary = Course::factory()->create([
+        'name' => 'Completed Implicit Training',
+        'slug' => 'completed-implicit-training',
+        'external_id' => 'completed_implicit_training',
+        'evaluation_course_id' => $evaluationCourse->id,
+        'is_private' => true,
+    ]);
+    $completedPrimary->users()->attach($user->id);
+    $completedLesson = Lesson::factory()->create(['course_id' => $completedPrimary->id]);
+    $completedStep = Step::factory()->create(['lesson_id' => $completedLesson->id]);
+    $completedStep->complete($user);
+
+    $incompletePrimary = Course::factory()->create([
+        'name' => 'Incomplete Implicit Training',
+        'slug' => 'incomplete-implicit-training',
+        'external_id' => 'incomplete_implicit_training',
+        'evaluation_course_id' => $evaluationCourse->id,
+        'is_private' => true,
+    ]);
+    $incompletePrimary->users()->attach($user->id);
+    Lesson::factory()->create(['course_id' => $incompletePrimary->id]);
+
+    // Only $completedPrimary has finished its training requirements, so
+    // activePrimaryCourseForEvaluation() deterministically resolves to it.
+    $evaluationStep->complete($user, $completedPrimary->id);
+
+    Auth::login($user);
+    fakeRequestForCourse(null, $evaluationCourse->slug);
+
+    $page = app(StepPage::class);
+    $page->mount($evaluationCourse->slug, $evaluationLesson->slug, $evaluationStep->slug);
+
+    expect($page->evaluationPrimaryCourseId)->toBe($completedPrimary->id)
+        ->and(app(CourseEvaluationService::class)->evaluationPrimaryCourseIdFromRequest())->toBe($completedPrimary->id)
+        ->and($evaluationStep->fresh()->completed_at)->not->toBeNull()
+        ->and((float) $evaluationCourse->fresh()->completion_percentage)->toBe(100.0);
+});

--- a/tests/Feature/CourseEvaluationTest.php
+++ b/tests/Feature/CourseEvaluationTest.php
@@ -5,10 +5,12 @@ declare(strict_types=1);
 namespace Tapp\FilamentLms\Tests\Feature;
 
 use Illuminate\Http\RedirectResponse;
+use Illuminate\Support\Facades\Event;
 use Livewire\Livewire;
 use Tapp\FilamentFormBuilder\Models\FilamentForm;
 use Tapp\FilamentFormBuilder\Models\FilamentFormField;
 use Tapp\FilamentFormBuilder\Models\FilamentFormUser;
+use Tapp\FilamentLms\Events\CourseCompleted as CourseCompletedEvent;
 use Tapp\FilamentLms\Livewire\FormStep;
 use Tapp\FilamentLms\Models\Course;
 use Tapp\FilamentLms\Models\Lesson;
@@ -50,28 +52,10 @@ test('canSelectEvaluationCourse validates evaluation targets on create', functio
 });
 
 test('primary course completion is deferred until evaluation is completed', function () {
-    if (! class_exists(FilamentForm::class)) {
-        $this->markTestSkipped('Filament Form Builder is not installed.');
-    }
-
     $user = TestUser::create([
         'name' => 'Test User',
         'email' => 'evaluation-test@example.com',
         'password' => bcrypt('password'),
-    ]);
-
-    $form = FilamentForm::create([
-        'name' => 'Evaluation Form',
-        'slug' => 'evaluation-form',
-    ]);
-
-    FilamentFormField::create([
-        'filament_form_id' => $form->id,
-        'field' => 'feedback',
-        'label' => 'Feedback',
-        'type' => 'TEXTAREA',
-        'required' => true,
-        'order' => 1,
     ]);
 
     $evaluationCourse = Course::factory()->create([
@@ -86,13 +70,11 @@ test('primary course completion is deferred until evaluation is completed', func
         'order' => 1,
     ]);
 
-    Step::factory()->create([
+    $evaluationStep = Step::factory()->create([
         'lesson_id' => $evaluationLesson->id,
         'order' => 1,
         'name' => 'Evaluation',
         'slug' => 'evaluation',
-        'material_type' => 'form',
-        'material_id' => $form->id,
     ]);
 
     $primaryCourse = Course::factory()->create([
@@ -117,24 +99,22 @@ test('primary course completion is deferred until evaluation is completed', func
         'slug' => 'lesson-step',
     ]);
 
-    StepUser::create([
-        'user_id' => $user->id,
-        'step_id' => $primaryStep->id,
-        'completed_at' => now(),
-    ]);
+    Event::fake([CourseCompletedEvent::class]);
 
-    $primaryCourse->maybeSetCompletedAtForUser($user->id);
+    $primaryStep->complete($user);
+
+    Event::assertNotDispatched(CourseCompletedEvent::class, function (CourseCompletedEvent $event) use ($primaryCourse): bool {
+        return $event->course->is($primaryCourse);
+    });
 
     expect($primaryCourse->fresh()->completedByUserAt($user->id))->toBeNull()
         ->and($evaluationCourse->users()->where('user_id', $user->id)->exists())->toBeTrue();
 
-    StepUser::create([
-        'user_id' => $user->id,
-        'step_id' => $evaluationCourse->steps()->first()->id,
-        'completed_at' => now(),
-    ]);
+    $evaluationStep->complete($user);
 
-    $evaluationCourse->maybeSetCompletedAtForUser($user->id);
+    Event::assertDispatched(CourseCompletedEvent::class, function (CourseCompletedEvent $event) use ($user, $primaryCourse): bool {
+        return $event->user->is($user) && $event->course->is($primaryCourse);
+    });
 
     expect($primaryCourse->fresh()->completedByUserAt($user->id))->not->toBeNull()
         ->and($evaluationCourse->fresh()->completedByUserAt($user->id))->not->toBeNull();

--- a/tests/Feature/CourseEvaluationTest.php
+++ b/tests/Feature/CourseEvaluationTest.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace Tapp\FilamentLms\Tests\Feature;
 
 use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Event;
 use Livewire\Livewire;
 use Tapp\FilamentFormBuilder\Models\FilamentForm;
@@ -255,14 +257,14 @@ test('shared evaluation progress stays scoped to the active primary course', fun
 
     $this->actingAs($user);
 
-    app()->instance('request', \Illuminate\Http\Request::create('/', 'GET', [
+    app()->instance('request', Request::create('/', 'GET', [
         'primaryCourse' => (string) $secondPrimary->id,
     ]));
 
     expect($evaluationStep->fresh()->completed_at)->toBeNull()
         ->and((float) $evaluationCourse->fresh()->completion_percentage)->toBe(0.0);
 
-    app()->instance('request', \Illuminate\Http\Request::create('/', 'GET', [
+    app()->instance('request', Request::create('/', 'GET', [
         'primaryCourse' => (string) $firstPrimary->id,
     ]));
 
@@ -346,7 +348,7 @@ test('evaluation step urls preserve requested primary course context', function 
     ]);
 
     $this->actingAs($user);
-    app()->instance('request', \Illuminate\Http\Request::create('/', 'GET', [
+    app()->instance('request', Request::create('/', 'GET', [
         'primaryCourse' => (string) $secondPrimary->id,
     ]));
 
@@ -446,8 +448,8 @@ test('step page uses primary scoped evaluation progress for access checks', func
         'created_at' => now(),
     ]);
 
-    \Illuminate\Support\Facades\Auth::login($user);
-    app()->instance('request', \Illuminate\Http\Request::create('/', 'GET', [
+    Auth::login($user);
+    app()->instance('request', Request::create('/', 'GET', [
         'primaryCourse' => (string) $secondPrimary->id,
     ]));
 

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -107,6 +107,7 @@ abstract class TestCase extends Orchestra
             $table->boolean('is_private')->default(false);
             $table->boolean('embedded_player')->default(false);
             $table->string('completion_mode', 32)->default('native');
+            $table->foreignId('evaluation_course_id')->nullable()->constrained('lms_courses')->nullOnDelete();
             $table->timestamps();
             $table->softDeletes();
         });

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -146,6 +146,7 @@ abstract class TestCase extends Orchestra
             $table->id();
             $table->foreignId('step_id')->references('id')->on('lms_steps')->onDelete('cascade');
             $table->foreignId('user_id')->references('id')->on('users')->onDelete('cascade');
+            $table->foreignId('filament_form_user_id')->nullable()->constrained('filament_form_user')->nullOnDelete();
             $table->unsignedInteger('seconds')->nullable();
             $table->timestamp('completed_at')->nullable();
             $table->timestamps();

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -146,6 +146,7 @@ abstract class TestCase extends Orchestra
             $table->id();
             $table->foreignId('step_id')->references('id')->on('lms_steps')->onDelete('cascade');
             $table->foreignId('user_id')->references('id')->on('users')->onDelete('cascade');
+            $table->foreignId('evaluation_primary_course_id')->nullable()->constrained('lms_courses')->nullOnDelete();
             $table->foreignId('filament_form_user_id')->nullable()->constrained('filament_form_user')->nullOnDelete();
             $table->unsignedInteger('seconds')->nullable();
             $table->timestamp('completed_at')->nullable();

--- a/tests/TestFilamentFormShow.php
+++ b/tests/TestFilamentFormShow.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Tapp\FilamentLms\Tests;
 
+use Illuminate\Contracts\Support\MessageBag as MessageBagContract;
+use Illuminate\Support\MessageBag;
 use Livewire\Component;
 
 class TestFilamentFormShow extends Component
@@ -18,6 +20,13 @@ class TestFilamentFormShow extends Component
     public function mount(mixed $form = null, bool $blockRedirect = false, bool $allowMultipleSubmissions = false): void
     {
         self::$lastAllowMultipleSubmissions = $allowMultipleSubmissions;
+    }
+
+    public function getErrorBag(): MessageBagContract
+    {
+        $errorBag = parent::getErrorBag();
+
+        return $errorBag instanceof MessageBagContract ? $errorBag : new MessageBag;
     }
 
     public function render(): string

--- a/tests/TestFilamentFormShow.php
+++ b/tests/TestFilamentFormShow.php
@@ -8,9 +8,16 @@ use Livewire\Component;
 
 class TestFilamentFormShow extends Component
 {
+    public static ?bool $lastAllowMultipleSubmissions = null;
+
+    public static function resetLastAllowMultipleSubmissions(): void
+    {
+        self::$lastAllowMultipleSubmissions = null;
+    }
+
     public function mount(mixed $form = null, bool $blockRedirect = false, bool $allowMultipleSubmissions = false): void
     {
-        //
+        self::$lastAllowMultipleSubmissions = $allowMultipleSubmissions;
     }
 
     public function render(): string

--- a/tests/TestFilamentFormShow.php
+++ b/tests/TestFilamentFormShow.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tapp\FilamentLms\Tests;
+
+use Livewire\Component;
+
+class TestFilamentFormShow extends Component
+{
+    public function mount(mixed $form = null, bool $blockRedirect = false, bool $allowMultipleSubmissions = false): void
+    {
+        //
+    }
+
+    public function render(): string
+    {
+        return '<div data-testid="filament-form-show"></div>';
+    }
+}

--- a/tests/TestFilamentFormUserShow.php
+++ b/tests/TestFilamentFormUserShow.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tapp\FilamentLms\Tests;
+
+use Livewire\Component;
+
+class TestFilamentFormUserShow extends Component
+{
+    public function mount(mixed $entry = null): void
+    {
+        //
+    }
+
+    public function render(): string
+    {
+        return '<div data-testid="filament-form-user-show"></div>';
+    }
+}

--- a/tests/TestFilamentFormUserShow.php
+++ b/tests/TestFilamentFormUserShow.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Tapp\FilamentLms\Tests;
 
+use Illuminate\Contracts\Support\MessageBag as MessageBagContract;
+use Illuminate\Support\MessageBag;
 use Livewire\Component;
 
 class TestFilamentFormUserShow extends Component
@@ -11,6 +13,13 @@ class TestFilamentFormUserShow extends Component
     public function mount(mixed $entry = null): void
     {
         //
+    }
+
+    public function getErrorBag(): MessageBagContract
+    {
+        $errorBag = parent::getErrorBag();
+
+        return $errorBag instanceof MessageBagContract ? $errorBag : new MessageBag;
     }
 
     public function render(): string


### PR DESCRIPTION
# Details

Schema
* `evaluation_course_id` on `lms_courses` — links a training course to its evaluation course

Completion flow
* Primary course `completed_at` and certificate wait until evaluation is done
* Auto-assigns evaluation course when primary training steps are complete
* Redirects to evaluation after last primary step
* CourseCompleted page shows “Complete Evaluation” when pending
* Access gating blocks evaluation steps until primary is complete

Config (`filament-lms.evaluations.enabled`) — opt-in feature flag

Complete instructions added on README file.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes core completion, certificate eligibility, and step progress scoping across Course/Step/Livewire pages; misconfiguration or shared-evaluation edge cases could block certificates or show wrong progress.
> 
> **Overview**
> Adds an **opt-in** course evaluation flow (`filament-lms.evaluations.enabled`) where a training course links to a separate private evaluation course via **`evaluation_course_id`**. Learners must finish that linked form course before the primary course gets **`completed_at`**, a certificate, or the normal completion UI.
> 
> **Schema & admin:** New migrations add `evaluation_course_id` on courses, plus `evaluation_primary_course_id` and `filament_form_user_id` on `lms_step_user` so one shared evaluation course can track **per-training** progress and form submissions. Admin **Course** resource gets an **Evaluation course** select with validation (private targets only, no reverse/nested links). README documents setup; **`tapp/filament-form-builder`** is bumped to `^4.3.5`.
> 
> **Completion & UX:** New **`CourseEvaluationService`** centralizes gating, auto-enrollment, URLs with `primaryCourse` query param, and finalizing primary completion after evaluation. **`maybeSetCompletedAtForUser`** defers primary completion until evaluation passes (and still respects test score rules). **Course completed** page shows **Complete Evaluation** when pending and **View Evaluation** after submit; evaluation-only courses are hidden from the dashboard listing. **Step** / **FormStep** / embedded SCORM exit paths redirect into evaluation; evaluation form steps hide **Next**, allow resubmissions, and tie submissions to the scoped **`StepUser`** row.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1082a510298ff8d307781652791e7c9eeae74dad. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->