### PR TITLE
Add assign user groups to course

### DIFF
--- a/README.md
+++ b/README.md
@@ -521,6 +521,17 @@ class AuthServiceProvider extends ServiceProvider
 #### Available Gates
 - `viewLmsReporting`: Controls access to the LMS reporting page. Users must pass this Gate check to view the reporting interface.
 
+## How to Assign Multiple Users to Courses
+
+Choose the approach that fits the workflow:
+
+| Approach | Best for | Where |
+|---|---|---|
+| **Bulk action on users** | Pick specific users, then assign the same course(s) to all of them | User resource table → [Assign Courses bulk action](#user-course-management-in-filament) |
+| **Dynamic user groups** | Assign a private course by shared criteria (role, department, fields, etc.) so membership updates as user data changes | Course edit → [Assigned User Groups](#dynamic-user-groups) |
+
+You can also attach users one-by-one from a user’s **Assigned Courses** tab or a course’s **Assigned Users** tab. Bulk and group assignment both set (or imply) manual vs criteria-based access as described in those sections.
+
 ## Course Authorization
 
 ### Restricting Course Visibility
@@ -570,6 +581,131 @@ public static function table(Table $table): Table
             // ... other bulk actions ...
         ]);
 }
+```
+
+When [dynamic user groups](#dynamic-user-groups) are enabled, the Assigned Courses relation manager also lists courses the user receives through group membership (with an Assignment badge: Manual, Group, or Manual + Group). Detach only applies to manually attached courses.
+
+## Dynamic User Groups
+
+Assign private courses to users by **criteria** (Filament Query Builder rules) instead of attaching individuals one by one. Membership is rebuilt when group rules change and optionally when user records are saved.
+
+The **Assigned User Groups** tab on the course edit page is **hidden until** you configure a criteria provider.
+
+### 1. Publish and run migrations
+
+If you have not already published LMS migrations (or need the newer user-group tables):
+
+```bash
+php artisan vendor:publish --tag=filament-lms-migrations
+php artisan migrate
+```
+
+This creates `lms_user_groups`, `lms_course_user_group` (with `is_default`), `lms_user_group_memberships`, and adds `is_explicitly_assigned` on `lms_course_user` when those migrations are present.
+
+### 2. Create a criteria provider
+
+Implement `Tapp\FilamentLms\UserGroups\Contracts\UserGroupCriteriaProvider` and return allow-listed `CriteriaSource` entries. Only expose fields you intend admins to filter on.
+
+```php
+<?php
+
+namespace App\Lms;
+
+use Filament\QueryBuilder\Constraints\SelectConstraint;
+use Filament\QueryBuilder\Constraints\TextConstraint;
+use Tapp\FilamentLms\UserGroups\Contracts\UserGroupCriteriaProvider;
+use Tapp\FilamentLms\UserGroups\CriteriaSource;
+
+final class AppUserGroupCriteriaProvider implements UserGroupCriteriaProvider
+{
+    public function sources(): array
+    {
+        return [
+            // Constraints apply to the configured user model (no userRelationship).
+            'user' => new CriteriaSource(
+                key: 'user',
+                label: 'User',
+                constraints: fn (): array => [
+                    TextConstraint::make('email')->label('Email'),
+                    TextConstraint::make('first_name')->label('First name'),
+                    TextConstraint::make('last_name')->label('Last name'),
+                    SelectConstraint::make('user_type')
+                        ->label('User type')
+                        ->options([
+                            'staff' => 'Staff',
+                            'admin' => 'Admin',
+                        ])
+                        ->nullable(),
+                ],
+            ),
+
+            // Optional: filter on a relationship of the user model (AND with other sources).
+            // 'roles' => new CriteriaSource(
+            //     key: 'roles',
+            //     label: 'Role',
+            //     userRelationship: 'roles',
+            //     constraints: fn (): array => [
+            //         TextConstraint::make('name')->label('Role name'),
+            //     ],
+            // ),
+        ];
+    }
+}
+```
+
+### 3. Enable in config
+
+Publish the config if needed, then set `user_groups` in `config/filament-lms.php`:
+
+```bash
+php artisan vendor:publish --tag=filament-lms-config
+```
+
+```php
+'user_groups' => [
+    // Required to enable the feature (Assigned User Groups tab).
+    'criteria_provider' => \App\Lms\AppUserGroupCriteriaProvider::class,
+
+    // Safety limits for Query Builder trees.
+    'max_rules' => 100,
+    'max_nesting_depth' => 10,
+
+    // Queue membership rebuilds (recommended in production).
+    'sync_queue' => true,
+
+    // Refresh the user's group memberships when the user model is saved.
+    'refresh_on_user_save' => true,
+
+    // Columns shown in the matching-users preview table on the course tab.
+    // Use first_name/last_name when your users table has those columns.
+    'display_columns' => [
+        'name',
+        'email',
+    ],
+
+    // Optional override for searchable columns on that preview table.
+    'search_columns' => null,
+],
+```
+
+Leaving `criteria_provider` as `null` keeps user groups disabled.
+
+### 4. Admin workflow
+
+1. Edit a course → **Assigned User Groups**.
+2. Add Query Builder rules, click **Apply filters** to preview matching users.
+3. **Save as group** (name/description). The first group on a course becomes the **default**.
+4. Use **Default group** to switch between saved groups, update rules, or choose “New unsaved criteria” to create another.
+5. Memberships sync in the background when `sync_queue` is `true`.
+
+Private courses become accessible to users who match an active group’s published membership (in addition to manually attached users with `is_explicitly_assigned`).
+
+### 5. Reconciliation command
+
+Rebuild all active group memberships (useful after imports or if the queue fell behind):
+
+```bash
+php artisan filament-lms:reconcile-user-group-memberships
 ```
 
 ## Overriding Course Visibility

--- a/config/filament-lms.php
+++ b/config/filament-lms.php
@@ -67,6 +67,30 @@ return [
         'email',
     ],
 
+    /*
+    |--------------------------------------------------------------------------
+    | Dynamic user groups
+    |--------------------------------------------------------------------------
+    |
+    | Assign courses to users by criteria instead of attaching individuals.
+    | Set criteria_provider to a class implementing
+    | Tapp\FilamentLms\UserGroups\Contracts\UserGroupCriteriaProvider.
+    | When null, the "Assigned User Groups" tab is hidden.
+    |
+    */
+    'user_groups' => [
+        'criteria_provider' => null,
+        'max_rules' => 100,
+        'max_nesting_depth' => 10,
+        'sync_queue' => true,
+        'refresh_on_user_save' => true,
+        'display_columns' => [
+            'name',
+            'email',
+        ],
+        'search_columns' => null,
+    ],
+
     // Course search columns for relation managers
     'course_search_columns' => [
         'name',

--- a/database/factories/UserGroupFactory.php
+++ b/database/factories/UserGroupFactory.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tapp\FilamentLms\Database\Factories;
+
+use Illuminate\Database\Eloquent\Factories\Factory;
+use Tapp\FilamentLms\Models\UserGroup;
+
+/**
+ * @extends Factory<UserGroup>
+ */
+class UserGroupFactory extends Factory
+{
+    protected $model = UserGroup::class;
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            'name' => $this->faker->unique()->words(3, true),
+            'description' => $this->faker->optional()->sentence(),
+            'rules' => [
+                'version' => 1,
+                'sources' => [],
+            ],
+            'rules_version' => 1,
+            'published_revision' => 0,
+            'is_active' => true,
+            'sync_status' => 'idle',
+            'sync_error' => null,
+            'last_synced_at' => null,
+        ];
+    }
+}

--- a/database/migrations/add_is_explicitly_assigned_to_lms_course_user_table.php.stub
+++ b/database/migrations/add_is_explicitly_assigned_to_lms_course_user_table.php.stub
@@ -1,0 +1,24 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('lms_course_user', function (Blueprint $table) {
+            $table->boolean('is_explicitly_assigned')
+                ->default(true)
+                ->after('completed_at');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('lms_course_user', function (Blueprint $table) {
+            $table->dropColumn('is_explicitly_assigned');
+        });
+    }
+};

--- a/database/migrations/create_lms_course_user_group_table.php.stub
+++ b/database/migrations/create_lms_course_user_group_table.php.stub
@@ -1,0 +1,26 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('lms_course_user_group', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('course_id')->constrained('lms_courses')->cascadeOnDelete();
+            $table->foreignId('user_group_id')->constrained('lms_user_groups')->cascadeOnDelete();
+            $table->boolean('is_default')->default(false);
+            $table->timestamps();
+
+            $table->unique(['course_id', 'user_group_id']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('lms_course_user_group');
+    }
+};

--- a/database/migrations/create_lms_user_group_memberships_table.php.stub
+++ b/database/migrations/create_lms_user_group_memberships_table.php.stub
@@ -1,0 +1,29 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('lms_user_group_memberships', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('user_group_id')->constrained('lms_user_groups')->cascadeOnDelete();
+            $table->unsignedBigInteger('user_id');
+            $table->unsignedInteger('revision');
+            $table->timestamp('matched_at')->nullable();
+            $table->timestamps();
+
+            $table->unique(['user_group_id', 'user_id', 'revision'], 'lms_ugm_group_user_revision_unique');
+            $table->index(['user_id', 'user_group_id', 'revision'], 'lms_ugm_user_group_revision_index');
+            $table->index(['user_group_id', 'revision'], 'lms_ugm_group_revision_index');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('lms_user_group_memberships');
+    }
+};

--- a/database/migrations/create_lms_user_groups_table.php.stub
+++ b/database/migrations/create_lms_user_groups_table.php.stub
@@ -1,0 +1,45 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+use Tapp\FilamentLms\Helpers\TenantHelper;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('lms_user_groups', function (Blueprint $table) {
+            $table->id();
+
+            if (config('filament-lms.tenancy.enabled')) {
+                $tenantModel = config('filament-lms.tenancy.model');
+                if (! $tenantModel) {
+                    throw new \Exception('Tenant model must be configured when tenancy is enabled.');
+                }
+
+                $table->foreignId(TenantHelper::getTenantColumnName())
+                    ->constrained(TenantHelper::getTenantTableName())
+                    ->cascadeOnDelete();
+            }
+
+            $table->string('name');
+            $table->text('description')->nullable();
+            $table->json('rules');
+            $table->unsignedSmallInteger('rules_version')->default(1);
+            $table->unsignedInteger('published_revision')->default(0);
+            $table->boolean('is_active')->default(true);
+            $table->string('sync_status', 32)->default('idle');
+            $table->text('sync_error')->nullable();
+            $table->timestamp('last_synced_at')->nullable();
+            $table->timestamps();
+
+            $table->index(['is_active', 'published_revision']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('lms_user_groups');
+    }
+};

--- a/resources/views/filament/course-user-groups-description.blade.php
+++ b/resources/views/filament/course-user-groups-description.blade.php
@@ -1,0 +1,30 @@
+<div class="space-y-3">
+    <p class="fi-ta-header-description text-sm text-gray-500 dark:text-gray-400">
+        @if (count($groupOptions) > 0)
+            Add criteria rules below, click Apply filters to preview matching users, then Save as group to assign them to this course. Switch Default group to edit another saved group, or choose “New unsaved criteria” to create another.
+        @else
+            Add criteria rules below, click Apply filters to preview matching users, then Save as group to assign them to this course.
+        @endif
+    </p>
+
+    @if (count($groupOptions) > 0)
+        <div class="fi-fo-field-wrp max-w-sm">
+            <label for="course-default-user-group" class="fi-fo-field-wrp-label inline-flex items-center gap-x-1.5 text-sm font-medium text-gray-950 dark:text-white">
+                Default group
+            </label>
+            <div class="mt-1">
+                <x-filament::input.wrapper>
+                    <x-filament::input.select
+                        id="course-default-user-group"
+                        wire:model.live="activeGroupId"
+                    >
+                        <option value="">New unsaved criteria</option>
+                        @foreach ($groupOptions as $id => $name)
+                            <option value="{{ $id }}">{{ $name }}</option>
+                        @endforeach
+                    </x-filament::input.select>
+                </x-filament::input.wrapper>
+            </div>
+        </div>
+    @endif
+</div>

--- a/resources/views/filament/course-user-groups-description.blade.php
+++ b/resources/views/filament/course-user-groups-description.blade.php
@@ -1,9 +1,9 @@
 <div class="space-y-3">
     <p class="fi-ta-header-description text-sm text-gray-500 dark:text-gray-400">
         @if (count($groupOptions) > 0)
-            Add criteria rules below, click Apply filters to preview matching users, then Save as group to assign them to this course. Switch Default group to edit another saved group, or choose “New unsaved criteria” to create another.
+            Add criteria below (each source is combined with AND), click Apply filters to preview matching users, then Save as group to assign them to this course. Switch Default group to edit another saved group, or choose “New unsaved criteria” to create another.
         @else
-            Add criteria rules below, click Apply filters to preview matching users, then Save as group to assign them to this course.
+            Add criteria below (each source is combined with AND), click Apply filters to preview matching users, then Save as group to assign them to this course.
         @endif
     </p>
 

--- a/src/Actions/AssignCoursesBulkAction.php
+++ b/src/Actions/AssignCoursesBulkAction.php
@@ -36,7 +36,11 @@ class AssignCoursesBulkAction extends BulkAction
                     /** @var Model&FilamentLmsUserInterface $record */
                     if (method_exists($record, 'courses')) {
                         // @phpstan-ignore-next-line - courses() method is provided by FilamentLmsUser trait
-                        $record->courses()->syncWithoutDetaching($data['courses']);
+                        $pivotData = [];
+                        foreach ($data['courses'] as $courseId) {
+                            $pivotData[$courseId] = ['is_explicitly_assigned' => true];
+                        }
+                        $record->courses()->syncWithoutDetaching($pivotData);
                     }
                 }
             })

--- a/src/Console/Commands/ReconcileUserGroupMemberships.php
+++ b/src/Console/Commands/ReconcileUserGroupMemberships.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tapp\FilamentLms\Console\Commands;
+
+use Illuminate\Console\Command;
+use Tapp\FilamentLms\UserGroups\UserGroupCriteriaRegistry;
+use Tapp\FilamentLms\UserGroups\UserGroupMembershipSynchronizer;
+
+final class ReconcileUserGroupMemberships extends Command
+{
+    protected $signature = 'filament-lms:reconcile-user-group-memberships';
+
+    protected $description = 'Rebuild published memberships for all active LMS user groups';
+
+    public function handle(
+        UserGroupCriteriaRegistry $registry,
+        UserGroupMembershipSynchronizer $synchronizer,
+    ): int {
+        if (! $registry->enabled()) {
+            $this->warn('User groups are not enabled (no criteria provider configured).');
+
+            return self::SUCCESS;
+        }
+
+        $count = $synchronizer->reconcileAll();
+        $this->info("Reconciled {$count} user group(s).");
+
+        return self::SUCCESS;
+    }
+}

--- a/src/FilamentLmsServiceProvider.php
+++ b/src/FilamentLmsServiceProvider.php
@@ -14,6 +14,7 @@ use Tapp\FilamentLibrary\Models\LibraryItem;
 use Tapp\FilamentLms\Console\Commands\BackfillCourseCompletedAt;
 use Tapp\FilamentLms\Console\Commands\BackfillEmbeddedPlayerCourses;
 use Tapp\FilamentLms\Console\Commands\ImportCartridgesCommand;
+use Tapp\FilamentLms\Console\Commands\ReconcileUserGroupMemberships;
 use Tapp\FilamentLms\Livewire\DocumentStep;
 use Tapp\FilamentLms\Livewire\FormStep;
 use Tapp\FilamentLms\Livewire\ImageStep;
@@ -26,7 +27,9 @@ use Tapp\FilamentLms\Livewire\VideoPlayer;
 use Tapp\FilamentLms\Livewire\VideoStep;
 use Tapp\FilamentLms\Livewire\ViewGradedEntry;
 use Tapp\FilamentLms\Livewire\VimeoVideo;
+use Tapp\FilamentLms\Observers\UserGroupMembershipUserObserver;
 use Tapp\FilamentLms\Pages\CreateTestEntry;
+use Tapp\FilamentLms\UserGroups\UserGroupCriteriaRegistry;
 
 class FilamentLmsServiceProvider extends PackageServiceProvider
 {
@@ -65,10 +68,15 @@ class FilamentLmsServiceProvider extends PackageServiceProvider
                 'add_evaluation_course_id_to_lms_courses_table',
                 'add_filament_form_user_id_to_lms_step_user_table',
                 'add_evaluation_primary_course_id_to_lms_step_user_table',
+                'create_lms_user_groups_table',
+                'create_lms_course_user_group_table',
+                'create_lms_user_group_memberships_table',
+                'add_is_explicitly_assigned_to_lms_course_user_table',
             ])
             ->hasCommand(BackfillCourseCompletedAt::class)
             ->hasCommand(BackfillEmbeddedPlayerCourses::class)
             ->hasCommand(ImportCartridgesCommand::class)
+            ->hasCommand(ReconcileUserGroupMemberships::class)
             ->hasInstallCommand(function (InstallCommand $command) {
                 $command
                     ->publishMigrations()
@@ -129,6 +137,24 @@ class FilamentLmsServiceProvider extends PackageServiceProvider
         $this->loadRoutesFrom(__DIR__.'/../routes/web.php');
 
         $this->configureLivewireTemporaryUploadLimits();
+        $this->registerUserGroupMembershipObserver();
+    }
+
+    protected function registerUserGroupMembershipObserver(): void
+    {
+        $registry = $this->app->make(UserGroupCriteriaRegistry::class);
+
+        if (! $registry->enabled()) {
+            return;
+        }
+
+        $userModel = config('filament-lms.user_model');
+
+        if (! is_string($userModel) || ! class_exists($userModel)) {
+            return;
+        }
+
+        $userModel::observe(UserGroupMembershipUserObserver::class);
     }
 
     protected function configureLivewireTemporaryUploadLimits(): void

--- a/src/Jobs/RebuildUserGroupMemberships.php
+++ b/src/Jobs/RebuildUserGroupMemberships.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tapp\FilamentLms\Jobs;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+use Tapp\FilamentLms\Models\UserGroup;
+use Tapp\FilamentLms\UserGroups\UserGroupMembershipSynchronizer;
+
+final class RebuildUserGroupMemberships implements ShouldQueue
+{
+    use Dispatchable;
+    use InteractsWithQueue;
+    use Queueable;
+    use SerializesModels;
+
+    public function __construct(
+        public int $userGroupId,
+    ) {}
+
+    public function handle(UserGroupMembershipSynchronizer $synchronizer): void
+    {
+        $group = UserGroup::query()->find($this->userGroupId);
+
+        if ($group === null || ! $group->is_active) {
+            return;
+        }
+
+        $synchronizer->rebuild($group);
+    }
+}

--- a/src/Jobs/RefreshUserGroupMembershipsForUser.php
+++ b/src/Jobs/RefreshUserGroupMembershipsForUser.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tapp\FilamentLms\Jobs;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+use Tapp\FilamentLms\UserGroups\UserGroupCriteriaRegistry;
+use Tapp\FilamentLms\UserGroups\UserGroupMembershipSynchronizer;
+
+final class RefreshUserGroupMembershipsForUser implements ShouldQueue
+{
+    use Dispatchable;
+    use InteractsWithQueue;
+    use Queueable;
+    use SerializesModels;
+
+    public function __construct(
+        public int|string $userId,
+    ) {}
+
+    public function handle(
+        UserGroupCriteriaRegistry $registry,
+        UserGroupMembershipSynchronizer $synchronizer,
+    ): void {
+        if (! $registry->enabled()) {
+            return;
+        }
+
+        $synchronizer->refreshUser($this->userId);
+    }
+}

--- a/src/Models/Course.php
+++ b/src/Models/Course.php
@@ -32,6 +32,7 @@ use Tapp\FilamentLms\Pages\Dashboard;
 use Tapp\FilamentLms\Pages\Step as StepPage;
 use Tapp\FilamentLms\Services\CourseEvaluationService;
 use Tapp\FilamentLms\Traits\HasMediaUrl;
+use Tapp\FilamentLms\UserGroups\CourseAccessResolver;
 
 /**
  * @property int $id
@@ -90,34 +91,15 @@ final class Course extends Model implements HasMedia
      */
     public function scopeAccessibleTo(Builder $query, $user): void
     {
-        $query->where(function ($q) use ($user) {
-            // Public courses - not private, accessible to everyone
-            $q->where('is_private', false)
-              // Private courses - only accessible to LMS admins or assigned users
-                ->orWhere(function ($subQ) use ($user) {
-                    $subQ->where('is_private', true)
-                        ->where(function ($adminOrAssignedQuery) use ($user) {
-                            // LMS admins can see all private courses
-                            if ($user->isLmsAdmin()) {
-                                $adminOrAssignedQuery->whereRaw('1 = 1'); // Always true for admins
-                            } else {
-                                // Non-admins can only see assigned courses
-                                $adminOrAssignedQuery->whereHas('users', function ($userQuery) use ($user) {
-                                    $userQuery->where('user_id', $user->id);
-                                });
-                            }
-                        });
-                });
-        })
-        // Only include courses that have at least one step
-            ->whereHas('steps')
-            ->when(config('filament-lms.evaluations.enabled', false), function (Builder $query): void {
-                $evaluationCourseIds = app(CourseEvaluationService::class)->lockedEvaluationCourseIds();
+        app(CourseAccessResolver::class)->scopeAccessibleTo($query, $user);
+    }
 
-                if ($evaluationCourseIds->isNotEmpty()) {
-                    $query->whereNotIn('lms_courses.id', $evaluationCourseIds);
-                }
-            });
+    /**
+     * Courses assigned to the user via lms_course_user and/or active user-group membership.
+     */
+    public function scopeAssignedToUser(Builder $query, $user): void
+    {
+        app(CourseAccessResolver::class)->scopeAssignedToUser($query, $user);
     }
 
     /**
@@ -366,7 +348,10 @@ final class Course extends Model implements HasMedia
             $this->users()->updateExistingPivot($userId, ['completed_at' => $completedAt]);
         } else {
             try {
-                $this->users()->attach($userId, ['completed_at' => $completedAt]);
+                $this->users()->attach($userId, [
+                    'completed_at' => $completedAt,
+                    'is_explicitly_assigned' => false,
+                ]);
             } catch (UniqueConstraintViolationException) {
                 $this->users()->updateExistingPivot($userId, ['completed_at' => $completedAt]);
             }
@@ -514,8 +499,47 @@ final class Course extends Model implements HasMedia
         $userModel = config('filament-lms.user_model');
 
         return $this->belongsToMany($userModel, 'lms_course_user', 'course_id', 'user_id')
-            ->withPivot('completed_at')
+            ->withPivot('completed_at', 'is_explicitly_assigned')
             ->withTimestamps();
+    }
+
+    /**
+     * Dynamic criteria groups assigned to this course.
+     *
+     * @return BelongsToMany<UserGroup, $this>
+     */
+    public function userGroups(): BelongsToMany
+    {
+        return $this->belongsToMany(UserGroup::class, 'lms_course_user_group', 'course_id', 'user_group_id')
+            ->withPivot('is_default')
+            ->withTimestamps();
+    }
+
+    public function defaultUserGroup(): ?UserGroup
+    {
+        $default = $this->userGroups()
+            ->wherePivot('is_default', true)
+            ->orderBy('lms_user_groups.name')
+            ->first();
+
+        if ($default !== null) {
+            return $default;
+        }
+
+        return $this->userGroups()
+            ->orderBy('lms_user_groups.name')
+            ->first();
+    }
+
+    public function setDefaultUserGroup(?int $userGroupId): void
+    {
+        $this->userGroups()->newPivotQuery()->update(['is_default' => false]);
+
+        if ($userGroupId === null) {
+            return;
+        }
+
+        $this->userGroups()->updateExistingPivot($userGroupId, ['is_default' => true]);
     }
 
     /**
@@ -527,7 +551,7 @@ final class Course extends Model implements HasMedia
         $userModel = config('filament-lms.user_model');
 
         return $this->belongsToMany($userModel, 'lms_course_user', 'course_id', 'user_id')
-            ->withPivot('completed_at')
+            ->withPivot('completed_at', 'is_explicitly_assigned')
             ->withTimestamps()
             ->where('lms_course_user.user_id', Auth::id());
     }
@@ -574,31 +598,7 @@ final class Course extends Model implements HasMedia
      */
     public function canBeAccessedBy($user): bool
     {
-        if (! $user) {
-            return false;
-        }
-
-        if ($this->isEvaluationCourse()) {
-            if ($user->isLmsAdmin()) {
-                return true;
-            }
-
-            return app(CourseEvaluationService::class)->isEvaluationUnlockedForUser($this, $user)
-                && ($this->users()->where('user_id', $user->id)->exists() || ! $this->is_private);
-        }
-
-        // Public courses (not private) - accessible to everyone
-        if (! $this->is_private) {
-            return true;
-        }
-
-        // Private courses - only accessible to LMS admins or assigned users
-        if ($user->isLmsAdmin()) {
-            return true;
-        }
-
-        // Check if user is assigned to this course
-        return $this->users()->where('user_id', $user->id)->exists();
+        return app(CourseAccessResolver::class)->canAccess($this, $user);
     }
 
     /**

--- a/src/Models/Course.php
+++ b/src/Models/Course.php
@@ -506,11 +506,12 @@ final class Course extends Model implements HasMedia
     /**
      * Dynamic criteria groups assigned to this course.
      *
-     * @return BelongsToMany<UserGroup, $this>
+     * @return BelongsToMany<UserGroup, $this, CourseUserGroup>
      */
     public function userGroups(): BelongsToMany
     {
         return $this->belongsToMany(UserGroup::class, 'lms_course_user_group', 'course_id', 'user_group_id')
+            ->using(CourseUserGroup::class)
             ->withPivot('is_default')
             ->withTimestamps();
     }

--- a/src/Models/CourseUserGroup.php
+++ b/src/Models/CourseUserGroup.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tapp\FilamentLms\Models;
+
+use Illuminate\Database\Eloquent\Relations\Pivot;
+
+/**
+ * @property int $id
+ * @property int $course_id
+ * @property int $user_group_id
+ * @property bool $is_default
+ */
+class CourseUserGroup extends Pivot
+{
+    protected $table = 'lms_course_user_group';
+
+    /**
+     * @return array<string, string>
+     */
+    protected function casts(): array
+    {
+        return [
+            'is_default' => 'boolean',
+        ];
+    }
+}

--- a/src/Models/UserGroup.php
+++ b/src/Models/UserGroup.php
@@ -1,0 +1,95 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tapp\FilamentLms\Models;
+
+use Carbon\Carbon;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+use Tapp\FilamentLms\Database\Factories\UserGroupFactory;
+use Tapp\FilamentLms\Models\Traits\BelongsToTenant;
+
+/**
+ * @property int $id
+ * @property string $name
+ * @property string|null $description
+ * @property array $rules
+ * @property int $rules_version
+ * @property int $published_revision
+ * @property bool $is_active
+ * @property string $sync_status
+ * @property string|null $sync_error
+ * @property Carbon|null $last_synced_at
+ * @property Carbon $created_at
+ * @property Carbon $updated_at
+ */
+class UserGroup extends Model
+{
+    use BelongsToTenant;
+    use HasFactory;
+
+    protected $guarded = [];
+
+    protected $table = 'lms_user_groups';
+
+    /**
+     * @return array<string, string>
+     */
+    protected function casts(): array
+    {
+        return [
+            'rules' => 'array',
+            'rules_version' => 'integer',
+            'published_revision' => 'integer',
+            'is_active' => 'boolean',
+            'last_synced_at' => 'datetime',
+        ];
+    }
+
+    protected static function newFactory(): UserGroupFactory
+    {
+        return UserGroupFactory::new();
+    }
+
+    /**
+     * @return BelongsToMany<Course, $this>
+     */
+    public function courses(): BelongsToMany
+    {
+        return $this->belongsToMany(Course::class, 'lms_course_user_group', 'user_group_id', 'course_id')
+            ->withPivot('is_default')
+            ->withTimestamps();
+    }
+
+    /**
+     * @return HasMany<UserGroupMembership, $this>
+     */
+    public function memberships(): HasMany
+    {
+        return $this->hasMany(UserGroupMembership::class);
+    }
+
+    /**
+     * @return HasMany<UserGroupMembership, $this>
+     */
+    public function publishedMemberships(): HasMany
+    {
+        return $this->memberships()
+            ->where('revision', $this->published_revision);
+    }
+
+    public function hasPublishedMembership(int|string $userId): bool
+    {
+        if ($this->published_revision < 1 || ! $this->is_active) {
+            return false;
+        }
+
+        return $this->memberships()
+            ->where('revision', $this->published_revision)
+            ->where('user_id', $userId)
+            ->exists();
+    }
+}

--- a/src/Models/UserGroup.php
+++ b/src/Models/UserGroup.php
@@ -25,6 +25,7 @@ use Tapp\FilamentLms\Models\Traits\BelongsToTenant;
  * @property Carbon|null $last_synced_at
  * @property Carbon $created_at
  * @property Carbon $updated_at
+ * @property-read CourseUserGroup|null $pivot
  */
 class UserGroup extends Model
 {
@@ -55,11 +56,12 @@ class UserGroup extends Model
     }
 
     /**
-     * @return BelongsToMany<Course, $this>
+     * @return BelongsToMany<Course, $this, CourseUserGroup>
      */
     public function courses(): BelongsToMany
     {
         return $this->belongsToMany(Course::class, 'lms_course_user_group', 'user_group_id', 'course_id')
+            ->using(CourseUserGroup::class)
             ->withPivot('is_default')
             ->withTimestamps();
     }

--- a/src/Models/UserGroupMembership.php
+++ b/src/Models/UserGroupMembership.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tapp\FilamentLms\Models;
+
+use Carbon\Carbon;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+/**
+ * @property int $id
+ * @property int $user_group_id
+ * @property int $user_id
+ * @property int $revision
+ * @property Carbon|null $matched_at
+ * @property Carbon $created_at
+ * @property Carbon $updated_at
+ * @property-read UserGroup $userGroup
+ */
+class UserGroupMembership extends Model
+{
+    protected $guarded = [];
+
+    protected $table = 'lms_user_group_memberships';
+
+    /**
+     * @return array<string, string>
+     */
+    protected function casts(): array
+    {
+        return [
+            'revision' => 'integer',
+            'matched_at' => 'datetime',
+        ];
+    }
+
+    /**
+     * @return BelongsTo<UserGroup, $this>
+     */
+    public function userGroup(): BelongsTo
+    {
+        return $this->belongsTo(UserGroup::class);
+    }
+
+    public function user(): BelongsTo
+    {
+        $userModel = config('filament-lms.user_model');
+
+        return $this->belongsTo($userModel, 'user_id');
+    }
+}

--- a/src/Observers/UserGroupMembershipUserObserver.php
+++ b/src/Observers/UserGroupMembershipUserObserver.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tapp\FilamentLms\Observers;
+
+use Illuminate\Database\Eloquent\Model;
+use Tapp\FilamentLms\Jobs\RefreshUserGroupMembershipsForUser;
+use Tapp\FilamentLms\UserGroups\UserGroupCriteriaRegistry;
+
+final class UserGroupMembershipUserObserver
+{
+    public function __construct(
+        private readonly UserGroupCriteriaRegistry $registry,
+    ) {}
+
+    public function saved(Model $user): void
+    {
+        $this->queueRefresh($user);
+    }
+
+    public function deleted(Model $user): void
+    {
+        $this->queueRefresh($user);
+    }
+
+    private function queueRefresh(Model $user): void
+    {
+        if (! $this->registry->enabled()) {
+            return;
+        }
+
+        if (! config('filament-lms.user_groups.refresh_on_user_save', true)) {
+            return;
+        }
+
+        RefreshUserGroupMembershipsForUser::dispatch($user->getKey());
+    }
+}

--- a/src/RelationManagers/CourseUserGroupsRelationManager.php
+++ b/src/RelationManagers/CourseUserGroupsRelationManager.php
@@ -80,7 +80,7 @@ class CourseUserGroupsRelationManager extends RelationManager
                 Action::make('saveGroup')
                     ->label(fn (): string => $this->resolvedActiveGroupId() !== null ? 'Update group' : 'Save as group')
                     ->color('primary')
-                    ->form([
+                    ->schema([
                         TextInput::make('name')
                             ->required()
                             ->maxLength(255)
@@ -142,8 +142,6 @@ class CourseUserGroupsRelationManager extends RelationManager
     protected function criteriaFilters(): array
     {
         $registry = app(UserGroupCriteriaRegistry::class);
-        $maxRules = (int) config('filament-lms.user_groups.max_rules', 100);
-        $maxNestingDepth = (int) config('filament-lms.user_groups.max_nesting_depth', 10);
         $filters = [];
 
         foreach ($registry->sources() as $source) {
@@ -151,8 +149,6 @@ class CourseUserGroupsRelationManager extends RelationManager
                 ->label($source->label)
                 ->constraints($this->freshConstraints($source))
                 ->constraintPickerColumns(2)
-                ->maxRules($maxRules)
-                ->maxNestingDepth($maxNestingDepth)
                 ->schema(fn (QueryBuilder $filter): array => [
                     Fieldset::make($source->label)
                         ->columns(1)
@@ -162,13 +158,9 @@ class CourseUserGroupsRelationManager extends RelationManager
                                 ->constraints($filter->getConstraints())
                                 ->blockPickerColumns($filter->getConstraintPickerColumns())
                                 ->blockPickerWidth($filter->getConstraintPickerWidth())
-                                ->maxRules($filter->getMaxRules())
-                                ->maxNestingDepth($filter->getMaxNestingDepth())
                                 ->addAction(fn (Action $action): Action => $action
                                     ->label("Add {$source->label} rule")
-                                    ->icon(FilamentIcon::resolve(QueryBuilderIconAlias::ADD_RULE_ACTION) ?? Heroicon::Plus)
-                                    ->disabled(fn (RuleBuilder $component): bool => $component->isAtRuleLimit())
-                                    ->tooltip(fn (RuleBuilder $component): ?string => $component->getRuleLimitReachedTooltip())),
+                                    ->icon(FilamentIcon::resolve(QueryBuilderIconAlias::ADD_RULE_ACTION) ?? Heroicon::Plus)),
                         ]),
                 ])
                 // Matching is applied in resolveMatchingUsersQuery() so related-model

--- a/src/RelationManagers/CourseUserGroupsRelationManager.php
+++ b/src/RelationManagers/CourseUserGroupsRelationManager.php
@@ -1,0 +1,546 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tapp\FilamentLms\RelationManagers;
+
+use Filament\Actions\Action;
+use Filament\Forms\Components\TextInput;
+use Filament\Notifications\Notification;
+use Filament\QueryBuilder\Constraints\Constraint;
+use Filament\Resources\RelationManagers\RelationManager;
+use Filament\Schemas\Schema;
+use Filament\Tables\Columns\TextColumn;
+use Filament\Tables\Enums\FiltersLayout;
+use Filament\Tables\Filters\QueryBuilder;
+use Filament\Tables\Table;
+use Illuminate\Contracts\View\View;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Validation\ValidationException;
+use Tapp\FilamentLms\Models\Course;
+use Tapp\FilamentLms\Models\UserGroup;
+use Tapp\FilamentLms\UserGroups\CriteriaSource;
+use Tapp\FilamentLms\UserGroups\UserGroupCriteriaRegistry;
+use Tapp\FilamentLms\UserGroups\UserGroupMembershipSynchronizer;
+use Tapp\FilamentLms\UserGroups\UserGroupRuleMatcher;
+
+class CourseUserGroupsRelationManager extends RelationManager
+{
+    protected static string $relationship = 'userGroups';
+
+    protected static ?string $title = 'Assigned User Groups';
+
+    protected static ?string $modelLabel = 'User Group';
+
+    protected static ?string $pluralModelLabel = 'User Groups';
+
+    public ?string $activeGroupId = null;
+
+    public static function canViewForRecord(Model $ownerRecord, string $pageClass): bool
+    {
+        return app(UserGroupCriteriaRegistry::class)->enabled();
+    }
+
+    public function mount(): void
+    {
+        parent::mount();
+
+        /** @var Course $course */
+        $course = $this->getOwnerRecord();
+        $defaultGroupId = $course->defaultUserGroup()?->id;
+        $this->activeGroupId = $defaultGroupId !== null ? (string) $defaultGroupId : null;
+        $this->loadActiveGroupIntoFilters();
+    }
+
+    public function form(Schema $schema): Schema
+    {
+        return $schema->components([]);
+    }
+
+    public function table(Table $table): Table
+    {
+        $displayColumns = config('filament-lms.user_groups.display_columns', ['name', 'email']);
+
+        return $table
+            ->query(fn (): Builder => $this->resolveMatchingUsersQuery())
+            ->columns($this->userTableColumns($displayColumns))
+            ->heading('Assigned User Groups')
+            ->description(fn (): View => view('filament-lms::filament.course-user-groups-description', [
+                'groupOptions' => $this->attachedGroupOptions(),
+            ]))
+            ->filters($this->criteriaFilters(), layout: FiltersLayout::AboveContent)
+            ->deferFilters()
+            ->headerActions([
+                Action::make('saveGroup')
+                    ->label(fn (): string => $this->resolvedActiveGroupId() !== null ? 'Update group' : 'Save as group')
+                    ->color('primary')
+                    ->form([
+                        TextInput::make('name')
+                            ->required()
+                            ->maxLength(255)
+                            ->default(fn (): ?string => $this->activeGroup()?->name),
+                        TextInput::make('description')
+                            ->maxLength(1000)
+                            ->default(fn (): ?string => $this->activeGroup()?->description),
+                    ])
+                    ->action(function (array $data): void {
+                        $this->saveActiveGroup($data);
+                        $this->refreshMatchingUsersTable();
+                    }),
+                Action::make('removeGroup')
+                    ->label('Remove group')
+                    ->color('danger')
+                    ->requiresConfirmation()
+                    ->visible(fn (): bool => $this->resolvedActiveGroupId() !== null)
+                    ->action(function (): void {
+                        $this->removeActiveGroup();
+                        $this->refreshMatchingUsersTable();
+                    }),
+            ])
+            ->recordActions([])
+            ->toolbarActions([])
+            ->emptyStateHeading('No matching users')
+            ->emptyStateDescription('Add criteria above and apply filters to preview matching users, then save as a group.');
+    }
+
+    /**
+     * @param  list<string>  $displayColumns
+     * @return array<int, TextColumn>
+     */
+    protected function userTableColumns(array $displayColumns): array
+    {
+        $columns = [];
+
+        foreach ($displayColumns as $column) {
+            $columns[] = TextColumn::make($column)
+                ->label(str($column)->replace('_', ' ')->title()->toString())
+                ->searchable()
+                ->sortable();
+        }
+
+        if ($columns === []) {
+            $columns[] = TextColumn::make('email')->searchable()->sortable();
+        }
+
+        return $columns;
+    }
+
+    /**
+     * One official QueryBuilder filter per criteria source.
+     *
+     * Nested custom RuleBuilders (inside Form Builder / Repeater) break Filament
+     * schema container initialization; Tables\Filters\QueryBuilder is the supported path.
+     *
+     * @return list<QueryBuilder>
+     */
+    protected function criteriaFilters(): array
+    {
+        $registry = app(UserGroupCriteriaRegistry::class);
+        $maxRules = (int) config('filament-lms.user_groups.max_rules', 100);
+        $maxNestingDepth = (int) config('filament-lms.user_groups.max_nesting_depth', 10);
+        $filters = [];
+
+        foreach ($registry->sources() as $source) {
+            $filters[] = QueryBuilder::make($source->key)
+                ->label($source->label)
+                ->constraints($this->freshConstraints($source))
+                ->constraintPickerColumns(2)
+                ->maxRules($maxRules)
+                ->maxNestingDepth($maxNestingDepth)
+                // Matching is applied in resolveMatchingUsersQuery() so related-model
+                // sources can use whereHas and unsaved drafts can still preview.
+                ->query(fn (Builder $query): Builder => $query)
+                ->baseQuery(fn (Builder $query): Builder => $query)
+                ->indicateUsing(function (array $state) use ($source): array {
+                    try {
+                        return app(UserGroupRuleMatcher::class)->summarize([
+                            'version' => 1,
+                            'sources' => [[
+                                'source' => $source->key,
+                                'rules' => is_array($state['rules'] ?? null) ? $state['rules'] : [],
+                            ]],
+                        ]);
+                    } catch (\InvalidArgumentException) {
+                        return [];
+                    }
+                });
+        }
+
+        return $filters;
+    }
+
+    /**
+     * @return list<Constraint>
+     */
+    protected function freshConstraints(CriteriaSource $source): array
+    {
+        return $source->getConstraints();
+    }
+
+    protected function resolveMatchingUsersQuery(): Builder
+    {
+        /** @var class-string<Model> $userModel */
+        $userModel = config('filament-lms.user_model');
+        $keyName = (new $userModel)->getQualifiedKeyName();
+
+        $sources = $this->activeFilterSources();
+
+        if ($sources !== []) {
+            try {
+                return app(UserGroupRuleMatcher::class)->matchingUsersQuery([
+                    'version' => 1,
+                    'sources' => $sources,
+                ]);
+            } catch (\InvalidArgumentException $exception) {
+                throw ValidationException::withMessages([
+                    'mountedTableFilters' => $exception->getMessage(),
+                ]);
+            }
+        }
+
+        $group = $this->activeGroup();
+
+        if ($group !== null && $group->published_revision > 0) {
+            return $userModel::query()->whereIn(
+                $keyName,
+                $group->publishedMemberships()->select('user_id'),
+            );
+        }
+
+        return $userModel::query()->whereRaw('0 = 1');
+    }
+
+    /**
+     * @return list<array{source: string, rules: array<string, mixed>}>
+     */
+    protected function activeFilterSources(): array
+    {
+        try {
+            return app(UserGroupRuleMatcher::class)->normalize([
+                'version' => 1,
+                'sources' => $this->normalizeFilterSources($this->tableFilters ?? []),
+            ])['sources'];
+        } catch (\InvalidArgumentException) {
+            return [];
+        }
+    }
+
+    /**
+     * @return array<int|string, string>
+     */
+    protected function attachedGroupOptions(): array
+    {
+        /** @var Course $course */
+        $course = $this->getOwnerRecord();
+
+        return $course->userGroups()
+            ->orderBy('lms_user_groups.name')
+            ->get()
+            ->mapWithKeys(function (UserGroup $group): array {
+                $label = $group->name;
+
+                if ((bool) $group->pivot?->is_default) {
+                    $label .= ' (default)';
+                }
+
+                return [$group->id => $label];
+            })
+            ->all();
+    }
+
+    protected function resolvedActiveGroupId(): ?int
+    {
+        if (blank($this->activeGroupId)) {
+            return null;
+        }
+
+        return (int) $this->activeGroupId;
+    }
+
+    protected function activeGroup(): ?UserGroup
+    {
+        $groupId = $this->resolvedActiveGroupId();
+
+        if ($groupId === null) {
+            return null;
+        }
+
+        /** @var Course $course */
+        $course = $this->getOwnerRecord();
+
+        return $course->userGroups()->where('lms_user_groups.id', $groupId)->first();
+    }
+
+    /**
+     * @return array<string, array{rules: array<string, mixed>}>
+     */
+    protected function filterStateForActiveGroup(): array
+    {
+        $group = $this->activeGroup();
+        $sources = $group?->rules['sources'] ?? [];
+        $rulesBySource = [];
+
+        foreach ($sources as $source) {
+            if (! is_array($source) || blank($source['source'] ?? null)) {
+                continue;
+            }
+
+            $rulesBySource[(string) $source['source']] = is_array($source['rules'] ?? null)
+                ? $source['rules']
+                : [];
+        }
+
+        $state = [];
+
+        foreach (app(UserGroupCriteriaRegistry::class)->sources() as $key => $source) {
+            $state[$key] = [
+                'rules' => $rulesBySource[$key] ?? [],
+            ];
+        }
+
+        return $state;
+    }
+
+    protected function loadActiveGroupIntoFilters(): void
+    {
+        $state = $this->filterStateForActiveGroup();
+
+        $this->tableFilters = $state;
+        $this->tableDeferredFilters = $state;
+
+        if (! isset($this->table)) {
+            return;
+        }
+
+        $this->getTableFiltersForm()->fill($state);
+    }
+
+    protected function refreshMatchingUsersTable(): void
+    {
+        $this->resetPage();
+        $this->flushCachedTableRecords();
+    }
+
+    /**
+     * @param  array<string, mixed>  $data
+     */
+    protected function saveActiveGroup(array $data): void
+    {
+        $rules = [
+            'version' => 1,
+            'sources' => $this->normalizeFilterSources(
+                $this->getTable()->hasDeferredFilters()
+                    ? ($this->tableDeferredFilters ?? $this->tableFilters ?? [])
+                    : ($this->tableFilters ?? [])
+            ),
+        ];
+
+        try {
+            $rules = app(UserGroupRuleMatcher::class)->normalize($rules);
+        } catch (\InvalidArgumentException $exception) {
+            Notification::make()
+                ->title('Invalid criteria')
+                ->body($exception->getMessage())
+                ->danger()
+                ->send();
+
+            return;
+        }
+
+        if ($rules['sources'] === []) {
+            Notification::make()
+                ->title('Add at least one criteria rule before saving.')
+                ->danger()
+                ->send();
+
+            return;
+        }
+
+        /** @var Course $course */
+        $course = $this->getOwnerRecord();
+        $group = $this->activeGroup();
+        $makeDefault = $course->userGroups()->wherePivot('is_default', true)->doesntExist();
+
+        if ($group === null) {
+            $group = UserGroup::query()->create([
+                'name' => $data['name'],
+                'description' => $data['description'] ?? null,
+                'rules' => $rules,
+                'is_active' => true,
+            ]);
+            $course->userGroups()->attach($group->id, [
+                'is_default' => $makeDefault,
+            ]);
+            $this->activeGroupId = (string) $group->id;
+
+            if ($makeDefault) {
+                $course->setDefaultUserGroup($group->id);
+            }
+        } else {
+            $group->forceFill([
+                'name' => $data['name'],
+                'description' => $data['description'] ?? null,
+                'rules' => $rules,
+                'is_active' => true,
+            ])->save();
+        }
+
+        app(UserGroupMembershipSynchronizer::class)->queueRebuild($group->fresh());
+        $this->loadActiveGroupIntoFilters();
+
+        Notification::make()
+            ->title('User group saved')
+            ->success()
+            ->send();
+    }
+
+    protected function removeActiveGroup(): void
+    {
+        $group = $this->activeGroup();
+
+        if ($group === null) {
+            return;
+        }
+
+        /** @var Course $course */
+        $course = $this->getOwnerRecord();
+        $wasDefault = (bool) $group->pivot?->is_default;
+        $course->userGroups()->detach($group->id);
+
+        if ($group->courses()->count() === 0) {
+            $group->delete();
+        }
+
+        $nextDefault = $course->defaultUserGroup();
+
+        if ($wasDefault && $nextDefault !== null) {
+            $course->setDefaultUserGroup($nextDefault->id);
+        }
+
+        $this->activeGroupId = $nextDefault !== null ? (string) $nextDefault->id : null;
+        $this->loadActiveGroupIntoFilters();
+
+        Notification::make()
+            ->title('User group removed from course')
+            ->success()
+            ->send();
+    }
+
+    /**
+     * @return list<array{source: string, rules: array<string, mixed>}>
+     */
+    protected function normalizeFilterSources(mixed $state): array
+    {
+        if (! is_array($state)) {
+            return [];
+        }
+
+        $normalized = [];
+        $configuredKeys = array_keys(app(UserGroupCriteriaRegistry::class)->sources());
+
+        // Official QueryBuilder filters: tableFilters[sourceKey]['rules']
+        foreach ($configuredKeys as $sourceKey) {
+            $filterState = $state[$sourceKey] ?? null;
+
+            if (! is_array($filterState)) {
+                continue;
+            }
+
+            $rules = $filterState['rules'] ?? null;
+
+            if (! is_array($rules)) {
+                continue;
+            }
+
+            $normalized[] = [
+                'source' => $sourceKey,
+                'rules' => $rules,
+            ];
+        }
+
+        if ($normalized !== []) {
+            return $normalized;
+        }
+
+        // Legacy: single "criteria" filter with per-source RuleBuilder trees.
+        if (isset($state['criteria']) && is_array($state['criteria'])) {
+            foreach ($configuredKeys as $sourceKey) {
+                if (! array_key_exists($sourceKey, $state['criteria']) || ! is_array($state['criteria'][$sourceKey])) {
+                    continue;
+                }
+
+                $normalized[] = [
+                    'source' => $sourceKey,
+                    'rules' => $state['criteria'][$sourceKey],
+                ];
+            }
+
+            if ($normalized !== []) {
+                return $normalized;
+            }
+
+            $legacySources = $state['criteria']['sources'] ?? $state['criteria'];
+        } else {
+            $legacySources = $state['sources'] ?? $state;
+        }
+
+        if (! is_array($legacySources)) {
+            return [];
+        }
+
+        foreach ($legacySources as $source) {
+            if (! is_array($source)) {
+                continue;
+            }
+
+            if (isset($source['type'])) {
+                if (blank($source['type'])) {
+                    continue;
+                }
+
+                $normalized[] = [
+                    'source' => (string) $source['type'],
+                    'rules' => is_array($source['data']['rules'] ?? null) ? $source['data']['rules'] : [],
+                ];
+
+                continue;
+            }
+
+            if (blank($source['source'] ?? null)) {
+                continue;
+            }
+
+            $normalized[] = [
+                'source' => (string) $source['source'],
+                'rules' => is_array($source['rules'] ?? null) ? $source['rules'] : [],
+            ];
+        }
+
+        return $normalized;
+    }
+
+    public function updatedActiveGroupId(mixed $value): void
+    {
+        /** @var Course $course */
+        $course = $this->getOwnerRecord();
+
+        if (blank($value)) {
+            $this->activeGroupId = null;
+            $this->loadActiveGroupIntoFilters();
+            $this->refreshMatchingUsersTable();
+
+            return;
+        }
+
+        $groupId = (int) $value;
+        $this->activeGroupId = (string) $groupId;
+
+        if ($course->userGroups()->where('lms_user_groups.id', $groupId)->exists()) {
+            $course->setDefaultUserGroup($groupId);
+        }
+
+        $this->loadActiveGroupIntoFilters();
+        $this->refreshMatchingUsersTable();
+    }
+}

--- a/src/RelationManagers/CourseUserGroupsRelationManager.php
+++ b/src/RelationManagers/CourseUserGroupsRelationManager.php
@@ -8,8 +8,13 @@ use Filament\Actions\Action;
 use Filament\Forms\Components\TextInput;
 use Filament\Notifications\Notification;
 use Filament\QueryBuilder\Constraints\Constraint;
+use Filament\QueryBuilder\Forms\Components\RuleBuilder;
+use Filament\QueryBuilder\View\QueryBuilderIconAlias;
 use Filament\Resources\RelationManagers\RelationManager;
+use Filament\Schemas\Components\Fieldset;
 use Filament\Schemas\Schema;
+use Filament\Support\Facades\FilamentIcon;
+use Filament\Support\Icons\Heroicon;
 use Filament\Tables\Columns\TextColumn;
 use Filament\Tables\Enums\FiltersLayout;
 use Filament\Tables\Filters\QueryBuilder;
@@ -148,6 +153,24 @@ class CourseUserGroupsRelationManager extends RelationManager
                 ->constraintPickerColumns(2)
                 ->maxRules($maxRules)
                 ->maxNestingDepth($maxNestingDepth)
+                ->schema(fn (QueryBuilder $filter): array => [
+                    Fieldset::make($source->label)
+                        ->columns(1)
+                        ->schema([
+                            RuleBuilder::make('rules')
+                                ->hiddenLabel()
+                                ->constraints($filter->getConstraints())
+                                ->blockPickerColumns($filter->getConstraintPickerColumns())
+                                ->blockPickerWidth($filter->getConstraintPickerWidth())
+                                ->maxRules($filter->getMaxRules())
+                                ->maxNestingDepth($filter->getMaxNestingDepth())
+                                ->addAction(fn (Action $action): Action => $action
+                                    ->label("Add {$source->label} rule")
+                                    ->icon(FilamentIcon::resolve(QueryBuilderIconAlias::ADD_RULE_ACTION) ?? Heroicon::Plus)
+                                    ->disabled(fn (RuleBuilder $component): bool => $component->isAtRuleLimit())
+                                    ->tooltip(fn (RuleBuilder $component): ?string => $component->getRuleLimitReachedTooltip())),
+                        ]),
+                ])
                 // Matching is applied in resolveMatchingUsersQuery() so related-model
                 // sources can use whereHas and unsaved drafts can still preview.
                 ->query(fn (Builder $query): Builder => $query)

--- a/src/RelationManagers/CourseUsersRelationManager.php
+++ b/src/RelationManagers/CourseUsersRelationManager.php
@@ -14,6 +14,8 @@ use Filament\Tables;
 use Filament\Tables\Enums\RecordActionsPosition;
 use Filament\Tables\Table;
 use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\Pivot;
 
 class CourseUsersRelationManager extends RelationManager
 {
@@ -66,6 +68,7 @@ class CourseUsersRelationManager extends RelationManager
             ->filters([
                 //
             ])
+            ->checkIfRecordIsSelectableUsing(fn (Model $record): bool => $this->hasManualAssignment($record))
             ->headerActions([
                 AttachAction::make()
                     ->preloadRecordSelect()
@@ -89,7 +92,8 @@ class CourseUsersRelationManager extends RelationManager
             ])
             ->recordActions([
                 ActionGroup::make([
-                    DetachAction::make(),
+                    DetachAction::make()
+                        ->visible(fn (Model $record): bool => $this->hasManualAssignment($record)),
                 ]),
             ], position: RecordActionsPosition::BeforeColumns)
             ->toolbarActions([
@@ -97,6 +101,21 @@ class CourseUsersRelationManager extends RelationManager
                     DetachBulkAction::make(),
                 ]),
             ]);
+    }
+
+    protected function hasManualAssignment(Model $record): bool
+    {
+        if (! $record->relationLoaded('pivot')) {
+            return false;
+        }
+
+        $pivot = $record->getRelation('pivot');
+
+        if (! $pivot instanceof Pivot) {
+            return false;
+        }
+
+        return (int) $pivot->getAttribute('is_explicitly_assigned') === 1;
     }
 
     /**

--- a/src/RelationManagers/CourseUsersRelationManager.php
+++ b/src/RelationManagers/CourseUsersRelationManager.php
@@ -83,6 +83,8 @@ class CourseUsersRelationManager extends RelationManager
                     })
                     ->schema(fn (AttachAction $action): array => [
                         $action->getRecordSelect(),
+                        Forms\Components\Hidden::make('is_explicitly_assigned')
+                            ->default(true),
                     ]),
             ])
             ->recordActions([

--- a/src/RelationManagers/CoursesRelationManager.php
+++ b/src/RelationManagers/CoursesRelationManager.php
@@ -14,6 +14,7 @@ use Filament\Tables\Enums\RecordActionsPosition;
 use Filament\Tables\Table;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\Pivot;
 use Tapp\FilamentLms\Models\Course;
 use Tapp\FilamentLms\UserGroups\CourseAccessResolver;
 use Tapp\FilamentLms\UserGroups\UserGroupCriteriaRegistry;
@@ -67,7 +68,7 @@ class CoursesRelationManager extends RelationManager
                     }),
                 TextColumn::make('assigned_at')
                     ->label('Assigned At')
-                    ->getStateUsing(fn (Course $record) => $this->coursePivot($record)?->created_at)
+                    ->getStateUsing(fn (Course $record) => $this->coursePivot($record)?->getAttribute('created_at'))
                     ->dateTime()
                     ->sortable(query: function (Builder $query, string $direction): Builder {
                         return $query
@@ -135,9 +136,17 @@ class CoursesRelationManager extends RelationManager
             ]);
     }
 
-    protected function coursePivot(Course $record): mixed
+    protected function coursePivot(Course $record): ?Pivot
     {
-        return $record->users->firstWhere('id', $this->getOwnerRecord()->getKey())?->pivot;
+        $assignedUser = $record->users->firstWhere('id', $this->getOwnerRecord()->getKey());
+
+        if ($assignedUser === null || ! $assignedUser->relationLoaded('pivot')) {
+            return null;
+        }
+
+        $pivot = $assignedUser->getRelation('pivot');
+
+        return $pivot instanceof Pivot ? $pivot : null;
     }
 
     protected function hasManualAssignment(Model $record): bool

--- a/src/RelationManagers/CoursesRelationManager.php
+++ b/src/RelationManagers/CoursesRelationManager.php
@@ -7,12 +7,16 @@ use Filament\Actions\AttachAction;
 use Filament\Actions\BulkActionGroup;
 use Filament\Actions\DetachAction;
 use Filament\Actions\DetachBulkAction;
+use Filament\Forms\Components\Hidden;
 use Filament\Resources\RelationManagers\RelationManager;
 use Filament\Tables\Columns\TextColumn;
 use Filament\Tables\Enums\RecordActionsPosition;
 use Filament\Tables\Table;
 use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model;
 use Tapp\FilamentLms\Models\Course;
+use Tapp\FilamentLms\UserGroups\CourseAccessResolver;
+use Tapp\FilamentLms\UserGroups\UserGroupCriteriaRegistry;
 
 class CoursesRelationManager extends RelationManager
 {
@@ -27,6 +31,7 @@ class CoursesRelationManager extends RelationManager
     public function table(Table $table): Table
     {
         return $table
+            ->query(fn (): Builder => $this->resolveAssignedCoursesQuery())
             ->recordTitleAttribute('name')
             ->columns([
                 TextColumn::make('name')
@@ -37,6 +42,17 @@ class CoursesRelationManager extends RelationManager
                     ->searchable()
                     ->sortable()
                     ->toggleable(isToggledHiddenByDefault: true),
+                TextColumn::make('assignment_source')
+                    ->label('Assignment')
+                    ->badge()
+                    ->getStateUsing(fn (Course $record): string => $this->assignmentSourceLabel($record))
+                    ->color(fn (string $state): string => match ($state) {
+                        'Manual' => 'success',
+                        'Group' => 'info',
+                        'Manual + Group' => 'warning',
+                        default => 'gray',
+                    })
+                    ->visible(fn (): bool => app(UserGroupCriteriaRegistry::class)->enabled()),
                 TextColumn::make('progress')
                     ->label('Progress')
                     ->getStateUsing(function ($record) {
@@ -49,14 +65,22 @@ class CoursesRelationManager extends RelationManager
 
                         return 'N/A';
                     }),
-                TextColumn::make('pivot.created_at')
+                TextColumn::make('assigned_at')
                     ->label('Assigned At')
+                    ->getStateUsing(fn (Course $record) => $this->coursePivot($record)?->created_at)
                     ->dateTime()
                     ->sortable(query: function (Builder $query, string $direction): Builder {
-                        return $query->orderBy('lms_course_user.created_at', $direction);
+                        return $query
+                            ->leftJoin('lms_course_user as assigned_courses_pivot', function ($join): void {
+                                $join->on('assigned_courses_pivot.course_id', '=', 'lms_courses.id')
+                                    ->where('assigned_courses_pivot.user_id', $this->getOwnerRecord()->getKey());
+                            })
+                            ->orderBy('assigned_courses_pivot.created_at', $direction)
+                            ->select('lms_courses.*');
                     })
                     ->toggleable(isToggledHiddenByDefault: true),
             ])
+            ->checkIfRecordIsSelectableUsing(fn (Model $record): bool => $this->hasManualAssignment($record))
             ->headerActions([
                 AttachAction::make()
                     ->label('Attach')
@@ -75,11 +99,14 @@ class CoursesRelationManager extends RelationManager
                     })
                     ->schema(fn (AttachAction $action): array => [
                         $action->getRecordSelect(),
+                        Hidden::make('is_explicitly_assigned')
+                            ->default(true),
                     ]),
             ])
             ->recordActions([
                 ActionGroup::make([
-                    DetachAction::make(),
+                    DetachAction::make()
+                        ->visible(fn (Model $record): bool => $this->hasManualAssignment($record)),
                 ]),
             ], position: RecordActionsPosition::BeforeColumns)
             ->toolbarActions([
@@ -87,6 +114,54 @@ class CoursesRelationManager extends RelationManager
                     DetachBulkAction::make(),
                 ]),
             ]);
+    }
+
+    protected function resolveAssignedCoursesQuery(): Builder
+    {
+        $user = $this->getOwnerRecord();
+
+        return Course::query()
+            ->assignedToUser($user)
+            ->with([
+                'users' => fn ($query) => $query->whereKey($user->getKey()),
+                'userGroups' => fn ($query) => $query
+                    ->where('lms_user_groups.is_active', true)
+                    ->where('lms_user_groups.published_revision', '>', 0)
+                    ->whereHas('memberships', function (Builder $membershipQuery) use ($user): void {
+                        $membershipQuery
+                            ->where('user_id', $user->getKey())
+                            ->whereColumn('revision', 'lms_user_groups.published_revision');
+                    }),
+            ]);
+    }
+
+    protected function coursePivot(Course $record): mixed
+    {
+        return $record->users->firstWhere('id', $this->getOwnerRecord()->getKey())?->pivot;
+    }
+
+    protected function hasManualAssignment(Model $record): bool
+    {
+        if (! $record instanceof Course) {
+            return false;
+        }
+
+        return $this->coursePivot($record) !== null;
+    }
+
+    protected function assignmentSourceLabel(Course $record): string
+    {
+        $hasManual = $this->hasManualAssignment($record);
+        $hasGroup = $record->relationLoaded('userGroups')
+            ? $record->userGroups->isNotEmpty()
+            : app(CourseAccessResolver::class)->belongsToAssignedGroup($record, $this->getOwnerRecord());
+
+        return match (true) {
+            $hasManual && $hasGroup => 'Manual + Group',
+            $hasManual => 'Manual',
+            $hasGroup => 'Group',
+            default => 'Unknown',
+        };
     }
 
     /**

--- a/src/RelationManagers/CoursesRelationManager.php
+++ b/src/RelationManagers/CoursesRelationManager.php
@@ -155,7 +155,13 @@ class CoursesRelationManager extends RelationManager
             return false;
         }
 
-        return $this->coursePivot($record) !== null;
+        $pivot = $this->coursePivot($record);
+
+        if ($pivot === null) {
+            return false;
+        }
+
+        return (int) $pivot->getAttribute('is_explicitly_assigned') === 1;
     }
 
     protected function assignmentSourceLabel(Course $record): string

--- a/src/Resources/CourseResource.php
+++ b/src/Resources/CourseResource.php
@@ -27,6 +27,7 @@ use Tapp\FilamentLms\Concerns\HasLmsSlug;
 use Tapp\FilamentLms\Enums\CompletionMode;
 use Tapp\FilamentLms\Models\Course;
 use Tapp\FilamentLms\Models\CreditCategory;
+use Tapp\FilamentLms\RelationManagers\CourseUserGroupsRelationManager;
 use Tapp\FilamentLms\RelationManagers\CourseUsersRelationManager;
 use Tapp\FilamentLms\Resources\CourseResource\Pages\CreateCourse;
 use Tapp\FilamentLms\Resources\CourseResource\Pages\EditCourse;
@@ -287,6 +288,7 @@ class CourseResource extends Resource
         return [
             LessonsRelationManager::make(),
             CourseUsersRelationManager::make(),
+            CourseUserGroupsRelationManager::make(),
         ];
     }
 

--- a/src/Services/CourseEvaluationService.php
+++ b/src/Services/CourseEvaluationService.php
@@ -12,6 +12,7 @@ use Tapp\FilamentLms\Models\Course;
 use Tapp\FilamentLms\Models\Step;
 use Tapp\FilamentLms\Models\StepUser;
 use Tapp\FilamentLms\Pages\Step as StepPage;
+use Tapp\FilamentLms\UserGroups\CourseAccessResolver;
 
 final class CourseEvaluationService
 {
@@ -177,7 +178,9 @@ final class CourseEvaluationService
         }
 
         try {
-            $evaluationCourse->users()->attach($userId);
+            $evaluationCourse->users()->attach($userId, [
+                'is_explicitly_assigned' => true,
+            ]);
         } catch (UniqueConstraintViolationException) {
             // Already assigned by a concurrent request.
         }
@@ -193,7 +196,10 @@ final class CourseEvaluationService
             return true;
         }
 
-        return $primary->users()->where('user_id', $user->id)->exists();
+        $access = app(CourseAccessResolver::class);
+
+        return $access->isExplicitlyAssigned($primary, $user)
+            || $access->belongsToAssignedGroup($primary, $user);
     }
 
     public function isEvaluationUnlockedForUser(Course $evaluationCourse, Authenticatable $user): bool

--- a/src/Traits/FilamentLmsUser.php
+++ b/src/Traits/FilamentLmsUser.php
@@ -33,7 +33,7 @@ trait FilamentLmsUser
     public function courses(): BelongsToMany
     {
         return $this->belongsToMany(Course::class, 'lms_course_user', 'user_id', 'course_id')
-            ->withPivot('completed_at')
+            ->withPivot('completed_at', 'is_explicitly_assigned')
             ->withTimestamps();
     }
 

--- a/src/UserGroups/Contracts/UserGroupCriteriaProvider.php
+++ b/src/UserGroups/Contracts/UserGroupCriteriaProvider.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tapp\FilamentLms\UserGroups\Contracts;
+
+use Tapp\FilamentLms\UserGroups\CriteriaSource;
+
+interface UserGroupCriteriaProvider
+{
+    /**
+     * Named criteria sources available when building user groups.
+     * Must include only allow-listed fields/constraints — never arbitrary columns.
+     *
+     * @return array<string, CriteriaSource>
+     */
+    public function sources(): array;
+}

--- a/src/UserGroups/CourseAccessResolver.php
+++ b/src/UserGroups/CourseAccessResolver.php
@@ -1,0 +1,178 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tapp\FilamentLms\UserGroups;
+
+use Illuminate\Database\Eloquent\Builder;
+use Tapp\FilamentLms\Models\Course;
+use Tapp\FilamentLms\Models\UserGroup;
+use Tapp\FilamentLms\Services\CourseEvaluationService;
+
+final class CourseAccessResolver
+{
+    public function __construct(
+        private readonly CourseEvaluationService $evaluationService,
+    ) {}
+
+    public function canAccess(Course $course, mixed $user): bool
+    {
+        if ($user === null) {
+            return false;
+        }
+
+        if ($course->isEvaluationCourse()) {
+            if ($this->isLmsAdmin($user)) {
+                return true;
+            }
+
+            return $this->evaluationService->isEvaluationUnlockedForUser($course, $user)
+                && ($this->isExplicitlyAssigned($course, $user) || ! $course->is_private);
+        }
+
+        if (! $course->is_private) {
+            return true;
+        }
+
+        if ($this->isLmsAdmin($user)) {
+            return true;
+        }
+
+        return $this->isExplicitlyAssigned($course, $user)
+            || $this->belongsToAssignedGroup($course, $user);
+    }
+
+    public function scopeAccessibleTo(Builder $query, mixed $user): void
+    {
+        $query->where(function (Builder $q) use ($user): void {
+            $q->where('is_private', false)
+                ->orWhere(function (Builder $subQ) use ($user): void {
+                    $subQ->where('is_private', true)
+                        ->where(function (Builder $adminOrAssignedQuery) use ($user): void {
+                            if ($this->isLmsAdmin($user)) {
+                                $adminOrAssignedQuery->whereRaw('1 = 1');
+
+                                return;
+                            }
+
+                            $adminOrAssignedQuery
+                                ->where(function (Builder $accessQuery) use ($user): void {
+                                    $accessQuery
+                                        ->whereHas('users', function (Builder $userQuery) use ($user): void {
+                                            $userQuery
+                                                ->where('user_id', $user->id)
+                                                ->where('lms_course_user.is_explicitly_assigned', true);
+                                        })
+                                        ->orWhereHas('userGroups', function (Builder $groupQuery) use ($user): void {
+                                            $groupQuery
+                                                ->where('lms_user_groups.is_active', true)
+                                                ->where('lms_user_groups.published_revision', '>', 0)
+                                                ->whereExists(function ($membershipQuery) use ($user): void {
+                                                    $membershipQuery
+                                                        ->selectRaw('1')
+                                                        ->from('lms_user_group_memberships')
+                                                        ->whereColumn(
+                                                            'lms_user_group_memberships.user_group_id',
+                                                            'lms_user_groups.id'
+                                                        )
+                                                        ->whereColumn(
+                                                            'lms_user_group_memberships.revision',
+                                                            'lms_user_groups.published_revision'
+                                                        )
+                                                        ->where('lms_user_group_memberships.user_id', $user->id);
+                                                });
+                                        });
+                                });
+                        });
+                });
+        })
+            ->whereHas('steps')
+            ->when(config('filament-lms.evaluations.enabled', false), function (Builder $query): void {
+                $evaluationCourseIds = $this->evaluationService->lockedEvaluationCourseIds();
+
+                if ($evaluationCourseIds->isNotEmpty()) {
+                    $query->whereNotIn('lms_courses.id', $evaluationCourseIds);
+                }
+            });
+    }
+
+    public function isExplicitlyAssigned(Course $course, mixed $user): bool
+    {
+        return $course->users()
+            ->where('user_id', $user->id)
+            ->wherePivot('is_explicitly_assigned', true)
+            ->exists();
+    }
+
+    public function belongsToAssignedGroup(Course $course, mixed $user): bool
+    {
+        if (! app(UserGroupCriteriaRegistry::class)->enabled()) {
+            return false;
+        }
+
+        return UserGroup::query()
+            ->where('is_active', true)
+            ->where('published_revision', '>', 0)
+            ->whereHas('courses', fn (Builder $q): Builder => $q->where('lms_courses.id', $course->id))
+            ->whereHas('memberships', function (Builder $q) use ($user): void {
+                $q->where('user_id', $user->id)
+                    ->whereColumn('revision', 'lms_user_groups.published_revision');
+            })
+            ->exists();
+    }
+
+    /**
+     * Courses the user is assigned to manually (lms_course_user) and/or via active group membership.
+     *
+     * @param  Builder<Course>  $query
+     */
+    public function scopeAssignedToUser(Builder $query, mixed $user): void
+    {
+        if ($user === null) {
+            $query->whereRaw('0 = 1');
+
+            return;
+        }
+
+        $query->where(function (Builder $accessQuery) use ($user): void {
+            $accessQuery
+                ->whereHas('users', function (Builder $userQuery) use ($user): void {
+                    $userQuery->where('user_id', $user->id);
+                })
+                ->orWhere(function (Builder $groupQuery) use ($user): void {
+                    if (! app(UserGroupCriteriaRegistry::class)->enabled()) {
+                        $groupQuery->whereRaw('0 = 1');
+
+                        return;
+                    }
+
+                    $groupQuery->whereHas('userGroups', function (Builder $assignedGroupQuery) use ($user): void {
+                        $assignedGroupQuery
+                            ->where('lms_user_groups.is_active', true)
+                            ->where('lms_user_groups.published_revision', '>', 0)
+                            ->whereExists(function ($membershipQuery) use ($user): void {
+                                $membershipQuery
+                                    ->selectRaw('1')
+                                    ->from('lms_user_group_memberships')
+                                    ->whereColumn(
+                                        'lms_user_group_memberships.user_group_id',
+                                        'lms_user_groups.id'
+                                    )
+                                    ->whereColumn(
+                                        'lms_user_group_memberships.revision',
+                                        'lms_user_groups.published_revision'
+                                    )
+                                    ->where('lms_user_group_memberships.user_id', $user->id);
+                            });
+                    });
+                });
+        });
+    }
+
+    private function isLmsAdmin(mixed $user): bool
+    {
+        return is_object($user)
+            && method_exists($user, 'isLmsAdmin')
+            && $user->isLmsAdmin();
+    }
+}

--- a/src/UserGroups/CriteriaSource.php
+++ b/src/UserGroups/CriteriaSource.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tapp\FilamentLms\UserGroups;
+
+use Closure;
+use Filament\QueryBuilder\Constraints\Constraint;
+use InvalidArgumentException;
+
+final class CriteriaSource
+{
+    /**
+     * @param  list<Constraint>|Closure(): list<Constraint>  $constraints
+     */
+    public function __construct(
+        public readonly string $key,
+        public readonly string $label,
+        public readonly array|Closure $constraints,
+        public readonly ?string $userRelationship = null,
+        public readonly ?string $icon = null,
+    ) {
+        if ($this->key === '') {
+            throw new InvalidArgumentException('Criteria source key cannot be empty.');
+        }
+    }
+
+    /**
+     * @return list<Constraint>
+     */
+    public function getConstraints(): array
+    {
+        $constraints = $this->constraints instanceof Closure
+            ? ($this->constraints)()
+            : $this->constraints;
+
+        return array_values($constraints);
+    }
+
+    public function isUserSource(): bool
+    {
+        return $this->userRelationship === null;
+    }
+}

--- a/src/UserGroups/UserGroupCriteriaRegistry.php
+++ b/src/UserGroups/UserGroupCriteriaRegistry.php
@@ -50,21 +50,15 @@ final class UserGroupCriteriaRegistry
         $keyed = [];
 
         foreach ($sources as $key => $source) {
-            if (! $source instanceof CriteriaSource) {
-                throw new InvalidArgumentException('Each criteria source must be an instance of '.CriteriaSource::class);
-            }
-
-            $sourceKey = is_string($key) ? $key : $source->key;
-
-            if ($sourceKey !== $source->key) {
+            if ($key !== $source->key) {
                 throw new InvalidArgumentException("Criteria source key mismatch for [{$source->key}].");
             }
 
-            if (isset($keyed[$sourceKey])) {
-                throw new InvalidArgumentException("Duplicate criteria source key [{$sourceKey}].");
+            if (isset($keyed[$key])) {
+                throw new InvalidArgumentException("Duplicate criteria source key [{$key}].");
             }
 
-            $keyed[$sourceKey] = $source;
+            $keyed[$key] = $source;
         }
 
         return $keyed;

--- a/src/UserGroups/UserGroupCriteriaRegistry.php
+++ b/src/UserGroups/UserGroupCriteriaRegistry.php
@@ -1,0 +1,93 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tapp\FilamentLms\UserGroups;
+
+use InvalidArgumentException;
+use Tapp\FilamentLms\UserGroups\Contracts\UserGroupCriteriaProvider;
+
+final class UserGroupCriteriaRegistry
+{
+    public function enabled(): bool
+    {
+        return $this->provider() !== null;
+    }
+
+    public function provider(): ?UserGroupCriteriaProvider
+    {
+        $provider = config('filament-lms.user_groups.criteria_provider');
+
+        if ($provider === null || $provider === '') {
+            return null;
+        }
+
+        if (is_string($provider)) {
+            $provider = app($provider);
+        }
+
+        if (! $provider instanceof UserGroupCriteriaProvider) {
+            throw new InvalidArgumentException(
+                'filament-lms.user_groups.criteria_provider must implement '.UserGroupCriteriaProvider::class
+            );
+        }
+
+        return $provider;
+    }
+
+    /**
+     * @return array<string, CriteriaSource>
+     */
+    public function sources(): array
+    {
+        $provider = $this->provider();
+
+        if ($provider === null) {
+            return [];
+        }
+
+        $sources = $provider->sources();
+        $keyed = [];
+
+        foreach ($sources as $key => $source) {
+            if (! $source instanceof CriteriaSource) {
+                throw new InvalidArgumentException('Each criteria source must be an instance of '.CriteriaSource::class);
+            }
+
+            $sourceKey = is_string($key) ? $key : $source->key;
+
+            if ($sourceKey !== $source->key) {
+                throw new InvalidArgumentException("Criteria source key mismatch for [{$source->key}].");
+            }
+
+            if (isset($keyed[$sourceKey])) {
+                throw new InvalidArgumentException("Duplicate criteria source key [{$sourceKey}].");
+            }
+
+            $keyed[$sourceKey] = $source;
+        }
+
+        return $keyed;
+    }
+
+    public function source(string $key): CriteriaSource
+    {
+        $sources = $this->sources();
+
+        if (! isset($sources[$key])) {
+            throw new InvalidArgumentException("Unknown user group criteria source [{$key}].");
+        }
+
+        return $sources[$key];
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    public function sourceOptions(): array
+    {
+        return collect($this->sources())
+            ->mapWithKeys(fn (CriteriaSource $source): array => [$source->key => $source->label])
+            ->all();
+    }
+}

--- a/src/UserGroups/UserGroupMembershipSynchronizer.php
+++ b/src/UserGroups/UserGroupMembershipSynchronizer.php
@@ -1,0 +1,179 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tapp\FilamentLms\UserGroups;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Facades\DB;
+use Tapp\FilamentLms\Jobs\RebuildUserGroupMemberships;
+use Tapp\FilamentLms\Models\UserGroup;
+use Throwable;
+
+final class UserGroupMembershipSynchronizer
+{
+    public function __construct(
+        private readonly UserGroupRuleMatcher $matcher,
+    ) {}
+
+    public function queueRebuild(UserGroup $group): void
+    {
+        if (! config('filament-lms.user_groups.sync_queue', true)) {
+            $this->rebuild($group);
+
+            return;
+        }
+
+        $group->forceFill([
+            'sync_status' => 'queued',
+            'sync_error' => null,
+        ])->save();
+
+        RebuildUserGroupMemberships::dispatch($group->id);
+    }
+
+    public function rebuild(UserGroup $group): void
+    {
+        $group->forceFill([
+            'sync_status' => 'syncing',
+            'sync_error' => null,
+        ])->save();
+
+        try {
+            $desiredRevision = $group->published_revision + 1;
+            $matchedAt = now();
+            $userIds = $this->matcher
+                ->matchingUsersQuery($group->rules ?? [])
+                ->pluck($this->userKeyName())
+                ->all();
+
+            DB::transaction(function () use ($group, $desiredRevision, $userIds, $matchedAt): void {
+                $now = now();
+                $rows = [];
+
+                foreach ($userIds as $userId) {
+                    $rows[] = [
+                        'user_group_id' => $group->id,
+                        'user_id' => $userId,
+                        'revision' => $desiredRevision,
+                        'matched_at' => $matchedAt,
+                        'created_at' => $now,
+                        'updated_at' => $now,
+                    ];
+
+                    if (count($rows) >= 500) {
+                        DB::table('lms_user_group_memberships')->upsert(
+                            $rows,
+                            ['user_group_id', 'user_id', 'revision'],
+                            ['matched_at', 'updated_at'],
+                        );
+                        $rows = [];
+                    }
+                }
+
+                if ($rows !== []) {
+                    DB::table('lms_user_group_memberships')->upsert(
+                        $rows,
+                        ['user_group_id', 'user_id', 'revision'],
+                        ['matched_at', 'updated_at'],
+                    );
+                }
+
+                $group->forceFill([
+                    'published_revision' => $desiredRevision,
+                    'sync_status' => 'idle',
+                    'sync_error' => null,
+                    'last_synced_at' => $now,
+                ])->save();
+
+                DB::table('lms_user_group_memberships')
+                    ->where('user_group_id', $group->id)
+                    ->where('revision', '<', $desiredRevision)
+                    ->delete();
+            });
+        } catch (Throwable $exception) {
+            $group->forceFill([
+                'sync_status' => 'failed',
+                'sync_error' => $exception->getMessage(),
+            ])->save();
+
+            throw $exception;
+        }
+    }
+
+    public function refreshUser(int|string $userId): void
+    {
+        $groups = UserGroup::query()
+            ->where('is_active', true)
+            ->get();
+
+        /** @var class-string<Model> $userModel */
+        $userModel = config('filament-lms.user_model');
+        $user = $userModel::query()->find($userId);
+
+        if ($user === null) {
+            return;
+        }
+
+        foreach ($groups as $group) {
+            $matches = $this->matcher->userMatches($user, $group->rules ?? []);
+            $revision = max(1, (int) $group->published_revision);
+
+            if ($group->published_revision < 1) {
+                $this->rebuild($group);
+
+                continue;
+            }
+
+            $exists = DB::table('lms_user_group_memberships')
+                ->where('user_group_id', $group->id)
+                ->where('user_id', $userId)
+                ->where('revision', $revision)
+                ->exists();
+
+            if ($matches && ! $exists) {
+                DB::table('lms_user_group_memberships')->upsert([
+                    [
+                        'user_group_id' => $group->id,
+                        'user_id' => $userId,
+                        'revision' => $revision,
+                        'matched_at' => now(),
+                        'created_at' => now(),
+                        'updated_at' => now(),
+                    ],
+                ], ['user_group_id', 'user_id', 'revision'], ['matched_at', 'updated_at']);
+            }
+
+            if (! $matches && $exists) {
+                DB::table('lms_user_group_memberships')
+                    ->where('user_group_id', $group->id)
+                    ->where('user_id', $userId)
+                    ->where('revision', $revision)
+                    ->delete();
+            }
+        }
+    }
+
+    public function reconcileAll(): int
+    {
+        $count = 0;
+
+        UserGroup::query()
+            ->where('is_active', true)
+            ->orderBy('id')
+            ->each(function (UserGroup $group) use (&$count): void {
+                $this->rebuild($group);
+                $count++;
+            });
+
+        return $count;
+    }
+
+    private function userKeyName(): string
+    {
+        /** @var class-string<Model> $userModel */
+        $userModel = config('filament-lms.user_model');
+
+        return (new $userModel)->getQualifiedKeyName();
+    }
+}

--- a/src/UserGroups/UserGroupMembershipSynchronizer.php
+++ b/src/UserGroups/UserGroupMembershipSynchronizer.php
@@ -8,6 +8,7 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Facades\DB;
 use Tapp\FilamentLms\Jobs\RebuildUserGroupMemberships;
 use Tapp\FilamentLms\Models\UserGroup;
+use Tapp\FilamentLms\Models\UserGroupMembership;
 use Throwable;
 
 final class UserGroupMembershipSynchronizer
@@ -112,6 +113,10 @@ final class UserGroupMembershipSynchronizer
         $user = $userModel::query()->find($userId);
 
         if ($user === null) {
+            UserGroupMembership::query()
+                ->where('user_id', $userId)
+                ->delete();
+
             return;
         }
 

--- a/src/UserGroups/UserGroupRuleMatcher.php
+++ b/src/UserGroups/UserGroupRuleMatcher.php
@@ -1,0 +1,307 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tapp\FilamentLms\UserGroups;
+
+use Filament\QueryBuilder\Constraints\Constraint;
+use Filament\QueryBuilder\Forms\Components\RuleBuilder;
+use Filament\QueryBuilder\Models\Scopes\QueryBuilderScope;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Arr;
+use InvalidArgumentException;
+
+final class UserGroupRuleMatcher
+{
+    public function __construct(
+        private readonly UserGroupCriteriaRegistry $registry,
+    ) {}
+
+    /**
+     * Normalize and validate persisted or form rule payloads.
+     *
+     * @param  array<string, mixed>  $rules
+     * @return array{version: int, sources: list<array{source: string, rules: array<string, mixed>}>}
+     */
+    public function normalize(array $rules): array
+    {
+        $version = (int) ($rules['version'] ?? 1);
+        $sourcesPayload = $rules['sources'] ?? [];
+
+        if (! is_array($sourcesPayload)) {
+            throw new InvalidArgumentException('User group rules sources must be an array.');
+        }
+
+        $maxRules = (int) config('filament-lms.user_groups.max_rules', 100);
+        $maxNestingDepth = (int) config('filament-lms.user_groups.max_nesting_depth', 10);
+        $normalizedSources = [];
+        $totalRules = 0;
+
+        foreach ($sourcesPayload as $sourcePayload) {
+            if (! is_array($sourcePayload)) {
+                continue;
+            }
+
+            $sourceKey = $sourcePayload['source'] ?? null;
+
+            if (! is_string($sourceKey) || $sourceKey === '') {
+                throw new InvalidArgumentException('Each criteria section must select a configured source.');
+            }
+
+            $source = $this->registry->source($sourceKey);
+            $sourceRules = $sourcePayload['rules'] ?? [];
+
+            if (! is_array($sourceRules)) {
+                throw new InvalidArgumentException("Rules for source [{$sourceKey}] must be an array.");
+            }
+
+            $sourceRules = $this->filterEmptyRules($sourceRules);
+            $this->assertRulesUseAllowedConstraints($sourceRules, $source);
+            $this->assertRuleLimits($sourceRules, $maxRules, $maxNestingDepth, $totalRules);
+
+            if ($sourceRules === []) {
+                continue;
+            }
+
+            $normalizedSources[] = [
+                'source' => $sourceKey,
+                'rules' => $sourceRules,
+            ];
+        }
+
+        return [
+            'version' => $version,
+            'sources' => array_values($normalizedSources),
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $rules
+     */
+    public function matchingUsersQuery(array $rules): Builder
+    {
+        $normalized = $this->normalize($rules);
+        /** @var class-string<Model> $userModel */
+        $userModel = config('filament-lms.user_model');
+        $query = $userModel::query();
+
+        if ($normalized['sources'] === []) {
+            return $query->whereRaw('0 = 1');
+        }
+
+        foreach ($normalized['sources'] as $sourcePayload) {
+            $source = $this->registry->source($sourcePayload['source']);
+            $constraints = $source->getConstraints();
+            $sourceRules = $sourcePayload['rules'];
+
+            if ($source->isUserSource()) {
+                $scope = QueryBuilderScope::make($sourceRules, $constraints);
+                $scope($query);
+
+                continue;
+            }
+
+            $relationship = $source->userRelationship;
+
+            if ($relationship === null || $relationship === '') {
+                throw new InvalidArgumentException("Criteria source [{$source->key}] is missing a user relationship.");
+            }
+
+            $query->whereHas($relationship, function (Builder $relatedQuery) use ($sourceRules, $constraints): void {
+                $scope = QueryBuilderScope::make($sourceRules, $constraints);
+                $scope($relatedQuery);
+            });
+        }
+
+        return $query;
+    }
+
+    /**
+     * @param  array<string, mixed>  $rules
+     */
+    public function userMatches(Model $user, array $rules): bool
+    {
+        return $this->matchingUsersQuery($rules)
+            ->whereKey($user->getKey())
+            ->exists();
+    }
+
+    /**
+     * @param  array<string, mixed>  $rules
+     * @return list<string>
+     */
+    public function summarize(array $rules): array
+    {
+        $normalized = $this->normalize($rules);
+        $summaries = [];
+
+        foreach ($normalized['sources'] as $sourcePayload) {
+            $source = $this->registry->source($sourcePayload['source']);
+            $constraints = Arr::mapWithKeys(
+                $source->getConstraints(),
+                fn (Constraint $constraint): array => [$constraint->getName() => $constraint],
+            );
+
+            foreach ($sourcePayload['rules'] as $rule) {
+                if (($rule['type'] ?? null) === RuleBuilder::OR_BLOCK_NAME) {
+                    $summaries[] = $source->label.': OR group';
+
+                    continue;
+                }
+
+                $constraint = $constraints[$rule['type'] ?? ''] ?? null;
+
+                if ($constraint === null) {
+                    continue;
+                }
+
+                $operatorString = $rule['data'][$constraint::OPERATOR_SELECT_NAME] ?? null;
+
+                if (! is_string($operatorString) || $operatorString === '') {
+                    continue;
+                }
+
+                [$operatorName, $isInverse] = $constraint->parseOperatorString($operatorString);
+                $operator = $constraint->getOperator($operatorName);
+
+                if ($operator === null) {
+                    continue;
+                }
+
+                $settings = $rule['data']['settings'] ?? [];
+                $constraint->settings($settings)->inverse($isInverse);
+                $operator->constraint($constraint)->settings($settings)->inverse($isInverse);
+
+                $summaries[] = $source->label.': '.$operator->getSummary($isInverse);
+
+                $constraint->settings(null)->inverse(null);
+                $operator->constraint(null)->settings(null)->inverse(null);
+            }
+        }
+
+        return $summaries;
+    }
+
+    /**
+     * @param  array<int|string, mixed>  $rules
+     * @return array<int|string, mixed>
+     */
+    private function filterEmptyRules(array $rules): array
+    {
+        $filtered = [];
+
+        foreach ($rules as $key => $rule) {
+            if (! is_array($rule)) {
+                continue;
+            }
+
+            if (($rule['type'] ?? null) === RuleBuilder::OR_BLOCK_NAME) {
+                $groups = $rule['data'][RuleBuilder::OR_BLOCK_GROUPS_REPEATER_NAME] ?? [];
+                $filteredGroups = [];
+
+                foreach ($groups as $groupKey => $group) {
+                    if (! is_array($group)) {
+                        continue;
+                    }
+
+                    $groupRules = $this->filterEmptyRules($group['rules'] ?? []);
+
+                    if ($groupRules === []) {
+                        continue;
+                    }
+
+                    $filteredGroups[$groupKey] = [
+                        ...$group,
+                        'rules' => $groupRules,
+                    ];
+                }
+
+                if ($filteredGroups === []) {
+                    continue;
+                }
+
+                $filtered[$key] = [
+                    ...$rule,
+                    'data' => [
+                        ...($rule['data'] ?? []),
+                        RuleBuilder::OR_BLOCK_GROUPS_REPEATER_NAME => $filteredGroups,
+                    ],
+                ];
+
+                continue;
+            }
+
+            $operator = $rule['data'][Constraint::OPERATOR_SELECT_NAME] ?? null;
+
+            if (blank($operator)) {
+                continue;
+            }
+
+            $filtered[$key] = $rule;
+        }
+
+        return $filtered;
+    }
+
+    /**
+     * @param  array<int|string, mixed>  $rules
+     */
+    private function assertRulesUseAllowedConstraints(array $rules, CriteriaSource $source): void
+    {
+        $allowed = Arr::mapWithKeys(
+            $source->getConstraints(),
+            fn (Constraint $constraint): array => [$constraint->getName() => true],
+        );
+
+        foreach ($rules as $rule) {
+            if (! is_array($rule)) {
+                continue;
+            }
+
+            $type = $rule['type'] ?? null;
+
+            if ($type === RuleBuilder::OR_BLOCK_NAME) {
+                foreach ($rule['data'][RuleBuilder::OR_BLOCK_GROUPS_REPEATER_NAME] ?? [] as $group) {
+                    $this->assertRulesUseAllowedConstraints($group['rules'] ?? [], $source);
+                }
+
+                continue;
+            }
+
+            if (! is_string($type) || ! isset($allowed[$type])) {
+                throw new InvalidArgumentException("Constraint [{$type}] is not allowed for source [{$source->key}].");
+            }
+        }
+    }
+
+    /**
+     * @param  array<int|string, mixed>  $rules
+     */
+    private function assertRuleLimits(array $rules, int $maxRules, int $maxNestingDepth, int &$totalRules, int $depth = 0): void
+    {
+        if ($depth > $maxNestingDepth) {
+            throw new InvalidArgumentException("User group rules exceed max nesting depth of {$maxNestingDepth}.");
+        }
+
+        foreach ($rules as $rule) {
+            if (! is_array($rule)) {
+                continue;
+            }
+
+            if (($rule['type'] ?? null) === RuleBuilder::OR_BLOCK_NAME) {
+                foreach ($rule['data'][RuleBuilder::OR_BLOCK_GROUPS_REPEATER_NAME] ?? [] as $group) {
+                    $this->assertRuleLimits($group['rules'] ?? [], $maxRules, $maxNestingDepth, $totalRules, $depth + 1);
+                }
+
+                continue;
+            }
+
+            $totalRules++;
+
+            if ($totalRules > $maxRules) {
+                throw new InvalidArgumentException("User group rules exceed max rule count of {$maxRules}.");
+            }
+        }
+    }
+}

--- a/tests/Feature/CourseUserGroupsRelationManagerTest.php
+++ b/tests/Feature/CourseUserGroupsRelationManagerTest.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+use Tapp\FilamentLms\Models\Course;
+use Tapp\FilamentLms\Models\UserGroup;
+use Tapp\FilamentLms\RelationManagers\CourseUserGroupsRelationManager;
+use Tapp\FilamentLms\Tests\Support\TestUserGroupCriteriaProvider;
+
+it('is configured for the userGroups relationship', function (): void {
+    $reflection = new ReflectionClass(CourseUserGroupsRelationManager::class);
+
+    expect(CourseUserGroupsRelationManager::getRelationshipName())->toBe('userGroups')
+        ->and($reflection->getStaticPropertyValue('title'))->toBe('Assigned User Groups');
+});
+
+it('keeps criteria filters visible by default with a how-to description', function (): void {
+    $source = file_get_contents(
+        (new ReflectionClass(CourseUserGroupsRelationManager::class))->getFileName()
+    );
+
+    expect($source)
+        ->toContain('FiltersLayout::AboveContent')
+        ->not->toContain('FiltersLayout::AboveContentCollapsible')
+        ->toContain('course-user-groups-description')
+        ->toContain('updatedActiveGroupId');
+});
+
+it('is hidden when no criteria provider is configured', function (): void {
+    config(['filament-lms.user_groups.criteria_provider' => null]);
+
+    $course = Course::factory()->create();
+
+    expect(CourseUserGroupsRelationManager::canViewForRecord($course, 'edit'))->toBeFalse();
+});
+
+it('is visible when a criteria provider is configured', function (): void {
+    config(['filament-lms.user_groups.criteria_provider' => TestUserGroupCriteriaProvider::class]);
+
+    $course = Course::factory()->create();
+
+    expect(CourseUserGroupsRelationManager::canViewForRecord($course, 'edit'))->toBeTrue();
+});
+
+it('marks the first attached group as the course default and can switch defaults', function (): void {
+    $course = Course::factory()->create();
+    $first = UserGroup::factory()->create(['name' => 'First Group']);
+    $second = UserGroup::factory()->create(['name' => 'Second Group']);
+
+    $course->userGroups()->attach($first->id, ['is_default' => true]);
+    $course->userGroups()->attach($second->id, ['is_default' => false]);
+
+    expect($course->defaultUserGroup()?->is($first))->toBeTrue();
+
+    $course->setDefaultUserGroup($second->id);
+    $course->refresh();
+
+    expect($course->defaultUserGroup()?->is($second))->toBeTrue()
+        ->and($course->userGroups()->wherePivot('is_default', true)->count())->toBe(1);
+});

--- a/tests/Feature/CoursesRelationManagerTest.php
+++ b/tests/Feature/CoursesRelationManagerTest.php
@@ -4,8 +4,15 @@ declare(strict_types=1);
 
 use Illuminate\Support\Facades\DB;
 use Tapp\FilamentLms\Models\Course;
+use Tapp\FilamentLms\Models\Lesson;
+use Tapp\FilamentLms\Models\Step;
+use Tapp\FilamentLms\Models\StepUser;
+use Tapp\FilamentLms\Models\UserGroup;
 use Tapp\FilamentLms\RelationManagers\CoursesRelationManager;
+use Tapp\FilamentLms\RelationManagers\CourseUsersRelationManager;
+use Tapp\FilamentLms\Tests\Support\TestUserGroupCriteriaProvider;
 use Tapp\FilamentLms\Tests\TestUser;
+use Tapp\FilamentLms\UserGroups\UserGroupMembershipSynchronizer;
 
 test('courses relation manager is configured for the courses relationship', function (): void {
     $reflection = new ReflectionClass(CoursesRelationManager::class);
@@ -115,4 +122,167 @@ test('course search columns can be configured', function (): void {
     $method = new ReflectionMethod($relationManager, 'getCourseSearchColumns');
 
     expect($method->invoke($relationManager))->toBe(['name']);
+});
+
+test('completion pivot rows from group access are not treated as manual assignments', function (): void {
+    config([
+        'filament-lms.user_groups.criteria_provider' => TestUserGroupCriteriaProvider::class,
+        'filament-lms.user_groups.sync_queue' => false,
+        'filament-lms.user_groups.refresh_on_user_save' => false,
+    ]);
+
+    $user = TestUser::query()->create([
+        'name' => 'Group Completer',
+        'email' => 'group-completer@example.com',
+        'password' => bcrypt('password'),
+    ]);
+
+    $course = Course::factory()->create(['is_private' => true]);
+    $lesson = Lesson::factory()->create(['course_id' => $course->id]);
+    $step = Step::factory()->create(['lesson_id' => $lesson->id]);
+
+    $group = UserGroup::factory()->create([
+        'rules' => [
+            'version' => 1,
+            'sources' => [
+                [
+                    'source' => 'user',
+                    'rules' => [
+                        'rule1' => [
+                            'type' => 'name',
+                            'data' => [
+                                'operator' => 'contains',
+                                'settings' => [
+                                    'text' => 'Group Completer',
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ],
+    ]);
+    $course->userGroups()->attach($group->id);
+    app(UserGroupMembershipSynchronizer::class)->rebuild($group->fresh());
+
+    StepUser::query()->create([
+        'user_id' => $user->id,
+        'step_id' => $step->id,
+        'completed_at' => now(),
+    ]);
+    $course->maybeSetCompletedAtForUser($user->id);
+
+    $manager = new CoursesRelationManager;
+    $manager->ownerRecord = $user;
+
+    $assignedCourse = (new ReflectionMethod($manager, 'resolveAssignedCoursesQuery'))
+        ->invoke($manager)
+        ->whereKey($course->id)
+        ->first();
+
+    expect($assignedCourse)->not->toBeNull()
+        ->and((new ReflectionMethod($manager, 'hasManualAssignment'))->invoke($manager, $assignedCourse))->toBeFalse()
+        ->and((new ReflectionMethod($manager, 'assignmentSourceLabel'))->invoke($manager, $assignedCourse))->toBe('Group')
+        ->and($course->completedByUserAt($user->id))->not->toBeNull();
+});
+
+test('explicit assignment with group membership is labeled manual plus group', function (): void {
+    config([
+        'filament-lms.user_groups.criteria_provider' => TestUserGroupCriteriaProvider::class,
+        'filament-lms.user_groups.sync_queue' => false,
+        'filament-lms.user_groups.refresh_on_user_save' => false,
+    ]);
+
+    $user = TestUser::query()->create([
+        'name' => 'Manual Group User',
+        'email' => 'manual-group@example.com',
+        'password' => bcrypt('password'),
+    ]);
+
+    $course = Course::factory()->create(['is_private' => true]);
+    $user->courses()->attach($course->id, ['is_explicitly_assigned' => true]);
+
+    $group = UserGroup::factory()->create([
+        'rules' => [
+            'version' => 1,
+            'sources' => [
+                [
+                    'source' => 'user',
+                    'rules' => [
+                        'rule1' => [
+                            'type' => 'name',
+                            'data' => [
+                                'operator' => 'contains',
+                                'settings' => [
+                                    'text' => 'Manual Group',
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ],
+    ]);
+    $course->userGroups()->attach($group->id);
+    app(UserGroupMembershipSynchronizer::class)->rebuild($group->fresh());
+
+    $manager = new CoursesRelationManager;
+    $manager->ownerRecord = $user;
+
+    $assignedCourse = (new ReflectionMethod($manager, 'resolveAssignedCoursesQuery'))
+        ->invoke($manager)
+        ->whereKey($course->id)
+        ->first();
+
+    expect($assignedCourse)->not->toBeNull()
+        ->and((new ReflectionMethod($manager, 'hasManualAssignment'))->invoke($manager, $assignedCourse))->toBeTrue()
+        ->and((new ReflectionMethod($manager, 'assignmentSourceLabel'))->invoke($manager, $assignedCourse))->toBe('Manual + Group');
+});
+
+test('explicit assignment without group membership is labeled manual', function (): void {
+    $user = TestUser::query()->create([
+        'name' => 'Manual Only User',
+        'email' => 'manual-only@example.com',
+        'password' => bcrypt('password'),
+    ]);
+
+    $course = Course::factory()->create();
+    $user->courses()->attach($course->id, ['is_explicitly_assigned' => true]);
+
+    $manager = new CoursesRelationManager;
+    $manager->ownerRecord = $user;
+
+    $assignedCourse = (new ReflectionMethod($manager, 'resolveAssignedCoursesQuery'))
+        ->invoke($manager)
+        ->whereKey($course->id)
+        ->first();
+
+    expect($assignedCourse)->not->toBeNull()
+        ->and((new ReflectionMethod($manager, 'hasManualAssignment'))->invoke($manager, $assignedCourse))->toBeTrue()
+        ->and((new ReflectionMethod($manager, 'assignmentSourceLabel'))->invoke($manager, $assignedCourse))->toBe('Manual');
+});
+
+test('course users manager does not treat completion-only pivot rows as detachable', function (): void {
+    $user = TestUser::query()->create([
+        'name' => 'Completion User',
+        'email' => 'completion-user@example.com',
+        'password' => bcrypt('password'),
+    ]);
+
+    $course = Course::factory()->create();
+    $course->users()->attach($user->id, [
+        'completed_at' => now(),
+        'is_explicitly_assigned' => false,
+    ]);
+
+    $manager = new CourseUsersRelationManager;
+    $assignedUser = $course->users()->whereKey($user->id)->first();
+
+    expect($assignedUser)->not->toBeNull()
+        ->and((new ReflectionMethod($manager, 'hasManualAssignment'))->invoke($manager, $assignedUser))->toBeFalse();
+
+    $course->users()->updateExistingPivot($user->id, ['is_explicitly_assigned' => true]);
+    $explicitUser = $course->users()->whereKey($user->id)->first();
+
+    expect((new ReflectionMethod($manager, 'hasManualAssignment'))->invoke($manager, $explicitUser))->toBeTrue();
 });

--- a/tests/Feature/UserGroupAssignmentTest.php
+++ b/tests/Feature/UserGroupAssignmentTest.php
@@ -1,0 +1,280 @@
+<?php
+
+declare(strict_types=1);
+
+use Filament\QueryBuilder\Constraints\Constraint;
+use Illuminate\Support\Facades\Queue;
+use Tapp\FilamentLms\Jobs\RebuildUserGroupMemberships;
+use Tapp\FilamentLms\Models\Course;
+use Tapp\FilamentLms\Models\Lesson;
+use Tapp\FilamentLms\Models\Step;
+use Tapp\FilamentLms\Models\UserGroup;
+use Tapp\FilamentLms\Tests\Support\TestUserGroupCriteriaProvider;
+use Tapp\FilamentLms\Tests\TestUser;
+use Tapp\FilamentLms\UserGroups\CourseAccessResolver;
+use Tapp\FilamentLms\UserGroups\UserGroupCriteriaRegistry;
+use Tapp\FilamentLms\UserGroups\UserGroupMembershipSynchronizer;
+use Tapp\FilamentLms\UserGroups\UserGroupRuleMatcher;
+
+beforeEach(function (): void {
+    config([
+        'filament-lms.user_groups.criteria_provider' => TestUserGroupCriteriaProvider::class,
+        'filament-lms.user_groups.sync_queue' => false,
+        'filament-lms.user_groups.refresh_on_user_save' => false,
+    ]);
+});
+
+function makeNameContainsRules(string $text): array
+{
+    return [
+        'version' => 1,
+        'sources' => [
+            [
+                'source' => 'user',
+                'rules' => [
+                    'rule1' => [
+                        'type' => 'name',
+                        'data' => [
+                            Constraint::OPERATOR_SELECT_NAME => 'contains',
+                            'settings' => [
+                                'text' => $text,
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ],
+    ];
+}
+
+function makePrivateCourseWithStep(): Course
+{
+    $course = Course::factory()->create([
+        'is_private' => true,
+    ]);
+
+    $lesson = Lesson::factory()->create([
+        'course_id' => $course->id,
+    ]);
+
+    Step::factory()->create([
+        'lesson_id' => $lesson->id,
+    ]);
+
+    return $course->fresh();
+}
+
+it('registers configured criteria sources', function (): void {
+    $sources = app(UserGroupCriteriaRegistry::class)->sources();
+
+    expect($sources)->toHaveKey('user')
+        ->and($sources['user']->label)->toBe('User');
+});
+
+it('rejects unknown criteria sources', function (): void {
+    app(UserGroupRuleMatcher::class)->normalize([
+        'version' => 1,
+        'sources' => [
+            [
+                'source' => 'unknown',
+                'rules' => [],
+            ],
+        ],
+    ]);
+})->throws(InvalidArgumentException::class);
+
+it('matches users with text constraints', function (): void {
+    $alice = TestUser::query()->create([
+        'name' => 'Alice Smith',
+        'email' => 'alice@example.com',
+        'password' => bcrypt('password'),
+    ]);
+    TestUser::query()->create([
+        'name' => 'Bob Jones',
+        'email' => 'bob@example.com',
+        'password' => bcrypt('password'),
+    ]);
+
+    $matcher = app(UserGroupRuleMatcher::class);
+    $ids = $matcher->matchingUsersQuery(makeNameContainsRules('Alice'))->pluck('id');
+
+    expect($ids)->toContain($alice->id)
+        ->and($ids)->toHaveCount(1);
+});
+
+it('rebuilds memberships atomically and grants private course access', function (): void {
+    $matching = TestUser::query()->create([
+        'name' => 'Match User',
+        'email' => 'match@example.com',
+        'password' => bcrypt('password'),
+    ]);
+    $other = TestUser::query()->create([
+        'name' => 'Other User',
+        'email' => 'other@example.com',
+        'password' => bcrypt('password'),
+    ]);
+
+    $course = makePrivateCourseWithStep();
+    $group = UserGroup::factory()->create([
+        'rules' => makeNameContainsRules('Match'),
+    ]);
+    $course->userGroups()->attach($group->id);
+
+    app(UserGroupMembershipSynchronizer::class)->rebuild($group->fresh());
+
+    $group->refresh();
+
+    expect($group->published_revision)->toBe(1)
+        ->and($group->hasPublishedMembership($matching->id))->toBeTrue()
+        ->and($group->hasPublishedMembership($other->id))->toBeFalse();
+
+    $resolver = app(CourseAccessResolver::class);
+
+    expect($resolver->canAccess($course, $matching))->toBeTrue()
+        ->and($resolver->canAccess($course, $other))->toBeFalse();
+
+    expect(
+        Course::query()->accessibleTo($matching)->whereKey($course->id)->exists()
+    )->toBeTrue()
+        ->and(
+            Course::query()->accessibleTo($other)->whereKey($course->id)->exists()
+        )->toBeFalse();
+});
+
+it('revokes group access when membership no longer matches after rebuild', function (): void {
+    $user = TestUser::query()->create([
+        'name' => 'Match User',
+        'email' => 'match@example.com',
+        'password' => bcrypt('password'),
+    ]);
+
+    $course = makePrivateCourseWithStep();
+    $group = UserGroup::factory()->create([
+        'rules' => makeNameContainsRules('Match'),
+    ]);
+    $course->userGroups()->attach($group->id);
+
+    $synchronizer = app(UserGroupMembershipSynchronizer::class);
+    $synchronizer->rebuild($group->fresh());
+
+    expect(app(CourseAccessResolver::class)->canAccess($course, $user))->toBeTrue();
+
+    $group->forceFill([
+        'rules' => makeNameContainsRules('Nobody'),
+    ])->save();
+    $synchronizer->rebuild($group->fresh());
+
+    expect(app(CourseAccessResolver::class)->canAccess($course, $user))->toBeFalse();
+});
+
+it('keeps completion history when access is only from a group and completion attaches without explicit assignment', function (): void {
+    $user = TestUser::query()->create([
+        'name' => 'Match User',
+        'email' => 'match@example.com',
+        'password' => bcrypt('password'),
+    ]);
+
+    $course = makePrivateCourseWithStep();
+    $group = UserGroup::factory()->create([
+        'rules' => makeNameContainsRules('Match'),
+    ]);
+    $course->userGroups()->attach($group->id);
+    app(UserGroupMembershipSynchronizer::class)->rebuild($group->fresh());
+
+    $course->users()->attach($user->id, [
+        'completed_at' => now(),
+        'is_explicitly_assigned' => false,
+    ]);
+
+    $pivot = $course->users()->where('user_id', $user->id)->first()?->pivot;
+
+    expect($pivot)->not->toBeNull()
+        ->and($pivot->completed_at)->not->toBeNull()
+        ->and((bool) $pivot->is_explicitly_assigned)->toBeFalse()
+        ->and(app(CourseAccessResolver::class)->canAccess($course, $user))->toBeTrue();
+
+    $group->forceFill([
+        'rules' => makeNameContainsRules('Nobody'),
+    ])->save();
+    app(UserGroupMembershipSynchronizer::class)->rebuild($group->fresh());
+
+    expect(app(CourseAccessResolver::class)->canAccess($course, $user))->toBeFalse()
+        ->and($course->completedByUserAt($user->id))->not->toBeNull();
+});
+
+it('prefers explicit manual assignment over group membership for access', function (): void {
+    $user = TestUser::query()->create([
+        'name' => 'Manual User',
+        'email' => 'manual@example.com',
+        'password' => bcrypt('password'),
+    ]);
+
+    $course = makePrivateCourseWithStep();
+    $course->users()->attach($user->id, ['is_explicitly_assigned' => true]);
+
+    expect(app(CourseAccessResolver::class)->canAccess($course, $user))->toBeTrue();
+});
+
+it('lists manually assigned and group-assigned courses for a user', function (): void {
+    $user = TestUser::query()->create([
+        'name' => 'Match User',
+        'email' => 'match@example.com',
+        'password' => bcrypt('password'),
+    ]);
+
+    $manualCourse = makePrivateCourseWithStep();
+    $manualCourse->forceFill(['name' => 'Manual Course '.uniqid()])->save();
+    $manualCourse->users()->attach($user->id, ['is_explicitly_assigned' => true]);
+
+    $groupCourse = makePrivateCourseWithStep();
+    $groupCourse->forceFill(['name' => 'Group Course '.uniqid()])->save();
+    $group = UserGroup::factory()->create([
+        'rules' => makeNameContainsRules('Match'),
+    ]);
+    $groupCourse->userGroups()->attach($group->id);
+    app(UserGroupMembershipSynchronizer::class)->rebuild($group->fresh());
+
+    $unrelated = makePrivateCourseWithStep();
+    $unrelated->forceFill(['name' => 'Unrelated Course '.uniqid()])->save();
+
+    $assignedIds = Course::query()->assignedToUser($user)->pluck('id');
+
+    expect($assignedIds)->toContain($manualCourse->id)
+        ->and($assignedIds)->toContain($groupCourse->id)
+        ->and($assignedIds)->not->toContain($unrelated->id);
+});
+
+it('queues membership rebuilds when configured', function (): void {
+    config(['filament-lms.user_groups.sync_queue' => true]);
+    Queue::fake();
+
+    $group = UserGroup::factory()->create([
+        'rules' => makeNameContainsRules('Match'),
+    ]);
+
+    app(UserGroupMembershipSynchronizer::class)->queueRebuild($group);
+
+    Queue::assertPushed(RebuildUserGroupMemberships::class, fn (RebuildUserGroupMemberships $job): bool => $job->userGroupId === $group->id);
+});
+
+it('refreshes a single user against active groups', function (): void {
+    $user = TestUser::query()->create([
+        'name' => 'Match User',
+        'email' => 'match@example.com',
+        'password' => bcrypt('password'),
+    ]);
+
+    $group = UserGroup::factory()->create([
+        'rules' => makeNameContainsRules('Match'),
+        'published_revision' => 1,
+    ]);
+
+    app(UserGroupMembershipSynchronizer::class)->refreshUser($user->id);
+
+    expect($group->fresh()->hasPublishedMembership($user->id))->toBeTrue();
+
+    $user->forceFill(['name' => 'Changed'])->save();
+    app(UserGroupMembershipSynchronizer::class)->refreshUser($user->id);
+
+    expect($group->fresh()->hasPublishedMembership($user->id))->toBeFalse();
+});

--- a/tests/Feature/UserGroupAssignmentTest.php
+++ b/tests/Feature/UserGroupAssignmentTest.php
@@ -9,6 +9,7 @@ use Tapp\FilamentLms\Models\Course;
 use Tapp\FilamentLms\Models\Lesson;
 use Tapp\FilamentLms\Models\Step;
 use Tapp\FilamentLms\Models\UserGroup;
+use Tapp\FilamentLms\Models\UserGroupMembership;
 use Tapp\FilamentLms\Tests\Support\TestUserGroupCriteriaProvider;
 use Tapp\FilamentLms\Tests\TestUser;
 use Tapp\FilamentLms\UserGroups\CourseAccessResolver;
@@ -277,4 +278,43 @@ it('refreshes a single user against active groups', function (): void {
     app(UserGroupMembershipSynchronizer::class)->refreshUser($user->id);
 
     expect($group->fresh()->hasPublishedMembership($user->id))->toBeFalse();
+});
+
+it('clears group memberships when the user no longer exists', function (): void {
+    $user = TestUser::query()->create([
+        'name' => 'Match User',
+        'email' => 'deleted-match@example.com',
+        'password' => bcrypt('password'),
+    ]);
+
+    $group = UserGroup::factory()->create([
+        'rules' => makeNameContainsRules('Match'),
+        'published_revision' => 1,
+    ]);
+
+    $inactiveGroup = UserGroup::factory()->create([
+        'rules' => makeNameContainsRules('Match'),
+        'published_revision' => 1,
+        'is_active' => false,
+    ]);
+
+    $synchronizer = app(UserGroupMembershipSynchronizer::class);
+    $synchronizer->refreshUser($user->id);
+
+    UserGroupMembership::query()->create([
+        'user_group_id' => $inactiveGroup->id,
+        'user_id' => $user->id,
+        'revision' => 1,
+        'matched_at' => now(),
+    ]);
+
+    expect(UserGroupMembership::query()->where('user_id', $user->id)->count())->toBe(2);
+
+    $userId = $user->id;
+    $user->delete();
+
+    $synchronizer->refreshUser($userId);
+
+    expect(UserGroupMembership::query()->where('user_id', $userId)->exists())->toBeFalse()
+        ->and($group->fresh()->hasPublishedMembership($userId))->toBeFalse();
 });

--- a/tests/Support/TestUserGroupCriteriaProvider.php
+++ b/tests/Support/TestUserGroupCriteriaProvider.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tapp\FilamentLms\Tests\Support;
+
+use Filament\QueryBuilder\Constraints\TextConstraint;
+use Tapp\FilamentLms\UserGroups\Contracts\UserGroupCriteriaProvider;
+use Tapp\FilamentLms\UserGroups\CriteriaSource;
+
+final class TestUserGroupCriteriaProvider implements UserGroupCriteriaProvider
+{
+    public function sources(): array
+    {
+        return [
+            'user' => new CriteriaSource(
+                key: 'user',
+                label: 'User',
+                constraints: fn (): array => [
+                    TextConstraint::make('name')->label('Name'),
+                    TextConstraint::make('email')->label('Email'),
+                ],
+            ),
+        ];
+    }
+}

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -159,7 +159,41 @@ abstract class TestCase extends Orchestra
             $table->foreignId('course_id')->constrained('lms_courses')->onDelete('cascade');
             $table->unsignedBigInteger('user_id');
             $table->timestamp('completed_at')->nullable();
+            $table->boolean('is_explicitly_assigned')->default(true);
             $table->timestamps();
+        });
+
+        $app['db']->connection()->getSchemaBuilder()->create('lms_user_groups', function (Blueprint $table) {
+            $table->id();
+            $table->string('name');
+            $table->text('description')->nullable();
+            $table->json('rules');
+            $table->unsignedSmallInteger('rules_version')->default(1);
+            $table->unsignedInteger('published_revision')->default(0);
+            $table->boolean('is_active')->default(true);
+            $table->string('sync_status', 32)->default('idle');
+            $table->text('sync_error')->nullable();
+            $table->timestamp('last_synced_at')->nullable();
+            $table->timestamps();
+        });
+
+        $app['db']->connection()->getSchemaBuilder()->create('lms_course_user_group', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('course_id')->constrained('lms_courses')->cascadeOnDelete();
+            $table->foreignId('user_group_id')->constrained('lms_user_groups')->cascadeOnDelete();
+            $table->boolean('is_default')->default(false);
+            $table->timestamps();
+            $table->unique(['course_id', 'user_group_id']);
+        });
+
+        $app['db']->connection()->getSchemaBuilder()->create('lms_user_group_memberships', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('user_group_id')->constrained('lms_user_groups')->cascadeOnDelete();
+            $table->unsignedBigInteger('user_id');
+            $table->unsignedInteger('revision');
+            $table->timestamp('matched_at')->nullable();
+            $table->timestamps();
+            $table->unique(['user_group_id', 'user_id', 'revision']);
         });
 
         // Create lms_videos table


### PR DESCRIPTION
# Details

Add assign user groups to course (see README file for details).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes who can see and enroll in private courses and pivot semantics; risk is mitigated because groups are disabled by default and require migrations plus a criteria provider.
> 
> **Overview**
> Adds **dynamic user groups** so private courses can be assigned via Filament Query Builder rules (app-defined `UserGroupCriteriaProvider`) instead of only per-user pivots. The feature is **opt-in** through `config/filament-lms.php` `user_groups.criteria_provider`; until set, the **Assigned User Groups** tab stays hidden.
> 
> New persistence (`lms_user_groups`, course–group links, versioned memberships) plus queued/incremental sync (`UserGroupMembershipSynchronizer`, user-save observer, `filament-lms:reconcile-user-group-memberships`). **Course access** (`accessibleTo`, `canBeAccessedBy`, evaluation checks) moves to `CourseAccessResolver`, treating users as assigned when they are in a published group membership or have an explicit pivot.
> 
> `lms_course_user.is_explicitly_assigned` separates **manual** enrollments from completion-only or implicit rows; bulk attach and relation managers set or respect this, show Manual/Group badges on the user’s **Assigned Courses** tab, and limit detach to manual assignments. Course edit gets **Assigned User Groups** UI to preview matchers, save/update groups, and pick a default group per course.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4b1d68df3cd75feea714847040ca835119ee7398. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->