### PR TITLE
CU-868kv4cgu: list learner dashboard courses newest first

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Changed
+
+- Learner dashboard lists courses newest first (`created_at` descending).
+
 ## v4.7.6 - 2026-08-07
 
 ### What's Changed

--- a/src/Pages/Dashboard.php
+++ b/src/Pages/Dashboard.php
@@ -47,6 +47,7 @@ class Dashboard extends \Filament\Pages\Dashboard
             return Course::accessibleTo($user)
                 ->with(array_merge($creditEager, $stepEager, ['authEnrollment']))
                 ->withCount('lessons')
+                ->latest()
                 ->get();
         }
 
@@ -54,6 +55,7 @@ class Dashboard extends \Filament\Pages\Dashboard
             ->whereHas('steps')
             ->with(array_merge($creditEager, $stepEager))
             ->withCount('lessons')
+            ->latest()
             ->get();
     }
 

--- a/tests/Feature/CourseRedirectTest.php
+++ b/tests/Feature/CourseRedirectTest.php
@@ -267,6 +267,74 @@ test('course completed page redirects to current step when course has steps but 
     expect($allSteps->isEmpty())->toBeFalse();
 });
 
+test('dashboard lists courses newest first for authenticated users', function () {
+    config(['filament-lms.credits_enabled' => false]);
+
+    $user = TestUser::create([
+        'name' => 'Test User',
+        'email' => 'newest-first-auth@example.com',
+        'password' => bcrypt('password'),
+    ]);
+
+    Auth::login($user);
+
+    $older = Course::factory()->create([
+        'name' => 'Older Public Course',
+        'slug' => 'older-public-course',
+        'external_id' => 'older_public_course',
+        'is_private' => false,
+        'created_at' => now()->subDay(),
+    ]);
+    $olderLesson = Lesson::factory()->create(['course_id' => $older->id]);
+    Step::factory()->create(['lesson_id' => $olderLesson->id]);
+
+    $newer = Course::factory()->create([
+        'name' => 'Newer Public Course',
+        'slug' => 'newer-public-course',
+        'external_id' => 'newer_public_course',
+        'is_private' => false,
+        'created_at' => now(),
+    ]);
+    $newerLesson = Lesson::factory()->create(['course_id' => $newer->id]);
+    Step::factory()->create(['lesson_id' => $newerLesson->id]);
+
+    $courses = (new Dashboard)->courses();
+
+    expect($courses->pluck('name')->all())
+        ->toBe(['Newer Public Course', 'Older Public Course']);
+});
+
+test('dashboard lists courses newest first for guests', function () {
+    config(['filament-lms.credits_enabled' => false]);
+
+    Auth::logout();
+
+    $older = Course::factory()->create([
+        'name' => 'Older Guest Course',
+        'slug' => 'older-guest-course',
+        'external_id' => 'older_guest_course',
+        'is_private' => false,
+        'created_at' => now()->subDay(),
+    ]);
+    $olderLesson = Lesson::factory()->create(['course_id' => $older->id]);
+    Step::factory()->create(['lesson_id' => $olderLesson->id]);
+
+    $newer = Course::factory()->create([
+        'name' => 'Newer Guest Course',
+        'slug' => 'newer-guest-course',
+        'external_id' => 'newer_guest_course',
+        'is_private' => false,
+        'created_at' => now(),
+    ]);
+    $newerLesson = Lesson::factory()->create(['course_id' => $newer->id]);
+    Step::factory()->create(['lesson_id' => $newerLesson->id]);
+
+    $courses = (new Dashboard)->courses();
+
+    expect($courses->pluck('name')->all())
+        ->toBe(['Newer Guest Course', 'Older Guest Course']);
+});
+
 test('dashboard only shows courses with steps for authenticated users', function () {
     // Create a user and authenticate
     $user = TestUser::create([


### PR DESCRIPTION
## Summary
- Learner `/lms` grid was oldest-first because `Dashboard::courses()` had no `orderBy`.
- Both auth (`accessibleTo`) and guest query branches now use `->latest()` (`created_at` desc).
- Pest covers newest-first for authenticated users and guests. No order added to `scopeAccessibleTo` (used for access checks).

## Test plan
- [x] `vendor/bin/pest --filter="dashboard lists courses newest first"`
- [x] `vendor/bin/pest --filter="dashboard"` (11 tests)
- [ ] After merge: tag `v4.7.7` and `composer update tapp/filament-lms` in CHECK-LMS


Made with [Cursor](https://cursor.com)