### PR TITLE
Show evaluation button on courses

### DIFF
--- a/resources/views/components/course-card.blade.php
+++ b/resources/views/components/course-card.blade.php
@@ -1,10 +1,17 @@
 @php
+    use Illuminate\Support\Facades\Auth;
+    use Tapp\FilamentLms\Services\CourseEvaluationService;
+
     $creditsEnabled = config('filament-lms.credits_enabled');
     $creditCategories = $creditsEnabled ? $course->courseCreditCategories : collect();
     $isCompleted = $course->completed_at !== null;
     $completionPercentage = $course->completion_percentage;
     $isInProgress = ! $isCompleted && $completionPercentage > 0;
     $moduleCount = (int) ($course->lessons_count ?? $course->lessons()->count());
+    $evaluationService = app(CourseEvaluationService::class);
+    $pendingEvaluation = Auth::check()
+        && $evaluationService->hasPendingEvaluationForUser($course, Auth::id());
+    $evaluationUrl = $pendingEvaluation ? $course->evaluationSubmissionUrl() : null;
 @endphp
 <div class="flex overflow-hidden relative flex-col bg-white rounded-lg border border-gray-200 group">
   {{-- Image section: fixed height, image or grey + icon --}}
@@ -55,7 +62,14 @@
       <p class="text-sm text-gray-500">
         {{ $moduleCount }} {{ Str::plural('module', $moduleCount) }}
       </p>
-      @if ($isCompleted)
+      @if ($pendingEvaluation && $evaluationUrl)
+        <a
+          href="{{ $evaluationUrl }}"
+          class="relative z-10 inline-flex items-center rounded-lg bg-primary-600 px-2.5 py-1 text-xs font-semibold text-white shadow-sm ring-1 ring-primary-600 transition hover:bg-primary-700"
+        >
+          Complete Evaluation
+        </a>
+      @elseif ($isCompleted)
         <span class="inline-flex items-center rounded-full bg-success-50 px-2.5 py-1 text-xs font-medium text-success-700">Completed</span>
       @elseif ($isInProgress)
         <span class="inline-flex items-center rounded-full bg-amber-50 px-2.5 py-1 text-xs font-medium text-amber-700">In Progress</span>

--- a/tests/Feature/CourseEvaluationTest.php
+++ b/tests/Feature/CourseEvaluationTest.php
@@ -632,6 +632,57 @@ test('evaluation course is never shown on the dashboard', function () {
         ->and(Course::accessibleTo($user)->pluck('id'))->toContain($primaryCourse->id);
 });
 
+test('pending evaluation replaces course card status badge conditions', function () {
+    $user = TestUser::create([
+        'name' => 'Course Card Evaluation User',
+        'email' => 'course-card-evaluation@example.com',
+        'password' => bcrypt('password'),
+    ]);
+
+    $evaluationCourse = Course::factory()->create([
+        'name' => 'Course Card Evaluation',
+        'slug' => 'course-card-evaluation',
+        'is_private' => true,
+    ]);
+
+    $evaluationLesson = Lesson::factory()->create(['course_id' => $evaluationCourse->id]);
+    Step::factory()->create(['lesson_id' => $evaluationLesson->id]);
+
+    $primaryCourse = Course::factory()->create([
+        'name' => 'Course Card Training',
+        'slug' => 'course-card-training',
+        'evaluation_course_id' => $evaluationCourse->id,
+        'is_private' => true,
+    ]);
+
+    $primaryCourse->users()->attach($user->id);
+
+    $primaryLesson = Lesson::factory()->create(['course_id' => $primaryCourse->id]);
+    $primaryStep = Step::factory()->create(['lesson_id' => $primaryLesson->id]);
+
+    $this->actingAs($user);
+
+    $service = app(CourseEvaluationService::class);
+
+    expect($service->hasPendingEvaluationForUser($primaryCourse, $user->id))->toBeFalse()
+        ->and((float) $primaryCourse->fresh()->completion_percentage)->toBe(0.0);
+
+    $primaryStep->complete($user);
+
+    $primaryCourse = $primaryCourse->fresh();
+    $evaluationUrl = $service->evaluationUrlForPrimaryCourse($primaryCourse);
+
+    expect($service->hasPendingEvaluationForUser($primaryCourse, $user->id))->toBeTrue()
+        ->and($evaluationUrl)->not->toBeNull()
+        ->and($primaryCourse->completed_at)->toBeNull()
+        ->and((float) $primaryCourse->completion_percentage)->toBe(100.0);
+
+    $evaluationCourse->steps()->first()->complete($user, $primaryCourse->id);
+
+    expect($service->hasPendingEvaluationForUser($primaryCourse->fresh(), $user->id))->toBeFalse()
+        ->and($primaryCourse->fresh()->completed_at)->not->toBeNull();
+});
+
 test('public primary course unlocks evaluation without enrollment on the training course', function () {
     $user = TestUser::create([
         'name' => 'Public Primary User',


### PR DESCRIPTION
# Details

Show evaluation button on courses.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only change in a Blade component using existing evaluation service APIs; no auth or completion logic changes.
> 
> **Overview**
> Course cards on the dashboard now surface a **Complete Evaluation** link when the signed-in learner has finished training content but still owes the linked evaluation, instead of showing the normal **Completed** / **In Progress** / **Not Started** badge.
> 
> The card resolves pending state via `CourseEvaluationService::hasPendingEvaluationForUser` and links to `Course::evaluationSubmissionUrl()` (with `z-10` so the button stays clickable above the card overlay). A feature test documents the lifecycle: no pending evaluation before the primary step is done, pending with a URL and 100% progress but no `completed_at` after training, then cleared pending and set completion after the evaluation step finishes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5cbd86619b57e01a872a2d4bb737372fc62a57c1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->