### PR TITLE
Add unique validation to slug, name, and external id

### DIFF
--- a/src/Resources/CourseResource.php
+++ b/src/Resources/CourseResource.php
@@ -82,11 +82,13 @@ class CourseResource extends Resource
                             $set('external_id', Str::slug($state ?? '', '_'));
                         }
                     })
+                    ->unique(ignoreRecord: true)
                     ->required(),
                 TextInput::make('external_id')
                     ->label('External ID')
                     ->helperText('Used for external integrations like HubSpot. Updating this will cause a new property to be added to the integration.')
                     ->required()
+                    ->unique(ignoreRecord: true)
                     ->rules([
                         'regex:/^[a-z][a-z0-9_]*$/',
                         'max:100',
@@ -97,6 +99,7 @@ class CourseResource extends Resource
                     ]),
                 TextInput::make('slug')
                     ->helperText('Used for urls.')
+                    ->unique(ignoreRecord: true)
                     ->required(),
                 SpatieMediaLibraryFileUpload::make('image')
                     ->helperText('Upload a course image.')


### PR DESCRIPTION
# Details

Add unique validation to slug, name, and external id.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Uniqueness is enforced at the form layer on globally scoped course identifiers (URLs and HubSpot external IDs); if tenancy expects per-tenant duplicates, this validation may be stricter than intended.
> 
> **Overview**
> Course create/edit forms now **reject duplicate `name`, `slug`, and `external_id` values** before save, using Filament’s `->unique(ignoreRecord: true)` on each of those `TextInput` fields in `CourseResource`.
> 
> `ignoreRecord: true` keeps edits valid when those fields are unchanged on the record being updated. Existing regex/max rules on `external_id` are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 58ef5029d183f25d471987a27a5c6f56ed7242b7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->