### PR TITLE
Add SCORM multi-part upload support

### DIFF
--- a/README.md
+++ b/README.md
@@ -332,6 +332,51 @@ Set it to `true` to enable top navigation on the LMS dashboard (courses list pag
 
 Use to display or not the `Exit LMS` link on top bar.
 
+## SCORM / Common Cartridge Import
+
+Admin users can import SCORM 1.2 or Articulate Storyline / Rise ZIP packages from the Courses list via **Import SCORM Package**. Packages are processed in the background and create the corresponding course, lessons, and steps.
+
+### Upload size limits
+
+Configure max ZIP size and Livewire temporary upload timeout under `common_cartridge_import` in `config/filament-lms.php`:
+
+```php
+'common_cartridge_import' => [
+    'storage_disk' => 'local', // Must be a local filesystem disk (ZipArchive needs a path)
+    'storage_directory' => 'filament-lms/cartridge-imports',
+    'max_upload_size_kb' => 512000, // ~500 MB
+    'max_upload_time_minutes' => 10,
+],
+```
+
+Also ensure `php.ini` `upload_max_filesize` and `post_max_size` meet or exceed your max upload size when using the default Filament file upload.
+
+### Chunked (multipart) uploads with Uppy
+
+Large SCORM packages often exceed server's request limit when uploaded in a single request. To use chunked uploads instead:
+
+1. Install the optional [spykapps/filament-uppy-upload](https://github.com/SpykApp/uppy-upload-plugin) package:
+
+```bash
+composer require spykapps/filament-uppy-upload
+php artisan filament:assets
+```
+
+2. Enable multipart upload in `config/filament-lms.php`:
+
+```php
+'common_cartridge_import' => [
+    // ...
+    'multipart_upload' => [
+        'enabled' => true,
+        // Chunk size in bytes (5MB works well with Cloudflare)
+        'chunk_size' => 5 * 1024 * 1024,
+    ],
+],
+```
+
+When `multipart_upload.enabled` is `true` **and** `spykapps/filament-uppy-upload` is installed, the Import SCORM Package action uses Uppy’s chunked uploader. Otherwise it falls back to Filament’s standard `FileUpload`.
+
 ## Certificate Customization
 
 The LMS package generates PDF certificates when users complete courses. You can customize the appearance and content of certificates using the following configuration options:

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,8 @@
         "tapp/filament-form-builder": "^4.3.5"
     },
     "suggest": {
-        "tapp/filament-library": "Required for Library file / Library link step materials (set filament-lms.integrations.filament_library.enabled for the admin material picker)."
+        "tapp/filament-library": "Required for Library file / Library link step materials (set filament-lms.integrations.filament_library.enabled for the admin material picker).",
+        "spykapps/filament-uppy-upload": "Optional. Enables Uppy chunked (multipart) uploads for SCORM package import so large ZIPs stay under Cloudflare's ~100MB limit (set filament-lms.common_cartridge_import.multipart_upload.enabled)."
     },
     "require-dev": {
         "filament/upgrade": "^4.0",

--- a/config/filament-lms.php
+++ b/config/filament-lms.php
@@ -193,6 +193,17 @@ return [
         'max_upload_size_kb' => 512000,
         // Livewire temporary upload timeout in minutes for large SCORM packages.
         'max_upload_time_minutes' => 10,
+        /*
+        | Chunked (multipart) SCORM ZIP uploads via spykapps/filament-uppy-upload.
+        | When enabled and that package is installed, the Import SCORM Package action uses
+        | Uppy instead of Filament FileUpload so large packages stay under Cloudflare's
+        | ~100MB request limit. Requires: composer require spykapps/filament-uppy-upload
+        */
+        'multipart_upload' => [
+            'enabled' => false,
+            // Chunk size in bytes (5MB works well with Cloudflare).
+            'chunk_size' => 5 * 1024 * 1024,
+        ],
     ],
 
     // Optional path to Node binary for Articulate slide JSON extraction

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -215,3 +215,9 @@ parameters:
 			identifier: property.nonObject
 			count: 1
 			path: src/Resources/TestResource/Pages/EditTest.php
+
+		-
+			message: '#^Call to static method make\(\) on an unknown class SpykApp\\UppyUpload\\Forms\\Components\\UppyUpload\.$#'
+			identifier: class.notFound
+			count: 1
+			path: src/Resources/CourseResource/Pages/ListCourses.php

--- a/src/Resources/CourseResource/Pages/ListCourses.php
+++ b/src/Resources/CourseResource/Pages/ListCourses.php
@@ -11,6 +11,7 @@ use Filament\Forms\Components\TextInput;
 use Filament\Notifications\Notification;
 use Filament\Resources\Pages\ListRecords;
 use Illuminate\Support\Str;
+use SpykApp\UppyUpload\Forms\Components\UppyUpload;
 use Tapp\FilamentLms\Jobs\ImportCourseFromCsv;
 use Tapp\FilamentLms\Resources\CourseResource;
 use Tapp\FilamentLms\Services\CommonCartridge\CartridgeImportStarter;
@@ -141,26 +142,7 @@ class ListCourses extends ListRecords
         ];
 
         if (CartridgeImportStarter::usesMultipartUpload()) {
-            /** @var class-string<Field> $uppyUploadClass */
-            $uppyUploadClass = 'SpykApp\\UppyUpload\\Forms\\Components\\UppyUpload';
-            $importStarter = app(CartridgeImportStarter::class);
-            $chunkSize = (int) config('filament-lms.common_cartridge_import.multipart_upload.chunk_size', 5 * 1024 * 1024);
-
-            return $uppyUploadClass::make('file')
-                ->label('ZIP package')
-                ->required()
-                ->disk($importStarter->storageDisk())
-                ->directory($importStarter->storageDirectory())
-                ->acceptedFileTypes($acceptedFileTypes)
-                ->maxFileSize($maxUploadSizeKb * 1024)
-                ->chunkSize($chunkSize)
-                ->single()
-                ->webcam(false)
-                ->screenCapture(false)
-                ->audio(false)
-                ->imageEditor(false)
-                ->note($helperText)
-                ->helperText($helperText);
+            return $this->makeUppyScormPackageUploadField($maxUploadSizeKb, $helperText, $acceptedFileTypes);
         }
 
         return FileUpload::make('file')
@@ -170,6 +152,33 @@ class ListCourses extends ListRecords
             ->acceptedFileTypes($acceptedFileTypes)
             ->rules(['mimes:zip'])
             ->maxSize($maxUploadSizeKb)
+            ->helperText($helperText);
+    }
+
+    /**
+     * Build the Uppy chunked upload field (optional spykapps/filament-uppy-upload).
+     *
+     * @param  list<string>  $acceptedFileTypes
+     */
+    protected function makeUppyScormPackageUploadField(int $maxUploadSizeKb, string $helperText, array $acceptedFileTypes): Field
+    {
+        $importStarter = app(CartridgeImportStarter::class);
+        $chunkSize = (int) config('filament-lms.common_cartridge_import.multipart_upload.chunk_size', 5 * 1024 * 1024);
+
+        return UppyUpload::make('file')
+            ->label('ZIP package')
+            ->required()
+            ->disk($importStarter->storageDisk())
+            ->directory($importStarter->storageDirectory())
+            ->acceptedFileTypes($acceptedFileTypes)
+            ->maxFileSize($maxUploadSizeKb * 1024)
+            ->chunkSize($chunkSize)
+            ->single()
+            ->webcam(false)
+            ->screenCapture(false)
+            ->audio(false)
+            ->imageEditor(false)
+            ->note($helperText)
             ->helperText($helperText);
     }
 }

--- a/src/Resources/CourseResource/Pages/ListCourses.php
+++ b/src/Resources/CourseResource/Pages/ListCourses.php
@@ -5,11 +5,11 @@ namespace Tapp\FilamentLms\Resources\CourseResource\Pages;
 use Filament\Actions\Action;
 use Filament\Actions\CreateAction;
 use Filament\Facades\Filament;
+use Filament\Forms\Components\Field;
 use Filament\Forms\Components\FileUpload;
 use Filament\Forms\Components\TextInput;
 use Filament\Notifications\Notification;
 use Filament\Resources\Pages\ListRecords;
-use Illuminate\Support\Facades\Storage;
 use Illuminate\Support\Str;
 use Tapp\FilamentLms\Jobs\ImportCourseFromCsv;
 use Tapp\FilamentLms\Resources\CourseResource;
@@ -88,23 +88,12 @@ class ListCourses extends ListRecords
                 ->label('Import SCORM Package')
                 ->icon('heroicon-o-archive-box-arrow-down')
                 ->schema([
-                    FileUpload::make('file')
-                        ->label('ZIP package')
-                        ->required()
-                        ->storeFiles(false)
-                        ->acceptedFileTypes([
-                            'application/zip',
-                            'application/x-zip-compressed',
-                            'application/octet-stream',
-                        ])
-                        ->rules(['mimes:zip'])
-                        ->maxSize($maxUploadSizeKb)
-                        ->helperText('Upload a SCORM 1.2 or Articulate Storyline / Rise ZIP export. Large packages may take a minute to upload.'),
+                    $this->scormPackageUploadField($maxUploadSizeKb),
                 ])
                 ->action(function (array $data, CartridgeImportStarter $importStarter): void {
-                    $file = $importStarter->resolveUploadedFile($data['file'] ?? null);
+                    $absolutePath = $importStarter->stageUploadedCartridge($data['file'] ?? null);
 
-                    if ($file === null) {
+                    if ($absolutePath === null) {
                         Notification::make()
                             ->title('Import failed')
                             ->body('Could not read the uploaded file.')
@@ -114,24 +103,6 @@ class ListCourses extends ListRecords
                         return;
                     }
 
-                    $directory = (string) config('filament-lms.common_cartridge_import.storage_directory', 'filament-lms/cartridge-imports');
-                    $storedPath = $file->storeAs(
-                        $directory,
-                        Str::uuid().'.zip',
-                        'local'
-                    );
-
-                    if ($storedPath === false) {
-                        Notification::make()
-                            ->title('Import failed')
-                            ->body('Could not store the uploaded file.')
-                            ->danger()
-                            ->send();
-
-                        return;
-                    }
-
-                    $absolutePath = Storage::disk('local')->path($storedPath);
                     $userId = auth()->id();
 
                     if ($userId === null) {
@@ -158,5 +129,47 @@ class ListCourses extends ListRecords
                 }),
             CreateAction::make(),
         ];
+    }
+
+    protected function scormPackageUploadField(int $maxUploadSizeKb): Field
+    {
+        $helperText = 'Upload a SCORM 1.2 or Articulate Storyline / Rise ZIP export. Large packages may take a minute to upload.';
+        $acceptedFileTypes = [
+            'application/zip',
+            'application/x-zip-compressed',
+            'application/octet-stream',
+        ];
+
+        if (CartridgeImportStarter::usesMultipartUpload()) {
+            /** @var class-string<Field> $uppyUploadClass */
+            $uppyUploadClass = 'SpykApp\\UppyUpload\\Forms\\Components\\UppyUpload';
+            $importStarter = app(CartridgeImportStarter::class);
+            $chunkSize = (int) config('filament-lms.common_cartridge_import.multipart_upload.chunk_size', 5 * 1024 * 1024);
+
+            return $uppyUploadClass::make('file')
+                ->label('ZIP package')
+                ->required()
+                ->disk($importStarter->storageDisk())
+                ->directory($importStarter->storageDirectory())
+                ->acceptedFileTypes($acceptedFileTypes)
+                ->maxFileSize($maxUploadSizeKb * 1024)
+                ->chunkSize($chunkSize)
+                ->single()
+                ->webcam(false)
+                ->screenCapture(false)
+                ->audio(false)
+                ->imageEditor(false)
+                ->note($helperText)
+                ->helperText($helperText);
+        }
+
+        return FileUpload::make('file')
+            ->label('ZIP package')
+            ->required()
+            ->storeFiles(false)
+            ->acceptedFileTypes($acceptedFileTypes)
+            ->rules(['mimes:zip'])
+            ->maxSize($maxUploadSizeKb)
+            ->helperText($helperText);
     }
 }

--- a/src/Services/CommonCartridge/CartridgeImportStarter.php
+++ b/src/Services/CommonCartridge/CartridgeImportStarter.php
@@ -78,40 +78,26 @@ final class CartridgeImportStarter
 
     /**
      * Move an Uppy-uploaded ZIP to a UUID filename under the staging directory.
+     *
+     * Only accepts disk-relative paths that resolve under the configured staging
+     * directory — never arbitrary filesystem paths from form state.
      */
     public function stageMultipartCartridge(mixed $file): ?string
     {
-        if (is_array($file)) {
-            $file = Arr::first($file);
-        }
+        $sourceRelativePath = $this->validatedStagingRelativePath($file);
 
-        if (! is_string($file) || $file === '') {
+        if ($sourceRelativePath === null) {
             return null;
         }
 
-        $disk = $this->storageDisk();
-        $storage = Storage::disk($disk);
+        $storage = Storage::disk($this->storageDisk());
         $uniqueRelativePath = rtrim($this->storageDirectory(), '/').'/'.Str::uuid().'.zip';
 
-        if ($storage->exists($file)) {
-            if ($file === $uniqueRelativePath) {
-                return $storage->path($file);
-            }
-
-            if (! $storage->move($file, $uniqueRelativePath)) {
-                return null;
-            }
-
-            return $storage->path($uniqueRelativePath);
+        if ($sourceRelativePath === $uniqueRelativePath) {
+            return $storage->path($sourceRelativePath);
         }
 
-        if (! is_file($file)) {
-            return null;
-        }
-
-        $contents = file_get_contents($file);
-
-        if ($contents === false || ! $storage->put($uniqueRelativePath, $contents)) {
+        if (! $storage->move($sourceRelativePath, $uniqueRelativePath)) {
             return null;
         }
 
@@ -120,29 +106,19 @@ final class CartridgeImportStarter
 
     /**
      * Resolve a relative storage path (from Uppy) to an absolute filesystem path.
+     *
+     * Rejects absolute paths and anything that does not resolve under the
+     * configured SCORM staging disk/directory.
      */
     public function absolutePathFromStoredRelativePath(mixed $file): ?string
     {
-        if (is_array($file)) {
-            $file = Arr::first($file);
-        }
+        $relativePath = $this->validatedStagingRelativePath($file);
 
-        if (! is_string($file) || $file === '') {
+        if ($relativePath === null) {
             return null;
         }
 
-        if (is_file($file)) {
-            return $file;
-        }
-
-        $disk = $this->storageDisk();
-        $storage = Storage::disk($disk);
-
-        if (! $storage->exists($file)) {
-            return null;
-        }
-
-        return $storage->path($file);
+        return Storage::disk($this->storageDisk())->path($relativePath);
     }
 
     /**
@@ -189,5 +165,74 @@ final class CartridgeImportStarter
     public function storageDirectory(): string
     {
         return (string) config('filament-lms.common_cartridge_import.storage_directory', 'filament-lms/cartridge-imports');
+    }
+
+    /**
+     * Return a disk-relative path only when it exists under the SCORM staging directory.
+     */
+    public function validatedStagingRelativePath(mixed $file): ?string
+    {
+        if (is_array($file)) {
+            $file = Arr::first($file);
+        }
+
+        if (! is_string($file) || $file === '') {
+            return null;
+        }
+
+        if ($this->isAbsolutePath($file) || str_contains($file, "\0")) {
+            return null;
+        }
+
+        $normalized = ltrim(str_replace('\\', '/', $file), '/');
+
+        if ($normalized === '') {
+            return null;
+        }
+
+        foreach (explode('/', $normalized) as $segment) {
+            if ($segment === '..') {
+                return null;
+            }
+        }
+
+        $directory = trim(str_replace('\\', '/', $this->storageDirectory()), '/');
+
+        if ($directory === '' || ! str_starts_with($normalized, $directory.'/')) {
+            return null;
+        }
+
+        $storage = Storage::disk($this->storageDisk());
+
+        if (! $storage->exists($normalized)) {
+            return null;
+        }
+
+        $absolutePath = $storage->path($normalized);
+        $stagingRoot = $storage->path($directory);
+
+        $realFile = realpath($absolutePath);
+        $realRoot = realpath($stagingRoot);
+
+        if ($realFile === false || $realRoot === false || ! is_file($realFile)) {
+            return null;
+        }
+
+        $realRootPrefix = rtrim($realRoot, DIRECTORY_SEPARATOR).DIRECTORY_SEPARATOR;
+
+        if (! str_starts_with($realFile, $realRootPrefix)) {
+            return null;
+        }
+
+        return $normalized;
+    }
+
+    private function isAbsolutePath(string $path): bool
+    {
+        if (str_starts_with($path, '/') || str_starts_with($path, '\\')) {
+            return true;
+        }
+
+        return (bool) preg_match('/^[A-Za-z]:[\\\\\\/]/', $path);
     }
 }

--- a/src/Services/CommonCartridge/CartridgeImportStarter.php
+++ b/src/Services/CommonCartridge/CartridgeImportStarter.php
@@ -42,14 +42,17 @@ final class CartridgeImportStarter
     /**
      * Stage an uploaded SCORM ZIP and return its absolute filesystem path.
      *
-     * With multipart upload enabled, the file is already on the staging disk and
-     * $file is a relative storage path (or array of paths) from Uppy.
-     * Otherwise $file is a Filament/Livewire temporary upload.
+     * Always stores under a UUID filename so concurrent imports of identically
+     * named packages cannot overwrite each other before the queued job runs.
+     *
+     * With multipart upload enabled, $file is a relative storage path (or array
+     * of paths) from Uppy and is moved to a unique name. Otherwise $file is a
+     * Filament/Livewire temporary upload that is stored as a unique ZIP.
      */
     public function stageUploadedCartridge(mixed $file): ?string
     {
         if (self::usesMultipartUpload()) {
-            return $this->absolutePathFromStoredRelativePath($file);
+            return $this->stageMultipartCartridge($file);
         }
 
         $uploadedFile = $this->resolveUploadedFile($file);
@@ -71,6 +74,48 @@ final class CartridgeImportStarter
         }
 
         return Storage::disk($disk)->path($storedPath);
+    }
+
+    /**
+     * Move an Uppy-uploaded ZIP to a UUID filename under the staging directory.
+     */
+    public function stageMultipartCartridge(mixed $file): ?string
+    {
+        if (is_array($file)) {
+            $file = Arr::first($file);
+        }
+
+        if (! is_string($file) || $file === '') {
+            return null;
+        }
+
+        $disk = $this->storageDisk();
+        $storage = Storage::disk($disk);
+        $uniqueRelativePath = rtrim($this->storageDirectory(), '/').'/'.Str::uuid().'.zip';
+
+        if ($storage->exists($file)) {
+            if ($file === $uniqueRelativePath) {
+                return $storage->path($file);
+            }
+
+            if (! $storage->move($file, $uniqueRelativePath)) {
+                return null;
+            }
+
+            return $storage->path($uniqueRelativePath);
+        }
+
+        if (! is_file($file)) {
+            return null;
+        }
+
+        $contents = file_get_contents($file);
+
+        if ($contents === false || ! $storage->put($uniqueRelativePath, $contents)) {
+            return null;
+        }
+
+        return $storage->path($uniqueRelativePath);
     }
 
     /**

--- a/src/Services/CommonCartridge/CartridgeImportStarter.php
+++ b/src/Services/CommonCartridge/CartridgeImportStarter.php
@@ -6,6 +6,8 @@ namespace Tapp\FilamentLms\Services\CommonCartridge;
 
 use Illuminate\Http\UploadedFile;
 use Illuminate\Support\Arr;
+use Illuminate\Support\Facades\Storage;
+use Illuminate\Support\Str;
 use Livewire\Features\SupportFileUploads\TemporaryUploadedFile;
 use RuntimeException;
 use Tapp\FilamentLms\Jobs\ImportCommonCartridgeJob;
@@ -13,6 +15,8 @@ use Throwable;
 
 final class CartridgeImportStarter
 {
+    private const UPPY_UPLOAD_CLASS = 'SpykApp\\UppyUpload\\Forms\\Components\\UppyUpload';
+
     public function dispatch(string $absolutePath, int $userId, int|string|null $tenantId = null, bool $sync = false): void
     {
         if (! is_file($absolutePath)) {
@@ -24,6 +28,76 @@ final class CartridgeImportStarter
         } else {
             ImportCommonCartridgeJob::dispatch($absolutePath, $userId, $tenantId);
         }
+    }
+
+    /**
+     * Whether SCORM import should use Uppy chunked uploads.
+     */
+    public static function usesMultipartUpload(): bool
+    {
+        return (bool) config('filament-lms.common_cartridge_import.multipart_upload.enabled', false)
+            && class_exists(self::UPPY_UPLOAD_CLASS);
+    }
+
+    /**
+     * Stage an uploaded SCORM ZIP and return its absolute filesystem path.
+     *
+     * With multipart upload enabled, the file is already on the staging disk and
+     * $file is a relative storage path (or array of paths) from Uppy.
+     * Otherwise $file is a Filament/Livewire temporary upload.
+     */
+    public function stageUploadedCartridge(mixed $file): ?string
+    {
+        if (self::usesMultipartUpload()) {
+            return $this->absolutePathFromStoredRelativePath($file);
+        }
+
+        $uploadedFile = $this->resolveUploadedFile($file);
+
+        if ($uploadedFile === null) {
+            return null;
+        }
+
+        $disk = $this->storageDisk();
+        $directory = $this->storageDirectory();
+        $storedPath = $uploadedFile->storeAs(
+            $directory,
+            Str::uuid().'.zip',
+            $disk
+        );
+
+        if ($storedPath === false) {
+            return null;
+        }
+
+        return Storage::disk($disk)->path($storedPath);
+    }
+
+    /**
+     * Resolve a relative storage path (from Uppy) to an absolute filesystem path.
+     */
+    public function absolutePathFromStoredRelativePath(mixed $file): ?string
+    {
+        if (is_array($file)) {
+            $file = Arr::first($file);
+        }
+
+        if (! is_string($file) || $file === '') {
+            return null;
+        }
+
+        if (is_file($file)) {
+            return $file;
+        }
+
+        $disk = $this->storageDisk();
+        $storage = Storage::disk($disk);
+
+        if (! $storage->exists($file)) {
+            return null;
+        }
+
+        return $storage->path($file);
     }
 
     /**
@@ -60,5 +134,15 @@ final class CartridgeImportStarter
         }
 
         return null;
+    }
+
+    public function storageDisk(): string
+    {
+        return (string) config('filament-lms.common_cartridge_import.storage_disk', 'local');
+    }
+
+    public function storageDirectory(): string
+    {
+        return (string) config('filament-lms.common_cartridge_import.storage_directory', 'filament-lms/cartridge-imports');
     }
 }

--- a/tests/Feature/ScormCartridgeUiImportTest.php
+++ b/tests/Feature/ScormCartridgeUiImportTest.php
@@ -167,5 +167,29 @@ test('stage multipart cartridge renames uppy upload to a unique uuid zip', funct
 });
 
 test('stage multipart cartridge returns null for missing uppy path', function () {
-    expect(app(CartridgeImportStarter::class)->stageMultipartCartridge('missing-uppy-upload.zip'))->toBeNull();
+    $starter = app(CartridgeImportStarter::class);
+
+    expect($starter->stageMultipartCartridge('missing-uppy-upload.zip'))->toBeNull()
+        ->and($starter->stageMultipartCartridge($starter->storageDirectory().'/missing-uppy-upload.zip'))->toBeNull();
+});
+
+test('staging path resolution rejects absolute paths and path traversal', function () {
+    $starter = app(CartridgeImportStarter::class);
+    $disk = $starter->storageDisk();
+    $outsidePath = storage_path('app/outside-scorm-staging.zip');
+
+    file_put_contents($outsidePath, file_get_contents(__DIR__.'/../fixtures/common-cartridge.zip'));
+
+    $traversalRelative = $starter->storageDirectory().'/../outside-scorm-staging.zip';
+
+    expect($starter->absolutePathFromStoredRelativePath($outsidePath))->toBeNull()
+        ->and($starter->absolutePathFromStoredRelativePath('/etc/passwd'))->toBeNull()
+        ->and($starter->absolutePathFromStoredRelativePath($traversalRelative))->toBeNull()
+        ->and($starter->stageMultipartCartridge($outsidePath))->toBeNull()
+        ->and($starter->stageMultipartCartridge('/etc/passwd'))->toBeNull()
+        ->and($starter->stageMultipartCartridge($traversalRelative))->toBeNull()
+        ->and($starter->validatedStagingRelativePath('other-directory/package.zip'))->toBeNull();
+
+    @unlink($outsidePath);
+    Storage::disk($disk)->delete($traversalRelative);
 });

--- a/tests/Feature/ScormCartridgeUiImportTest.php
+++ b/tests/Feature/ScormCartridgeUiImportTest.php
@@ -131,7 +131,41 @@ test('stage uploaded cartridge stores livewire upload when multipart is disabled
 
     expect($absolutePath)->not->toBeNull()
         ->and(is_file($absolutePath))->toBeTrue()
-        ->and(str_ends_with($absolutePath, '.zip'))->toBeTrue();
+        ->and(str_ends_with($absolutePath, '.zip'))->toBeTrue()
+        ->and(basename($absolutePath))->toMatch('/^[0-9a-f-]{36}\.zip$/i');
 
     @unlink($absolutePath);
+});
+
+test('stage multipart cartridge renames uppy upload to a unique uuid zip', function () {
+    $starter = app(CartridgeImportStarter::class);
+    $disk = $starter->storageDisk();
+    $sourceRelativePath = $starter->storageDirectory().'/same-package-name.zip';
+
+    Storage::disk($disk)->put($sourceRelativePath, file_get_contents(__DIR__.'/../fixtures/common-cartridge.zip'));
+
+    $firstPath = $starter->stageMultipartCartridge($sourceRelativePath);
+
+    expect($firstPath)->not->toBeNull()
+        ->and(is_file($firstPath))->toBeTrue()
+        ->and(basename($firstPath))->toMatch('/^[0-9a-f-]{36}\.zip$/i')
+        ->and(Storage::disk($disk)->exists($sourceRelativePath))->toBeFalse();
+
+    $secondSource = $starter->storageDirectory().'/same-package-name.zip';
+    Storage::disk($disk)->put($secondSource, file_get_contents(__DIR__.'/../fixtures/common-cartridge.zip'));
+
+    $secondPath = $starter->stageMultipartCartridge([$secondSource]);
+
+    expect($secondPath)->not->toBeNull()
+        ->and($secondPath)->not->toBe($firstPath)
+        ->and(is_file($firstPath))->toBeTrue()
+        ->and(is_file($secondPath))->toBeTrue()
+        ->and(basename($secondPath))->toMatch('/^[0-9a-f-]{36}\.zip$/i');
+
+    @unlink($firstPath);
+    @unlink($secondPath);
+});
+
+test('stage multipart cartridge returns null for missing uppy path', function () {
+    expect(app(CartridgeImportStarter::class)->stageMultipartCartridge('missing-uppy-upload.zip'))->toBeNull();
 });

--- a/tests/Feature/ScormCartridgeUiImportTest.php
+++ b/tests/Feature/ScormCartridgeUiImportTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 use Illuminate\Http\UploadedFile;
 use Illuminate\Support\Facades\Notification;
 use Illuminate\Support\Facades\Queue;
+use Illuminate\Support\Facades\Storage;
 use ReflectionMethod;
 use Tapp\FilamentLms\FilamentLmsServiceProvider;
 use Tapp\FilamentLms\Jobs\ImportCommonCartridgeJob;
@@ -88,3 +89,49 @@ test('cartridge import starter resolves uploaded file instances', function () {
 test('cartridge import starter throws when stored file is missing', function () {
     app(CartridgeImportStarter::class)->dispatch('/tmp/missing-scorm-package.zip', 1);
 })->throws(RuntimeException::class, 'Stored import file not found');
+
+test('multipart upload is disabled by default even when uppy class exists', function () {
+    config(['filament-lms.common_cartridge_import.multipart_upload.enabled' => false]);
+
+    expect(CartridgeImportStarter::usesMultipartUpload())->toBeFalse();
+});
+
+test('multipart upload requires both config and uppy package', function () {
+    config(['filament-lms.common_cartridge_import.multipart_upload.enabled' => true]);
+
+    expect(CartridgeImportStarter::usesMultipartUpload())
+        ->toBe(class_exists('SpykApp\\UppyUpload\\Forms\\Components\\UppyUpload'));
+});
+
+test('cartridge import starter resolves absolute path from storage relative path', function () {
+    $starter = app(CartridgeImportStarter::class);
+    $disk = $starter->storageDisk();
+    $relativePath = $starter->storageDirectory().'/ui-import-test.zip';
+
+    Storage::disk($disk)->put($relativePath, file_get_contents(__DIR__.'/../fixtures/common-cartridge.zip'));
+
+    $absolutePath = $starter->absolutePathFromStoredRelativePath($relativePath);
+
+    expect($absolutePath)->not->toBeNull()
+        ->and(is_file($absolutePath))->toBeTrue()
+        ->and($starter->absolutePathFromStoredRelativePath([$relativePath]))->toBe($absolutePath)
+        ->and($starter->absolutePathFromStoredRelativePath('missing-relative.zip'))->toBeNull()
+        ->and($starter->absolutePathFromStoredRelativePath(null))->toBeNull();
+
+    Storage::disk($disk)->delete($relativePath);
+});
+
+test('stage uploaded cartridge stores livewire upload when multipart is disabled', function () {
+    config(['filament-lms.common_cartridge_import.multipart_upload.enabled' => false]);
+
+    $starter = app(CartridgeImportStarter::class);
+    $uploadedFile = UploadedFile::fake()->create('package.zip', 100, 'application/zip');
+
+    $absolutePath = $starter->stageUploadedCartridge($uploadedFile);
+
+    expect($absolutePath)->not->toBeNull()
+        ->and(is_file($absolutePath))->toBeTrue()
+        ->and(str_ends_with($absolutePath, '.zip'))->toBeTrue();
+
+    @unlink($absolutePath);
+});


### PR DESCRIPTION
# Details

Add SCORM multi-part upload support.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes admin file-upload and staging paths for SCORM imports; new validation reduces path-traversal risk but multipart mode depends on correct config and optional package wiring.
> 
> **Overview**
> **Import SCORM Package** can use **chunked (multipart) uploads** when `common_cartridge_import.multipart_upload.enabled` is true and optional `spykapps/filament-uppy-upload` is installed; otherwise behavior stays on Filament `FileUpload`.
> 
> `ListCourses` builds the upload field via `scormPackageUploadField()` (Uppy vs standard) and the import action now calls `CartridgeImportStarter::stageUploadedCartridge()` instead of inlining store logic.
> 
> `CartridgeImportStarter` gains `usesMultipartUpload()`, unified staging with **UUID `.zip` names** for both Livewire and Uppy paths, and **`validatedStagingRelativePath()`** that rejects absolute paths, `..` traversal, and files outside the configured staging directory before queueing the job.
> 
> Config (`multipart_upload`), `composer.json` suggest, README SCORM import section, PHPStan baseline for the optional Uppy class, and feature tests cover multipart gating, staging, and path rejection.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 194940471b3bf8b0da44fc63c916d1ace2ad7970. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->