### PR TITLE
CU-868kcn1vz: Fix YouTube mobile play button

### DIFF
--- a/resources/views/livewire/video-player.blade.php
+++ b/resources/views/livewire/video-player.blade.php
@@ -11,9 +11,19 @@
 
 <style>
     .vidstack-player-custom {
-        height: 60vh;
-        max-width: calc(60vh * 16/9);
+        display: block;
+        width: min(100%, calc(60vh * 16 / 9));
+        aspect-ratio: 16 / 9;
+        height: auto;
         margin: 0 auto;
+        overflow: hidden;
+        position: relative;
+    }
+
+    .vidstack-player-custom media-player,
+    .vidstack-player-custom .vds-video-layout {
+        width: 100%;
+        height: 100%;
     }
 
     @if (! auth()->user()->is_admin)

--- a/resources/views/livewire/video-player.blade.php
+++ b/resources/views/livewire/video-player.blade.php
@@ -21,20 +21,7 @@
         aspect-ratio: 16 / 9;
         contain: layout;
         overflow: visible;
-    }
-
-    /*
-     * On mobile, the YouTube iframe paints above HTML overlays, so our Vidstack
-     * play button stacks on top of YouTube's native one. Until playback starts,
-     * hide Vidstack chrome/blocker so the learner only sees YouTube's play.
-     * After start, Vidstack controls take over (YouTube embed controls stay off).
-     */
-    .vidstack-player-custom media-player:not([data-started]) .vds-blocker,
-    .vidstack-player-custom media-player:not([data-started]) .vds-controls,
-    .vidstack-player-custom media-player:not([data-started]) .vds-gestures,
-    .vidstack-player-custom media-player:not([data-started]) .vds-buffering-indicator {
-        display: none !important;
-        pointer-events: none !important;
+        background: #000;
     }
 
     /* Vidstack small layout hangs the bottom bar slightly outside the player; keep it in frame. */
@@ -42,6 +29,49 @@
     .vidstack-player-custom .vds-video-layout[data-sm] .vds-controls-group:last-child {
         margin-bottom: 0 !important;
         margin-top: 0 !important;
+    }
+
+    /* Title duplicates the LMS step heading; hide the in-player overlay. */
+    .vidstack-player-custom .vds-chapter-title {
+        display: none !important;
+    }
+
+    /*
+     * Keep the control bar reachable. Default idle hide forces a second tap
+     * on touch (first tap only re-shows controls).
+     */
+    .vidstack-player-custom .vds-controls {
+        opacity: 1 !important;
+        visibility: visible !important;
+        pointer-events: auto !important;
+    }
+
+    /*
+     * On touch, Vidstack hides press-to-pause and uses press-to-toggle-controls.
+     * Prefer pause so "Tap to play/pause" is one tap.
+     */
+    @media (pointer: coarse) {
+        .vidstack-player-custom .vds-gesture[action='toggle:paused'] {
+            display: block !important;
+        }
+
+        .vidstack-player-custom .vds-gesture[action='toggle:controls'] {
+            display: none !important;
+        }
+    }
+
+    /*
+     * YouTube's iframe still paints its own centered play/pause chrome.
+     * Hide the iframe until playback is actively running so only Vidstack's
+     * control is visible (poster/black background remains underneath).
+     */
+    .vidstack-player-custom media-player:not([data-playing]) iframe {
+        opacity: 0 !important;
+    }
+
+    /* Idle buffering spinner can look like a second centered play icon. */
+    .vidstack-player-custom media-player:not([data-started]) .vds-buffering-indicator {
+        display: none !important;
     }
 
     @if (! auth()->user()->is_admin)
@@ -58,24 +88,51 @@
 <script>
  let completed = {{ $step->completed_at ? 1 : 0 }};
  let lastTime = {{ $step->seconds ?: 0 }};
+ let hasSeekedToResumePoint = false;
 
 const player = await VidstackPlayer.create({
      target: '#target',
-     src: '{{$video->url}}',
+     title: '',
      viewType: 'video',
      streamType: 'on-demand',
      logLevel: 'warn',
      crossOrigin: true,
      playsInline: true,
+     // Keep controls visible — touch otherwise needs a tap just to re-show them.
+     controlsDelay: Infinity,
+     hideControlsOnMouseLeave: false,
      layout: new VidstackPlayerLayout({
         disableTimeSlider: true,
         noScrubGesture: {{ auth()->user()->is_admin ? 'false' : 'true' }},
      }),
  });
 
- // Ensure the video starts at the correct time after loading
+ // Force YouTube captions off by default. They are NOT set in our LMS app —
+ // Vidstack's YouTube provider prefers English (`cc_lang_pref=en`) and YouTube
+ // may auto-show captions from the video / account. `cc_load_policy=0` opts out.
+ const disableYouTubeCaptionsByDefault = (provider) => {
+     if (provider?.type !== 'youtube' || typeof provider.buildParams !== 'function') {
+         return;
+     }
+
+     const originalBuildParams = provider.buildParams.bind(provider);
+     provider.buildParams = () => ({
+         ...originalBuildParams(),
+         cc_load_policy: 0,
+     });
+ };
+
+ player.addEventListener('provider-change', (event) => {
+     disableYouTubeCaptionsByDefault(event.detail);
+ });
+
+ // Set src after the provider-change listener so buildParams is patched first.
+ player.src = '{{$video->url}}';
+
+ // Resume once after load. Re-seeking on every canPlay can break play/pause on Chromium.
  player.subscribe(({canPlay}) => {
-     if (canPlay) {
+     if (canPlay && !hasSeekedToResumePoint && lastTime > 0) {
+         hasSeekedToResumePoint = true;
          player.currentTime = lastTime;
      }
  });

--- a/resources/views/livewire/video-player.blade.php
+++ b/resources/views/livewire/video-player.blade.php
@@ -1,8 +1,8 @@
 <div>
     <div class="vidstack-player-custom" wire:ignore id="target"></div>
     <p class="text-sm text-gray-600 text-center mt-2">
-        Click to play/pause • Double click for fullscreen
-    </p> 
+        Tap to play/pause
+    </p>
 </div>
 
 @assets
@@ -17,8 +17,10 @@
     }
 
     @if (! auth()->user()->is_admin)
-    .vds-controls {
-        display: none;
+    /* Keep play/fullscreen controls; hide seek UI so learners cannot skip ahead. */
+    .vidstack-player-custom .vds-seek-button,
+    .vidstack-player-custom .vds-time-slider {
+        display: none !important;
     }
     @endif
 </style>
@@ -39,6 +41,7 @@ const player = await VidstackPlayer.create({
      playsInline: true,
      layout: new VidstackPlayerLayout({
         disableTimeSlider: true,
+        noScrubGesture: {{ auth()->user()->is_admin ? 'false' : 'true' }},
      }),
  });
 

--- a/resources/views/livewire/video-player.blade.php
+++ b/resources/views/livewire/video-player.blade.php
@@ -13,17 +13,35 @@
     .vidstack-player-custom {
         display: block;
         width: min(100%, calc(60vh * 16 / 9));
-        aspect-ratio: 16 / 9;
-        height: auto;
         margin: 0 auto;
-        overflow: hidden;
-        position: relative;
     }
 
-    .vidstack-player-custom media-player,
-    .vidstack-player-custom .vds-video-layout {
+    .vidstack-player-custom media-player {
         width: 100%;
-        height: 100%;
+        aspect-ratio: 16 / 9;
+        contain: layout;
+        overflow: visible;
+    }
+
+    /*
+     * On mobile, the YouTube iframe paints above HTML overlays, so our Vidstack
+     * play button stacks on top of YouTube's native one. Until playback starts,
+     * hide Vidstack chrome/blocker so the learner only sees YouTube's play.
+     * After start, Vidstack controls take over (YouTube embed controls stay off).
+     */
+    .vidstack-player-custom media-player:not([data-started]) .vds-blocker,
+    .vidstack-player-custom media-player:not([data-started]) .vds-controls,
+    .vidstack-player-custom media-player:not([data-started]) .vds-gestures,
+    .vidstack-player-custom media-player:not([data-started]) .vds-buffering-indicator {
+        display: none !important;
+        pointer-events: none !important;
+    }
+
+    /* Vidstack small layout hangs the bottom bar slightly outside the player; keep it in frame. */
+    .vidstack-player-custom .vds-video-layout[data-sm] .vds-controls-group:nth-last-child(2),
+    .vidstack-player-custom .vds-video-layout[data-sm] .vds-controls-group:last-child {
+        margin-bottom: 0 !important;
+        margin-top: 0 !important;
     }
 
     @if (! auth()->user()->is_admin)


### PR DESCRIPTION
## Summary
- Learners could see YouTube step posters on iOS but could not play them because all Vidstack controls were hidden, leaving only mouse click-to-play (broken on touch) behind a blocker overlay.
- Keep play controls visible for non-admins so tap-to-play works, while still disabling seek/scrub so progress gating cannot be skipped.
- Update the on-screen hint to touch-friendly wording.

## Test plan
- [ ] As a non-admin learner on iOS (or mobile viewport + touch), open a YouTube LMS step and confirm the play button is visible and tap starts playback
- [ ] Confirm seek buttons / time slider are not available to learners and Next remains gated on progress
- [ ] As an admin, confirm controls still work as before
- [ ] Confirm desktop mouse play/pause still works

ClickUp: https://app.clickup.com/t/868kcn1vz


Made with [Cursor](https://cursor.com)