### PR TITLE
Fix certificate PDF generation on Chromium sandbox-restricted hosts

### DIFF
--- a/src/Http/Controllers/CertificateController.php
+++ b/src/Http/Controllers/CertificateController.php
@@ -65,11 +65,7 @@ class CertificateController extends Controller
             ['course' => $course, 'user' => Auth::id()]
         );
 
-        $pdf = Browsershot::url($url)
-            ->waitUntilNetworkIdle()
-            ->showBackground()
-            ->landscape()
-            ->pdf();
+        $pdf = $this->browsershot($url)->pdf();
 
         $filename = Str::slug($course->name).'-'.Str::slug(Auth::user()->name).'-certificate-'.now()->toDateString().'.pdf';
 
@@ -79,5 +75,14 @@ class CertificateController extends Controller
             'Content-Type' => 'application/pdf',
             'Content-Disposition' => 'attachment; filename='.$filename,
         ]);
+    }
+
+    public function browsershot(string $url): Browsershot
+    {
+        return Browsershot::url($url)
+            ->noSandbox()
+            ->waitUntilNetworkIdle()
+            ->showBackground()
+            ->landscape();
     }
 }

--- a/tests/Unit/CertificateBrowsershotTest.php
+++ b/tests/Unit/CertificateBrowsershotTest.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+use Tapp\FilamentLms\Http\Controllers\CertificateController;
+
+it('configures browsershot with no-sandbox for production chromium hosts', function () {
+    $controller = new CertificateController;
+    $command = $controller->browsershot('https://example.com/lms/certificates/1/1')->createPdfCommand();
+
+    expect($command['options']['args'] ?? [])
+        ->toContain('--no-sandbox')
+        ->and($command['options']['landscape'] ?? false)->toBeTrue()
+        ->and($command['options']['printBackground'] ?? false)->toBeTrue()
+        ->and($command['options']['waitUntil'] ?? null)->toBe('networkidle0');
+});


### PR DESCRIPTION
## Summary
- Certificate downloads via `CertificateController` were failing in production with Puppeteer's `No usable sandbox!` / `ProcessFailedException` (Honeybadger [132800309](https://app.honeybadger.io/projects/126031/faults/132800309) on CHECK-LMS).
- Configure Browsershot with `noSandbox()` when generating certificate PDFs, and extract a `browsershot()` helper so the Chromium args are unit-tested.

## Test plan
- [x] `vendor/bin/pest --compact tests/Unit/CertificateBrowsershotTest.php`
- [ ] After release/bump in CHECK-LMS, download an LMS certificate on production (`/lms/certificates/{course}/download`) and confirm it streams a PDF
- [ ] Confirm Honeybadger fault 132800309 stops recurring after deploy


Made with [Cursor](https://cursor.com)