### PR TITLE
Require course certificate templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -423,7 +423,33 @@ When `multipart_upload.enabled` is `true` **and** `spykapps/filament-uppy-upload
 
 ## Certificate Customization
 
-The LMS package generates PDF certificates when users complete courses. You can customize the appearance and content of certificates using the following configuration options:
+The LMS package generates PDF certificates when users complete courses. You can customize the appearance and content of certificates using the following configuration options.
+
+### Optional certificate-builder templates
+
+Install [tapp/filament-certificate-builder](https://github.com/TappNetwork/filament-certificate-builder) and enable the integration to assign a custom template per course. When a course has no template (or the package is not installed), the existing award Blade certificate is used.
+
+```bash
+composer require tapp/filament-certificate-builder
+php artisan vendor:publish --tag=filament-lms-migrations
+php artisan migrate
+```
+
+```php
+// config/filament-lms.php
+'integrations' => [
+    'certificate_builder' => [
+        'enabled' => true,
+        'token_set' => 'course',
+        // Point this at your host CertificateTemplateResource if you do not register the package resource.
+        'template_resource' => \Tapp\FilamentCertificateBuilder\Filament\Resources\CertificateTemplates\CertificateTemplateResource::class,
+    ],
+],
+```
+
+Add a matching `course` token set in `config/certificate-builder.php`. LMS resolves tokens with context `['course' => $course, 'user' => $user]` and keeps the `filament-lms::certificates.show` / `filament-lms::certificates.download` routes.
+
+On **Edit Course**, **Create Certificate Template** creates a template for that token set, sets `certificate_template_id` on the course, and redirects to the designer. When the course already has a template, the action is **Edit Certificate Template** and opens the designer for that template.
 
 ### certificate_logo
 

--- a/README.md
+++ b/README.md
@@ -313,9 +313,7 @@ return [
     
     'vite_theme' => '',
     'colors' => [],
-    'awards' => [
-        'Default' => 'default',
-    ],
+    // awards was removed. Course certificates use certificate_template_id.
     'top_navigation' => false,
     'show_exit_lms_link' => true,
 ];
@@ -425,9 +423,9 @@ When `multipart_upload.enabled` is `true` **and** `spykapps/filament-uppy-upload
 
 The LMS package generates PDF certificates when users complete courses. You can customize the appearance and content of certificates using the following configuration options.
 
-### Optional certificate-builder templates
+### Certificate-builder templates
 
-Install [tapp/filament-certificate-builder](https://github.com/TappNetwork/filament-certificate-builder) and enable the integration to assign a custom template per course. When a course has no template (or the package is not installed), the existing award Blade certificate is used.
+Course certificates require [tapp/filament-certificate-builder](https://github.com/TappNetwork/filament-certificate-builder). See [UPGRADING.md](UPGRADING.md) to convert legacy `award` Blades.
 
 ```bash
 composer require tapp/filament-certificate-builder
@@ -441,25 +439,14 @@ php artisan migrate
     'certificate_builder' => [
         'enabled' => true,
         'token_set' => 'course',
-        // Point this at your host CertificateTemplateResource if you do not register the package resource.
         'template_resource' => \Tapp\FilamentCertificateBuilder\Filament\Resources\CertificateTemplates\CertificateTemplateResource::class,
     ],
 ],
 ```
 
-Add a matching `course` token set in `config/certificate-builder.php`. LMS resolves tokens with context `['course' => $course, 'user' => $user]` and keeps the `filament-lms::certificates.show` / `filament-lms::certificates.download` routes.
+Add a matching `course` token set in `config/certificate-builder.php`. LMS resolves tokens with context `['course' => $course, 'user' => $user]` on `filament-lms::certificates.show` / `filament-lms::certificates.download`. A course without a template returns 404.
 
-On **Edit Course**, **Create Certificate Template** creates a template for that token set, sets `certificate_template_id` on the course, and redirects to the designer. When the course already has a template, the action is **Edit Certificate Template** and opens the designer for that template.
-
-Migrate existing award Blade certificates into builder templates (logos and copy only; layouts are not pixel-perfect):
-
-```bash
-php artisan filament-lms:migrate-awards-to-templates --dry-run
-php artisan filament-lms:migrate-awards-to-templates
-php artisan filament-lms:migrate-awards-to-templates --award=safb
-```
-
-The command reads `config('filament-lms.awards')` plus any `award` values already stored on courses, creates one template per award from the matching `filament-lms::certificates.{award}` view, and assigns it to courses that do not already have a `certificate_template_id`. Background/header images are skipped; `<img>` logos and static text are applied to the default builder layout. Use `--force` to refresh those layouts and reassign courses that already have a template.
+On **Edit Course**, **Create Certificate Template** creates a template for that token set, sets `certificate_template_id`, and opens the designer. **Edit Certificate Template** opens the assigned template.
 
 ### certificate_logo
 

--- a/README.md
+++ b/README.md
@@ -451,6 +451,16 @@ Add a matching `course` token set in `config/certificate-builder.php`. LMS resol
 
 On **Edit Course**, **Create Certificate Template** creates a template for that token set, sets `certificate_template_id` on the course, and redirects to the designer. When the course already has a template, the action is **Edit Certificate Template** and opens the designer for that template.
 
+Migrate existing award Blade certificates into builder templates (logos and copy only; layouts are not pixel-perfect):
+
+```bash
+php artisan filament-lms:migrate-awards-to-templates --dry-run
+php artisan filament-lms:migrate-awards-to-templates
+php artisan filament-lms:migrate-awards-to-templates --award=safb
+```
+
+The command reads `config('filament-lms.awards')` plus any `award` values already stored on courses, creates one template per award from the matching `filament-lms::certificates.{award}` view, and assigns it to courses that do not already have a `certificate_template_id`. Background/header images are skipped; `<img>` logos and static text are applied to the default builder layout. Use `--force` to refresh those layouts and reassign courses that already have a template.
+
 ### certificate_logo
 
 Specify a custom logo to display on certificates. If not set, it falls back to the `brand_logo` setting.

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -1,0 +1,58 @@
+# Upgrading
+
+## Award certificates → certificate templates
+
+This is a breaking change. Course certificates are builder-only. The `lms_courses.award` column is removed.
+
+### Before you deploy
+
+1. Require the builder in the host app:
+
+```bash
+composer require tapp/filament-certificate-builder
+```
+
+2. Keep `filament-lms.awards` in the host config until `php artisan migrate` has run. The upgrade reads those labels (and any `award` values already on courses) to name templates. After migrate succeeds you can delete the `awards` array.
+
+3. Keep published award Blades on disk until migrate has run (`resources/views/vendor/filament-lms/certificates/*.blade.php`). They are the source for logos, copy, borders, and headers.
+
+4. Enable the course token set in `config/certificate-builder.php` and point `filament-lms.integrations.certificate_builder.template_resource` at your Filament resource.
+
+### Upgrade
+
+```bash
+php artisan filament-lms:upgrade-awards --dry-run
+php artisan migrate
+```
+
+`php artisan migrate` runs `drop_award_from_lms_courses_table`, which:
+
+1. Creates or reuses one certificate template per award key
+2. Assigns a template to every course that does not already have a living `certificate_template_id` (`award = null` uses **Default Certificate**)
+3. Does **not** overwrite hand-edited templates or retarget courses that already point at a different template
+4. Fails if any course still lacks a template
+5. Makes `certificate_template_id` required (`restrictOnDelete`) and drops `award`
+
+Preview or force-refresh migrated layouts (not custom templates) with:
+
+```bash
+php artisan filament-lms:upgrade-awards --dump=storage/logs/lms-award-upgrade.json
+php artisan filament-lms:upgrade-awards --force
+php artisan filament-lms:upgrade-awards --award=decan
+```
+
+`filament-lms:migrate-awards-to-templates` is a hidden alias and will be removed in a later release.
+
+### After migrate
+
+- Delete published LMS award Blades and any Tailwind `@source` aimed only at those views
+- Remove `awards` from `config/filament-lms.php`
+- Point SCORM imports and new courses at a certificate template (the course form and `CourseFactory` default to **Default Certificate**)
+- Training / certification certificates (CHECK `awardCertification()`) are unchanged
+
+### Notes
+
+- Layouts are not pixel-perfect copies of the old Blades
+- `--force` only refreshes templates named `{Award label} Certificate`
+- Courses with `award` values that had no Blade (for example CHECK `chwad`) get the default Blade source
+- Rollback cannot restore per-course `award` values unless you keep the `--dump` JSON

--- a/composer.json
+++ b/composer.json
@@ -21,6 +21,7 @@
     },
     "suggest": {
         "tapp/filament-library": "Required for Library file / Library link step materials (set filament-lms.integrations.filament_library.enabled for the admin material picker).",
+        "tapp/filament-certificate-builder": "Optional. Enables custom certificate templates on courses (set filament-lms.integrations.certificate_builder.enabled).",
         "spykapps/filament-uppy-upload": "Optional. Enables Uppy chunked (multipart) uploads for SCORM package import so large ZIPs stay under Cloudflare's ~100MB limit (set filament-lms.common_cartridge_import.multipart_upload.enabled)."
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     },
     "suggest": {
         "tapp/filament-library": "Required for Library file / Library link step materials (set filament-lms.integrations.filament_library.enabled for the admin material picker).",
-        "tapp/filament-certificate-builder": "Optional. Enables custom certificate templates on courses (set filament-lms.integrations.certificate_builder.enabled).",
+        "tapp/filament-certificate-builder": "Required for course certificates. Install before running filament-lms:upgrade-awards.",
         "spykapps/filament-uppy-upload": "Optional. Enables Uppy chunked (multipart) uploads for SCORM package import so large ZIPs stay under Cloudflare's ~100MB limit (set filament-lms.common_cartridge_import.multipart_upload.enabled)."
     },
     "require-dev": {

--- a/config/filament-lms.php
+++ b/config/filament-lms.php
@@ -22,9 +22,6 @@ return [
 
     'vite_theme' => '',
     'colors' => [],
-    'awards' => [
-        'default' => 'Default',
-    ],
     // Enable top navigation on the LMS dashboard (courses list page).
     // Note: This only affects the dashboard. Course pages always use sidebar navigation.
     'top_navigation' => false,
@@ -189,8 +186,8 @@ return [
         ],
 
         'certificate_builder' => [
-            // When true (and tapp/filament-certificate-builder is installed), courses may use a custom template.
-            'enabled' => false,
+            // Required for course certificates. The builder package must be installed.
+            'enabled' => true,
 
             // Token set key from config/certificate-builder.php used for new course templates.
             'token_set' => 'course',

--- a/config/filament-lms.php
+++ b/config/filament-lms.php
@@ -186,6 +186,17 @@ return [
             // Max rows returned when searching library files or links on the Step form.
             'material_select_limit' => 200,
         ],
+
+        'certificate_builder' => [
+            // When true (and tapp/filament-certificate-builder is installed), courses may use a custom template.
+            'enabled' => false,
+
+            // Token set key from config/certificate-builder.php used for new course templates.
+            'token_set' => 'course',
+
+            // Filament resource used after creating a template from Edit Course.
+            'template_resource' => \Tapp\FilamentCertificateBuilder\Filament\Resources\CertificateTemplates\CertificateTemplateResource::class,
+        ],
     ],
 
     /*

--- a/config/filament-lms.php
+++ b/config/filament-lms.php
@@ -1,6 +1,7 @@
 <?php
 
 use App\Models\User;
+use Tapp\FilamentCertificateBuilder\Filament\Resources\CertificateTemplates\CertificateTemplateResource;
 
 return [
     'theme' => 'default',
@@ -195,7 +196,7 @@ return [
             'token_set' => 'course',
 
             // Filament resource used after creating a template from Edit Course.
-            'template_resource' => \Tapp\FilamentCertificateBuilder\Filament\Resources\CertificateTemplates\CertificateTemplateResource::class,
+            'template_resource' => CertificateTemplateResource::class,
         ],
     ],
 

--- a/database/factories/CourseFactory.php
+++ b/database/factories/CourseFactory.php
@@ -5,6 +5,7 @@ namespace Tapp\FilamentLms\Database\Factories;
 use Illuminate\Database\Eloquent\Factories\Factory;
 use Illuminate\Support\Str;
 use Tapp\FilamentLms\Models\Course;
+use Tapp\FilamentLms\Support\CertificateBuilder;
 
 class CourseFactory extends Factory
 {
@@ -23,8 +24,15 @@ class CourseFactory extends Factory
             'name' => $name,
             'slug' => $slug,
             'external_id' => $externalId,
-            'award' => 'default',
+            'certificate_template_id' => CertificateBuilder::defaultTemplateId(),
             'description' => $this->faker->sentence(),
         ];
+    }
+
+    public function withoutCertificateTemplate(): static
+    {
+        return $this->state([
+            'certificate_template_id' => null,
+        ]);
     }
 }

--- a/database/migrations/add_certificate_template_id_to_lms_courses_table.php.stub
+++ b/database/migrations/add_certificate_template_id_to_lms_courses_table.php.stub
@@ -1,0 +1,36 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        if (Schema::hasColumn('lms_courses', 'certificate_template_id')) {
+            return;
+        }
+
+        Schema::table('lms_courses', function (Blueprint $table) {
+            $table->unsignedBigInteger('certificate_template_id')
+                ->nullable()
+                ->after('award')
+                ->index();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('lms_courses', function (Blueprint $table) {
+            $table->dropIndex(['certificate_template_id']);
+            $table->dropColumn('certificate_template_id');
+        });
+    }
+};

--- a/database/migrations/drop_award_from_lms_courses_table.php.stub
+++ b/database/migrations/drop_award_from_lms_courses_table.php.stub
@@ -1,0 +1,55 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+use Tapp\FilamentLms\Services\MigrateAwardsToCertificateTemplates;
+use Tapp\FilamentLms\Support\CertificateBuilder;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        if (! Schema::hasColumn('lms_courses', 'award')) {
+            return;
+        }
+
+        if (! CertificateBuilder::enabled()) {
+            throw new RuntimeException('tapp/filament-certificate-builder must be installed before dropping lms_courses.award. See UPGRADING.md.');
+        }
+
+        app(MigrateAwardsToCertificateTemplates::class)->handle();
+
+        $unverified = app(MigrateAwardsToCertificateTemplates::class)->unverifiedCourseIds();
+
+        if ($unverified !== []) {
+            throw new RuntimeException(
+                'Cannot drop lms_courses.award while courses lack a certificate template (ids: '.implode(', ', $unverified).'). Run php artisan filament-lms:upgrade-awards.',
+            );
+        }
+
+        $hasForeignKey = collect(Schema::getForeignKeys('lms_courses'))
+            ->contains(fn (array $foreignKey): bool => in_array('certificate_template_id', $foreignKey['columns'], true));
+
+        if ($hasForeignKey) {
+            Schema::table('lms_courses', function (Blueprint $table): void {
+                $table->dropForeign(['certificate_template_id']);
+            });
+        }
+
+        Schema::table('lms_courses', function (Blueprint $table): void {
+            $table->unsignedBigInteger('certificate_template_id')->nullable(false)->change();
+        });
+
+        Schema::table('lms_courses', function (Blueprint $table): void {
+            $table->foreign('certificate_template_id')
+                ->references('id')
+                ->on('certificate_templates')
+                ->restrictOnDelete();
+        });
+
+        Schema::table('lms_courses', function (Blueprint $table): void {
+            $table->dropColumn('award');
+        });
+    }
+};

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -40,3 +40,7 @@ parameters:
             message: '#Call to an undefined method Illuminate\\Database\\Eloquent\\Model::(getFirstMedia|getSecureUrl)\(\)#'
             paths:
                 - src/Livewire/LibraryFileStep.php
+                - src/Livewire/LibraryLinkStep.php
+        # Optional filament-certificate-builder integration
+        - '#Class Tapp\\FilamentCertificateBuilder\\#'
+        - '#unknown class Tapp\\FilamentCertificateBuilder\\#'

--- a/src/Console/Commands/MigrateAwardsToCertificateTemplatesCommand.php
+++ b/src/Console/Commands/MigrateAwardsToCertificateTemplatesCommand.php
@@ -5,59 +5,28 @@ declare(strict_types=1);
 namespace Tapp\FilamentLms\Console\Commands;
 
 use Illuminate\Console\Command;
-use Tapp\FilamentLms\Services\MigrateAwardsToCertificateTemplates;
-use Tapp\FilamentLms\Support\CertificateBuilder;
 
 final class MigrateAwardsToCertificateTemplatesCommand extends Command
 {
+    protected $hidden = true;
+
     protected $signature = 'filament-lms:migrate-awards-to-templates
                             {--award= : Only migrate this award key}
                             {--dry-run : Show the plan without writing}
-                            {--force : Recreate layouts and reassign courses that already have a template}';
+                            {--force : Recreate layouts for migrated template names}
+                            {--dump= : Write a JSON summary to this path}';
 
-    protected $description = 'Create certificate templates from LMS award Blade views and assign them to courses';
+    protected $description = 'Deprecated alias of filament-lms:upgrade-awards';
 
-    public function handle(MigrateAwardsToCertificateTemplates $migrator): int
+    public function handle(): int
     {
-        if (! CertificateBuilder::enabled()) {
-            $this->error('Certificate builder is not enabled. Install tapp/filament-certificate-builder and set filament-lms.integrations.certificate_builder.enabled to true.');
+        $this->warn('filament-lms:migrate-awards-to-templates is deprecated. Use filament-lms:upgrade-awards.');
 
-            return self::FAILURE;
-        }
-
-        if ($this->option('dry-run')) {
-            $this->info('DRY RUN - no changes will be written.');
-        }
-
-        $award = $this->option('award');
-
-        $summary = $migrator->handle(
-            award: is_string($award) && $award !== '' ? $award : null,
-            dryRun: (bool) $this->option('dry-run'),
-            force: (bool) $this->option('force'),
-        );
-
-        $this->table(
-            ['Award', 'Template', 'Created', 'Courses', 'Logos'],
-            array_map(
-                fn (array $row): array => [
-                    $row['award'],
-                    $row['template'],
-                    $row['created'] ? 'yes' : 'no',
-                    $row['courses'],
-                    $row['logos'],
-                ],
-                $summary['awards'],
-            ),
-        );
-
-        $this->info('Migration summary: '.json_encode([
-            'templates_created' => $summary['templates_created'],
-            'templates_reused' => $summary['templates_reused'],
-            'courses_updated' => $summary['courses_updated'],
-            'logos_attached' => $summary['logos_attached'],
-        ], JSON_THROW_ON_ERROR));
-
-        return self::SUCCESS;
+        return $this->call('filament-lms:upgrade-awards', [
+            '--award' => $this->option('award'),
+            '--dry-run' => $this->option('dry-run'),
+            '--force' => $this->option('force'),
+            '--dump' => $this->option('dump'),
+        ]);
     }
 }

--- a/src/Console/Commands/MigrateAwardsToCertificateTemplatesCommand.php
+++ b/src/Console/Commands/MigrateAwardsToCertificateTemplatesCommand.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tapp\FilamentLms\Console\Commands;
+
+use Illuminate\Console\Command;
+use Tapp\FilamentLms\Services\MigrateAwardsToCertificateTemplates;
+use Tapp\FilamentLms\Support\CertificateBuilder;
+
+final class MigrateAwardsToCertificateTemplatesCommand extends Command
+{
+    protected $signature = 'filament-lms:migrate-awards-to-templates
+                            {--award= : Only migrate this award key}
+                            {--dry-run : Show the plan without writing}
+                            {--force : Recreate layouts and reassign courses that already have a template}';
+
+    protected $description = 'Create certificate templates from LMS award Blade views and assign them to courses';
+
+    public function handle(MigrateAwardsToCertificateTemplates $migrator): int
+    {
+        if (! CertificateBuilder::enabled()) {
+            $this->error('Certificate builder is not enabled. Install tapp/filament-certificate-builder and set filament-lms.integrations.certificate_builder.enabled to true.');
+
+            return self::FAILURE;
+        }
+
+        if ($this->option('dry-run')) {
+            $this->info('DRY RUN - no changes will be written.');
+        }
+
+        $award = $this->option('award');
+
+        $summary = $migrator->handle(
+            award: is_string($award) && $award !== '' ? $award : null,
+            dryRun: (bool) $this->option('dry-run'),
+            force: (bool) $this->option('force'),
+        );
+
+        $this->table(
+            ['Award', 'Template', 'Created', 'Courses', 'Logos'],
+            array_map(
+                fn (array $row): array => [
+                    $row['award'],
+                    $row['template'],
+                    $row['created'] ? 'yes' : 'no',
+                    $row['courses'],
+                    $row['logos'],
+                ],
+                $summary['awards'],
+            ),
+        );
+
+        $this->info('Migration summary: '.json_encode([
+            'templates_created' => $summary['templates_created'],
+            'templates_reused' => $summary['templates_reused'],
+            'courses_updated' => $summary['courses_updated'],
+            'logos_attached' => $summary['logos_attached'],
+        ], JSON_THROW_ON_ERROR));
+
+        return self::SUCCESS;
+    }
+}

--- a/src/Console/Commands/UpgradeAwardsCommand.php
+++ b/src/Console/Commands/UpgradeAwardsCommand.php
@@ -1,0 +1,94 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tapp\FilamentLms\Console\Commands;
+
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\File;
+use Tapp\FilamentLms\Services\MigrateAwardsToCertificateTemplates;
+use Tapp\FilamentLms\Support\CertificateBuilder;
+
+final class UpgradeAwardsCommand extends Command
+{
+    protected $signature = 'filament-lms:upgrade-awards
+                            {--award= : Only migrate this award key}
+                            {--dry-run : Show the plan without writing}
+                            {--force : Recreate layouts for migrated template names}
+                            {--dump= : Write a JSON summary to this path}';
+
+    protected $description = 'Convert LMS award Blades to certificate templates and assign every course a template';
+
+    public function handle(MigrateAwardsToCertificateTemplates $migrator): int
+    {
+        if (! CertificateBuilder::enabled()) {
+            $this->error('Certificate builder is not installed. Require tapp/filament-certificate-builder before upgrading.');
+
+            return 1;
+        }
+
+        if ($this->option('dry-run')) {
+            $this->info('DRY RUN - no changes will be written.');
+        }
+
+        $award = $this->option('award');
+
+        try {
+            $summary = $migrator->handle(
+                award: is_string($award) && $award !== '' ? $award : null,
+                dryRun: (bool) $this->option('dry-run'),
+                force: (bool) $this->option('force'),
+            );
+        } catch (\RuntimeException $exception) {
+            $this->error($exception->getMessage());
+
+            return 1;
+        }
+
+        $this->table(
+            ['Award', 'Template', 'Created', 'Courses', 'Logos'],
+            array_map(
+                fn (array $row): array => [
+                    $row['award'],
+                    $row['template'],
+                    $row['created'] ? 'yes' : 'no',
+                    $row['courses'],
+                    $row['logos'],
+                ],
+                $summary['awards'],
+            ),
+        );
+
+        $payload = [
+            'templates_created' => $summary['templates_created'],
+            'templates_reused' => $summary['templates_reused'],
+            'courses_updated' => $summary['courses_updated'],
+            'logos_attached' => $summary['logos_attached'],
+            'awards' => $summary['awards'],
+        ];
+
+        $this->info('Upgrade summary: '.json_encode($payload, JSON_THROW_ON_ERROR));
+
+        $dump = $this->option('dump');
+
+        if (is_string($dump) && $dump !== '') {
+            File::ensureDirectoryExists(dirname($dump));
+            File::put($dump, json_encode($payload, JSON_THROW_ON_ERROR | JSON_PRETTY_PRINT));
+            $this->info('Wrote '.$dump);
+        }
+
+        if ($this->option('dry-run')) {
+            return self::SUCCESS;
+        }
+
+        $unverified = $migrator->unverifiedCourseIds();
+
+        if ($unverified !== []) {
+            $this->error('Courses still missing a certificate template: '.implode(', ', $unverified));
+
+            return 2;
+        }
+
+        return self::SUCCESS;
+    }
+}

--- a/src/FilamentLmsServiceProvider.php
+++ b/src/FilamentLmsServiceProvider.php
@@ -14,6 +14,7 @@ use Tapp\FilamentLibrary\Models\LibraryItem;
 use Tapp\FilamentLms\Console\Commands\BackfillCourseCompletedAt;
 use Tapp\FilamentLms\Console\Commands\BackfillEmbeddedPlayerCourses;
 use Tapp\FilamentLms\Console\Commands\ImportCartridgesCommand;
+use Tapp\FilamentLms\Console\Commands\MigrateAwardsToCertificateTemplatesCommand;
 use Tapp\FilamentLms\Console\Commands\ReconcileUserGroupMemberships;
 use Tapp\FilamentLms\Livewire\DocumentStep;
 use Tapp\FilamentLms\Livewire\FormStep;
@@ -77,6 +78,7 @@ class FilamentLmsServiceProvider extends PackageServiceProvider
             ->hasCommand(BackfillCourseCompletedAt::class)
             ->hasCommand(BackfillEmbeddedPlayerCourses::class)
             ->hasCommand(ImportCartridgesCommand::class)
+            ->hasCommand(MigrateAwardsToCertificateTemplatesCommand::class)
             ->hasCommand(ReconcileUserGroupMemberships::class)
             ->hasInstallCommand(function (InstallCommand $command) {
                 $command

--- a/src/FilamentLmsServiceProvider.php
+++ b/src/FilamentLmsServiceProvider.php
@@ -72,6 +72,7 @@ class FilamentLmsServiceProvider extends PackageServiceProvider
                 'create_lms_course_user_group_table',
                 'create_lms_user_group_memberships_table',
                 'add_is_explicitly_assigned_to_lms_course_user_table',
+                'add_certificate_template_id_to_lms_courses_table',
             ])
             ->hasCommand(BackfillCourseCompletedAt::class)
             ->hasCommand(BackfillEmbeddedPlayerCourses::class)

--- a/src/FilamentLmsServiceProvider.php
+++ b/src/FilamentLmsServiceProvider.php
@@ -16,6 +16,7 @@ use Tapp\FilamentLms\Console\Commands\BackfillEmbeddedPlayerCourses;
 use Tapp\FilamentLms\Console\Commands\ImportCartridgesCommand;
 use Tapp\FilamentLms\Console\Commands\MigrateAwardsToCertificateTemplatesCommand;
 use Tapp\FilamentLms\Console\Commands\ReconcileUserGroupMemberships;
+use Tapp\FilamentLms\Console\Commands\UpgradeAwardsCommand;
 use Tapp\FilamentLms\Livewire\DocumentStep;
 use Tapp\FilamentLms\Livewire\FormStep;
 use Tapp\FilamentLms\Livewire\ImageStep;
@@ -74,11 +75,13 @@ class FilamentLmsServiceProvider extends PackageServiceProvider
                 'create_lms_user_group_memberships_table',
                 'add_is_explicitly_assigned_to_lms_course_user_table',
                 'add_certificate_template_id_to_lms_courses_table',
+                'drop_award_from_lms_courses_table',
             ])
             ->hasCommand(BackfillCourseCompletedAt::class)
             ->hasCommand(BackfillEmbeddedPlayerCourses::class)
             ->hasCommand(ImportCartridgesCommand::class)
             ->hasCommand(MigrateAwardsToCertificateTemplatesCommand::class)
+            ->hasCommand(UpgradeAwardsCommand::class)
             ->hasCommand(ReconcileUserGroupMemberships::class)
             ->hasInstallCommand(function (InstallCommand $command) {
                 $command

--- a/src/Http/Controllers/CertificateController.php
+++ b/src/Http/Controllers/CertificateController.php
@@ -2,7 +2,6 @@
 
 namespace Tapp\FilamentLms\Http\Controllers;
 
-use Carbon\Carbon;
 use Illuminate\Contracts\Auth\Authenticatable;
 use Illuminate\Routing\Controller;
 use Illuminate\Support\Facades\Auth;
@@ -41,22 +40,11 @@ class CertificateController extends Controller
 
         $builderView = $this->builderCertificateView($course, $user);
 
-        if ($builderView !== null) {
-            return $builderView;
+        if ($builderView === null) {
+            abort(404);
         }
 
-        $view = 'filament-lms::certificates.'.$course->award;
-
-        if (! view()->exists($view)) {
-            $view = 'filament-lms::certificates.default';
-        }
-
-        $completedAt = $course->completedByUserAt($userId) ?? now();
-
-        return view($view)
-            ->with('dateEarned', $completedAt ? Carbon::parse($completedAt)->format(('F j, Y')) : null)
-            ->with('user', $user)
-            ->with('course', $course);
+        return $builderView;
     }
 
     public function download(Course $course): StreamedResponse

--- a/src/Http/Controllers/CertificateController.php
+++ b/src/Http/Controllers/CertificateController.php
@@ -10,10 +10,10 @@ use Illuminate\Support\Facades\URL;
 use Illuminate\Support\Str;
 use Illuminate\View\View;
 use InvalidArgumentException;
-// TODO get from config
 use Spatie\Browsershot\Browsershot;
 use Symfony\Component\HttpFoundation\StreamedResponse;
 use Tapp\FilamentLms\Models\Course;
+use Tapp\FilamentLms\Support\CertificateBuilder;
 
 class CertificateController extends Controller
 {
@@ -35,8 +35,14 @@ class CertificateController extends Controller
 
         if (! request()->hasValidSignature() &&
             ! $course->completedByUserAt($userId) &&
-            ! Auth::user()->can('update', $course)) {
+            ! Auth::user()?->can('update', $course)) {
             abort(403);
+        }
+
+        $builderView = $this->builderCertificateView($course, $user);
+
+        if ($builderView !== null) {
+            return $builderView;
         }
 
         $view = 'filament-lms::certificates.'.$course->award;
@@ -55,7 +61,7 @@ class CertificateController extends Controller
 
     public function download(Course $course): StreamedResponse
     {
-        if (! $course->completedByUserAt(Auth::id()) && ! Auth::user()->can('update', $course)) {
+        if (! $course->completedByUserAt(Auth::id()) && ! Auth::user()?->can('update', $course)) {
             abort(403);
         }
 
@@ -84,5 +90,52 @@ class CertificateController extends Controller
             ->waitUntilNetworkIdle()
             ->showBackground()
             ->landscape();
+    }
+
+    private function builderCertificateView(Course $course, Authenticatable $user): ?View
+    {
+        if (! CertificateBuilder::enabled() || $course->certificate_template_id === null) {
+            return null;
+        }
+
+        $templateClass = CertificateBuilder::TEMPLATE_MODEL;
+        $template = $templateClass::query()->find($course->certificate_template_id);
+
+        if ($template === null) {
+            return null;
+        }
+
+        return view('filament-certificate-builder::certificate', [
+            'template' => $template,
+            'tokens' => $this->tokensForTemplate($template, $course, $user),
+        ]);
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    private function tokensForTemplate(object $template, Course $course, Authenticatable $user): array
+    {
+        $layoutClass = CertificateBuilder::LAYOUT_CLASS;
+        $resolves = CertificateBuilder::RESOLVES_TOKENS;
+
+        if (! class_exists($layoutClass)) {
+            return [];
+        }
+
+        $tokenSet = method_exists($template, 'tokenSet')
+            ? $template->tokenSet()
+            : CertificateBuilder::tokenSet();
+
+        $resolver = app($layoutClass::resolverClass($tokenSet));
+
+        if (! is_object($resolver) || ! $resolver instanceof $resolves) {
+            return $layoutClass::sampleTokens($tokenSet);
+        }
+
+        return $resolver->resolve([
+            'course' => $course,
+            'user' => $user,
+        ]);
     }
 }

--- a/src/Models/Course.php
+++ b/src/Models/Course.php
@@ -31,6 +31,7 @@ use Tapp\FilamentLms\Pages\CourseCompleted;
 use Tapp\FilamentLms\Pages\Dashboard;
 use Tapp\FilamentLms\Pages\Step as StepPage;
 use Tapp\FilamentLms\Services\CourseEvaluationService;
+use Tapp\FilamentLms\Support\CertificateBuilder;
 use Tapp\FilamentLms\Traits\HasMediaUrl;
 use Tapp\FilamentLms\UserGroups\CourseAccessResolver;
 
@@ -111,15 +112,9 @@ final class Course extends Model implements HasMedia
         return $this->belongsTo(self::class, 'evaluation_course_id');
     }
 
-    /**
-     * @return BelongsTo<Model, $this>
-     */
     public function certificateTemplate(): BelongsTo
     {
-        /** @var class-string<Model> $related */
-        $related = 'Tapp\\FilamentCertificateBuilder\\Models\\CertificateTemplate';
-
-        return $this->belongsTo($related, 'certificate_template_id');
+        return $this->belongsTo(CertificateBuilder::TEMPLATE_MODEL, 'certificate_template_id');
     }
 
     public function hasEvaluation(): bool

--- a/src/Models/Course.php
+++ b/src/Models/Course.php
@@ -41,9 +41,7 @@ use Tapp\FilamentLms\UserGroups\CourseAccessResolver;
  * @property string $slug
  * @property string $external_id
  * @property string|null $image
- * @property string|null $award
  * @property int|null $certificate_template_id
- * @property array $award_content
  * @property string|null $description
  * @property int|null $required_test_percentage
  * @property bool $is_private
@@ -68,7 +66,6 @@ final class Course extends Model implements HasMedia
     protected $table = 'lms_courses';
 
     protected $casts = [
-        'award_content' => 'array',
         'is_private' => 'boolean',
         'embedded_player' => 'boolean',
         'completion_mode' => CompletionMode::class,

--- a/src/Models/Course.php
+++ b/src/Models/Course.php
@@ -112,11 +112,11 @@ final class Course extends Model implements HasMedia
     }
 
     /**
-     * @return BelongsTo<\Illuminate\Database\Eloquent\Model, $this>
+     * @return BelongsTo<Model, $this>
      */
     public function certificateTemplate(): BelongsTo
     {
-        /** @var class-string<\Illuminate\Database\Eloquent\Model> $related */
+        /** @var class-string<Model> $related */
         $related = 'Tapp\\FilamentCertificateBuilder\\Models\\CertificateTemplate';
 
         return $this->belongsTo($related, 'certificate_template_id');

--- a/src/Models/Course.php
+++ b/src/Models/Course.php
@@ -41,6 +41,7 @@ use Tapp\FilamentLms\UserGroups\CourseAccessResolver;
  * @property string $external_id
  * @property string|null $image
  * @property string|null $award
+ * @property int|null $certificate_template_id
  * @property array $award_content
  * @property string|null $description
  * @property int|null $required_test_percentage
@@ -108,6 +109,17 @@ final class Course extends Model implements HasMedia
     public function evaluationCourse(): BelongsTo
     {
         return $this->belongsTo(self::class, 'evaluation_course_id');
+    }
+
+    /**
+     * @return BelongsTo<\Illuminate\Database\Eloquent\Model, $this>
+     */
+    public function certificateTemplate(): BelongsTo
+    {
+        /** @var class-string<\Illuminate\Database\Eloquent\Model> $related */
+        $related = 'Tapp\\FilamentCertificateBuilder\\Models\\CertificateTemplate';
+
+        return $this->belongsTo($related, 'certificate_template_id');
     }
 
     public function hasEvaluation(): bool

--- a/src/Pages/CourseCompleted.php
+++ b/src/Pages/CourseCompleted.php
@@ -172,7 +172,7 @@ final class CourseCompleted extends Page
 
     public function downloadCertificate()
     {
-        return response()->download(route('certificates.download', [auth()->user()->id, $this->course->id]));
+        return response()->download(route('filament-lms::certificates.download', [$this->course->id]));
     }
 
     /**

--- a/src/Resources/CourseResource.php
+++ b/src/Resources/CourseResource.php
@@ -116,24 +116,9 @@ class CourseResource extends Resource
                     ->maxValue(100)
                     ->default(0)
                     ->nullable(),
-                Select::make('award')
-                    ->options(config('filament-lms.awards'))
-                    ->required()
-                    ->hint(function ($record) {
-                        // @phpstan-ignore-next-line
-                        if ($record && $record->id) {
-                            // @phpstan-ignore-next-line
-                            $link = route('filament-lms::certificates.show', ['course' => $record->id, 'user' => auth()->id()]);
-
-                            return new HtmlString("<a rel='noopener noreferrer' target='_blank' href='{$link}'>Click to Preview</a>");
-                        }
-
-                        return null;
-                    })
-                    ->helperText('Form must be saved before previewing.'),
                 Select::make('certificate_template_id')
                     ->label('Certificate Template')
-                    ->helperText('Optional custom layout. Leave blank to use the award certificate.')
+                    ->helperText('Required. Form must be saved before previewing.')
                     ->options(function (): array {
                         $model = CertificateBuilder::TEMPLATE_MODEL;
 
@@ -143,9 +128,19 @@ class CourseResource extends Resource
                             ->pluck('name', 'id')
                             ->all();
                     })
+                    ->default(fn (): ?int => CertificateBuilder::defaultTemplateId())
+                    ->hint(function (?Course $record) {
+                        if ($record && $record->id) {
+                            $link = route('filament-lms::certificates.show', ['course' => $record->id, 'user' => auth()->id()]);
+
+                            return new HtmlString("<a rel='noopener noreferrer' target='_blank' href='{$link}'>Click to Preview</a>");
+                        }
+
+                        return null;
+                    })
                     ->searchable()
                     ->preload()
-                    ->nullable()
+                    ->required()
                     ->visible(fn (): bool => CertificateBuilder::enabled()),
                 Checkbox::make('embedded_player')
                     ->label('Embedded player mode')

--- a/src/Resources/CourseResource.php
+++ b/src/Resources/CourseResource.php
@@ -34,6 +34,7 @@ use Tapp\FilamentLms\Resources\CourseResource\Pages\EditCourse;
 use Tapp\FilamentLms\Resources\CourseResource\Pages\ListCourses;
 use Tapp\FilamentLms\Resources\CourseResource\RelationManagers\LessonsRelationManager;
 use Tapp\FilamentLms\Services\CourseEvaluationService;
+use Tapp\FilamentLms\Support\CertificateBuilder;
 
 class CourseResource extends Resource
 {
@@ -130,6 +131,22 @@ class CourseResource extends Resource
                         return null;
                     })
                     ->helperText('Form must be saved before previewing.'),
+                Select::make('certificate_template_id')
+                    ->label('Certificate Template')
+                    ->helperText('Optional custom layout. Leave blank to use the award certificate.')
+                    ->options(function (): array {
+                        $model = CertificateBuilder::TEMPLATE_MODEL;
+
+                        return $model::query()
+                            ->where('token_set', CertificateBuilder::tokenSet())
+                            ->orderBy('name')
+                            ->pluck('name', 'id')
+                            ->all();
+                    })
+                    ->searchable()
+                    ->preload()
+                    ->nullable()
+                    ->visible(fn (): bool => CertificateBuilder::enabled()),
                 Checkbox::make('embedded_player')
                     ->label('Embedded player mode')
                     ->helperText('Hides LMS step sidebar and uses the SCORM/HTML5 package as the primary navigation.'),

--- a/src/Resources/CourseResource/Pages/EditCourse.php
+++ b/src/Resources/CourseResource/Pages/EditCourse.php
@@ -22,13 +22,13 @@ class EditCourse extends EditRecord
                 ->icon('heroicon-o-document-duplicate')
                 ->visible(fn (): bool => CertificateBuilder::canCreateTemplate(
                     auth()->user(),
-                    $this->getRecord(),
+                    $this->courseRecord(),
                 ))
                 ->schema([
                     TextInput::make('name')
                         ->required()
                         ->maxLength(255)
-                        ->default(fn (): string => $this->getRecord()->name.' Certificate'),
+                        ->default(fn (): string => $this->courseRecord()->name.' Certificate'),
                 ])
                 ->action(function (array $data): void {
                     $this->createAndAssociateCertificateTemplate((string) $data['name']);
@@ -36,10 +36,10 @@ class EditCourse extends EditRecord
             Action::make('edit_certificate_template')
                 ->label('Edit Certificate Template')
                 ->icon('heroicon-o-pencil-square')
-                ->url(fn (): string => CertificateBuilder::templateEditUrl($this->getRecord()) ?? '#')
+                ->url(fn (): string => CertificateBuilder::templateEditUrl($this->courseRecord()) ?? '#')
                 ->visible(fn (): bool => CertificateBuilder::canEditTemplate(
                     auth()->user(),
-                    $this->getRecord(),
+                    $this->courseRecord(),
                 )),
             DeleteAction::make(),
         ];
@@ -63,9 +63,7 @@ class EditCourse extends EditRecord
             'layout' => $layout,
         ]);
 
-        /** @var Course $course */
-        $course = $this->getRecord();
-        $course->update([
+        $this->courseRecord()->update([
             'certificate_template_id' => $template->getKey(),
         ]);
 
@@ -74,5 +72,13 @@ class EditCourse extends EditRecord
         if ($resource !== null) {
             $this->redirect($resource::getUrl('edit', ['record' => $template]));
         }
+    }
+
+    private function courseRecord(): Course
+    {
+        /** @var Course $course */
+        $course = $this->getRecord();
+
+        return $course;
     }
 }

--- a/src/Resources/CourseResource/Pages/EditCourse.php
+++ b/src/Resources/CourseResource/Pages/EditCourse.php
@@ -2,9 +2,13 @@
 
 namespace Tapp\FilamentLms\Resources\CourseResource\Pages;
 
+use Filament\Actions\Action;
 use Filament\Actions\DeleteAction;
+use Filament\Forms\Components\TextInput;
 use Filament\Resources\Pages\EditRecord;
+use Tapp\FilamentLms\Models\Course;
 use Tapp\FilamentLms\Resources\CourseResource;
+use Tapp\FilamentLms\Support\CertificateBuilder;
 
 class EditCourse extends EditRecord
 {
@@ -13,7 +17,62 @@ class EditCourse extends EditRecord
     protected function getHeaderActions(): array
     {
         return [
+            Action::make('create_certificate_template')
+                ->label('Create Certificate Template')
+                ->icon('heroicon-o-document-duplicate')
+                ->visible(fn (): bool => CertificateBuilder::canCreateTemplate(
+                    auth()->user(),
+                    $this->getRecord(),
+                ))
+                ->schema([
+                    TextInput::make('name')
+                        ->required()
+                        ->maxLength(255)
+                        ->default(fn (): string => $this->getRecord()->name.' Certificate'),
+                ])
+                ->action(function (array $data): void {
+                    $this->createAndAssociateCertificateTemplate((string) $data['name']);
+                }),
+            Action::make('edit_certificate_template')
+                ->label('Edit Certificate Template')
+                ->icon('heroicon-o-pencil-square')
+                ->url(fn (): string => CertificateBuilder::templateEditUrl($this->getRecord()) ?? '#')
+                ->visible(fn (): bool => CertificateBuilder::canEditTemplate(
+                    auth()->user(),
+                    $this->getRecord(),
+                )),
             DeleteAction::make(),
         ];
+    }
+
+    public function createAndAssociateCertificateTemplate(string $name): void
+    {
+        if (! CertificateBuilder::enabled()) {
+            return;
+        }
+
+        $templateClass = CertificateBuilder::TEMPLATE_MODEL;
+        $layoutClass = CertificateBuilder::LAYOUT_CLASS;
+        $tokenSet = CertificateBuilder::tokenSet();
+
+        $layout = class_exists($layoutClass) ? $layoutClass::default($tokenSet) : [];
+
+        $template = $templateClass::query()->create([
+            'name' => $name,
+            'token_set' => $tokenSet,
+            'layout' => $layout,
+        ]);
+
+        /** @var Course $course */
+        $course = $this->getRecord();
+        $course->update([
+            'certificate_template_id' => $template->getKey(),
+        ]);
+
+        $resource = CertificateBuilder::templateResource();
+
+        if ($resource !== null) {
+            $this->redirect($resource::getUrl('edit', ['record' => $template]));
+        }
     }
 }

--- a/src/Services/CommonCartridge/CommonCartridgeImportService.php
+++ b/src/Services/CommonCartridge/CommonCartridgeImportService.php
@@ -16,6 +16,7 @@ use Tapp\FilamentLms\Models\Document;
 use Tapp\FilamentLms\Models\Lesson;
 use Tapp\FilamentLms\Models\Step;
 use Tapp\FilamentLms\Models\Test;
+use Tapp\FilamentLms\Support\CertificateBuilder;
 
 final class CommonCartridgeImportService
 {
@@ -156,16 +157,13 @@ final class CommonCartridgeImportService
         $externalId = $this->uniqueCourseColumn(Str::slug($manifest->courseTitle, '_'), 'external_id', $tenantId);
         $name = $this->uniqueCourseColumn($manifest->courseTitle, 'name', $tenantId);
 
-        $awards = config('filament-lms.awards', ['default' => 'Default']);
-        $defaultAward = array_key_first($awards);
-
         $data = [
             'name' => $name,
             'slug' => $slug,
             'external_id' => $externalId,
             'description' => $manifest->courseDescription,
             'is_private' => false,
-            'award' => $defaultAward,
+            'certificate_template_id' => CertificateBuilder::defaultTemplateId(),
         ];
 
         if (config('filament-lms.tenancy.enabled') && $tenantId !== null) {

--- a/src/Services/MigrateAwardsToCertificateTemplates.php
+++ b/src/Services/MigrateAwardsToCertificateTemplates.php
@@ -6,6 +6,7 @@ namespace Tapp\FilamentLms\Services;
 
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Facades\Schema;
 use RuntimeException;
 use Tapp\FilamentLms\Models\Course;
 use Tapp\FilamentLms\Support\AwardCertificateBlueprint;
@@ -51,6 +52,20 @@ final class MigrateAwardsToCertificateTemplates
             throw new RuntimeException('Certificate builder is not installed.');
         }
 
+        if (! Schema::hasColumn('lms_courses', 'award')) {
+            return [
+                'templates_created' => 0,
+                'templates_reused' => 0,
+                'courses_updated' => 0,
+                'logos_attached' => 0,
+                'awards' => [],
+            ];
+        }
+
+        if (! Schema::hasColumn('lms_courses', 'certificate_template_id')) {
+            throw new RuntimeException('lms_courses.certificate_template_id is missing. Publish and run filament-lms migrations first.');
+        }
+
         $tokenSet = CertificateBuilder::tokenSet();
         $summary = [
             'templates_created' => 0,
@@ -68,7 +83,7 @@ final class MigrateAwardsToCertificateTemplates
 
             $created = $existing === null;
             $logoCount = 0;
-            $courseCount = $this->coursesToUpdate($awardKey, $force)->count();
+            $courseCount = $this->coursesToUpdate($awardKey, $templateClass)->count();
 
             if (! $dryRun) {
                 $template = $existing ?? $templateClass::query()->create([
@@ -84,8 +99,9 @@ final class MigrateAwardsToCertificateTemplates
                     ]);
                 }
 
-                $logoCount = $this->attachLogos($template, $blueprint, $force);
-                $courseCount = $this->coursesToUpdate($awardKey, $force)->update([
+                $logoCount = $this->attachLogos($template, $blueprint, $force)
+                    + $this->attachHeader($template, $blueprint, $force);
+                $courseCount = $this->coursesToUpdate($awardKey, $templateClass)->update([
                     'certificate_template_id' => $template->getKey(),
                 ]);
             }
@@ -103,23 +119,89 @@ final class MigrateAwardsToCertificateTemplates
             ];
         }
 
+        if ($award === null) {
+            $orphanCount = $this->assignCoursesWithoutAward($templateClass, $layoutClass, $tokenSet, $dryRun);
+            $summary['courses_updated'] += $orphanCount;
+        }
+
         return $summary;
     }
 
     /**
+     * @param  class-string<Model>  $templateClass
+     * @return list<int|string>
+     */
+    public function unverifiedCourseIds(?string $templateClass = null): array
+    {
+        $templateClass ??= CertificateBuilder::TEMPLATE_MODEL;
+
+        return $this->coursesMissingTemplate($templateClass)
+            ->pluck('id')
+            ->all();
+    }
+
+    /**
+     * @param  class-string<Model>  $templateClass
      * @return Builder<Course>
      */
-    private function coursesToUpdate(string $awardKey, bool $force): Builder
+    private function coursesToUpdate(string $awardKey, string $templateClass): Builder
     {
-        $query = Course::query()
-            ->withoutTenantScope()
+        return $this->coursesMissingTemplate($templateClass)
             ->where('award', $awardKey);
+    }
 
-        if (! $force) {
-            $query->whereNull('certificate_template_id');
+    /**
+     * @param  class-string<Model>  $templateClass
+     * @return Builder<Course>
+     */
+    private function coursesMissingTemplate(string $templateClass): Builder
+    {
+        return Course::query()
+            ->withoutTenantScope()
+            ->where(function (Builder $query) use ($templateClass): void {
+                $query->whereNull('certificate_template_id')
+                    ->orWhereNotIn('certificate_template_id', $templateClass::query()->select('id'));
+            });
+    }
+
+    /**
+     * @param  class-string<Model>  $templateClass
+     * @param  class-string|null  $layoutClass
+     */
+    private function assignCoursesWithoutAward(
+        string $templateClass,
+        ?string $layoutClass,
+        string $tokenSet,
+        bool $dryRun,
+    ): int {
+        $query = $this->coursesMissingTemplate($templateClass)
+            ->where(function (Builder $query): void {
+                $query->whereNull('award')
+                    ->orWhere('award', '');
+            });
+
+        $count = $query->count();
+
+        if ($dryRun || $count === 0) {
+            return $count;
         }
 
-        return $query;
+        $template = $templateClass::query()
+            ->where('name', 'Default Certificate')
+            ->first();
+
+        if ($template === null) {
+            $blueprint = $this->blueprints->make('default');
+            $template = $templateClass::query()->create([
+                'name' => $blueprint->templateName,
+                'token_set' => $tokenSet,
+                'layout' => $this->layoutFor($blueprint, $layoutClass, $tokenSet),
+            ]);
+        }
+
+        return $query->update([
+            'certificate_template_id' => $template->getKey(),
+        ]);
     }
 
     /**
@@ -172,5 +254,28 @@ final class MigrateAwardsToCertificateTemplates
         }
 
         return $attached;
+    }
+
+    private function attachHeader(Model $template, AwardCertificateBlueprint $blueprint, bool $force): int
+    {
+        if ($blueprint->headerImagePath === null || ! method_exists($template, 'addMedia')) {
+            return 0;
+        }
+
+        $absolutePath = $this->blueprints->resolveLogoAbsolutePath($blueprint->headerImagePath);
+
+        if ($absolutePath === null) {
+            return 0;
+        }
+
+        if (! $force && method_exists($template, 'getFirstMedia') && $template->getFirstMedia('header') !== null) {
+            return 0;
+        }
+
+        $template->addMedia($absolutePath)
+            ->preservingOriginal()
+            ->toMediaCollection('header');
+
+        return 1;
     }
 }

--- a/src/Services/MigrateAwardsToCertificateTemplates.php
+++ b/src/Services/MigrateAwardsToCertificateTemplates.php
@@ -1,0 +1,176 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tapp\FilamentLms\Services;
+
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model;
+use RuntimeException;
+use Tapp\FilamentLms\Models\Course;
+use Tapp\FilamentLms\Support\AwardCertificateBlueprint;
+use Tapp\FilamentLms\Support\AwardCertificateBlueprintFactory;
+use Tapp\FilamentLms\Support\AwardCertificateLayoutApplier;
+use Tapp\FilamentLms\Support\CertificateBuilder;
+
+final class MigrateAwardsToCertificateTemplates
+{
+    public function __construct(
+        private AwardCertificateBlueprintFactory $blueprints,
+        private AwardCertificateLayoutApplier $layouts,
+    ) {}
+
+    /**
+     * @param  class-string<Model>|null  $templateClass
+     * @param  class-string|null  $layoutClass
+     * @return array{
+     *     templates_created: int,
+     *     templates_reused: int,
+     *     courses_updated: int,
+     *     logos_attached: int,
+     *     awards: list<array{
+     *         award: string,
+     *         template: string,
+     *         created: bool,
+     *         courses: int,
+     *         logos: int
+     *     }>
+     * }
+     */
+    public function handle(
+        ?string $award = null,
+        bool $dryRun = false,
+        bool $force = false,
+        ?string $templateClass = null,
+        ?string $layoutClass = null,
+    ): array {
+        $templateClass ??= CertificateBuilder::TEMPLATE_MODEL;
+        $layoutClass ??= CertificateBuilder::LAYOUT_CLASS;
+
+        if (! class_exists($templateClass)) {
+            throw new RuntimeException('Certificate builder is not installed.');
+        }
+
+        $tokenSet = CertificateBuilder::tokenSet();
+        $summary = [
+            'templates_created' => 0,
+            'templates_reused' => 0,
+            'courses_updated' => 0,
+            'logos_attached' => 0,
+            'awards' => [],
+        ];
+
+        foreach ($this->blueprints->awardKeys($award) as $awardKey) {
+            $blueprint = $this->blueprints->make($awardKey);
+            $existing = $templateClass::query()
+                ->where('name', $blueprint->templateName)
+                ->first();
+
+            $created = $existing === null;
+            $logoCount = 0;
+            $courseCount = $this->coursesToUpdate($awardKey, $force)->count();
+
+            if (! $dryRun) {
+                $template = $existing ?? $templateClass::query()->create([
+                    'name' => $blueprint->templateName,
+                    'token_set' => $tokenSet,
+                    'layout' => $this->layoutFor($blueprint, $layoutClass, $tokenSet),
+                ]);
+
+                if ($existing !== null && $force) {
+                    $template->update([
+                        'token_set' => $tokenSet,
+                        'layout' => $this->layoutFor($blueprint, $layoutClass, $tokenSet),
+                    ]);
+                }
+
+                $logoCount = $this->attachLogos($template, $blueprint, $force);
+                $courseCount = $this->coursesToUpdate($awardKey, $force)->update([
+                    'certificate_template_id' => $template->getKey(),
+                ]);
+            }
+
+            $summary['templates_created'] += $created ? 1 : 0;
+            $summary['templates_reused'] += $created ? 0 : 1;
+            $summary['courses_updated'] += $courseCount;
+            $summary['logos_attached'] += $logoCount;
+            $summary['awards'][] = [
+                'award' => $awardKey,
+                'template' => $blueprint->templateName,
+                'created' => $created,
+                'courses' => $courseCount,
+                'logos' => $logoCount,
+            ];
+        }
+
+        return $summary;
+    }
+
+    /**
+     * @return Builder<Course>
+     */
+    private function coursesToUpdate(string $awardKey, bool $force): Builder
+    {
+        $query = Course::query()
+            ->withoutTenantScope()
+            ->where('award', $awardKey);
+
+        if (! $force) {
+            $query->whereNull('certificate_template_id');
+        }
+
+        return $query;
+    }
+
+    /**
+     * @param  class-string|null  $layoutClass
+     * @return array<string, mixed>
+     */
+    private function layoutFor(AwardCertificateBlueprint $blueprint, ?string $layoutClass, string $tokenSet): array
+    {
+        $layout = class_exists((string) $layoutClass) && method_exists((string) $layoutClass, 'default')
+            ? $layoutClass::default($tokenSet)
+            : [
+                'width' => 1050,
+                'height' => 774,
+                'signature_count' => 2,
+                'elements' => [],
+            ];
+
+        if (! is_array($layout)) {
+            $layout = [];
+        }
+
+        return $this->layouts->apply($layout, $blueprint);
+    }
+
+    private function attachLogos(Model $template, AwardCertificateBlueprint $blueprint, bool $force): int
+    {
+        if (! method_exists($template, 'addMedia')) {
+            return 0;
+        }
+
+        $attached = 0;
+
+        foreach (array_slice($blueprint->logoPaths, 0, 3) as $index => $path) {
+            $absolutePath = $this->blueprints->resolveLogoAbsolutePath($path);
+            $collection = 'logo_'.($index + 1);
+
+            if ($absolutePath === null) {
+                continue;
+            }
+
+            if (! $force && method_exists($template, 'getFirstMedia') && $template->getFirstMedia($collection) !== null) {
+                continue;
+            }
+
+            $template->addMedia($absolutePath)
+                ->preservingOriginal()
+                ->toMediaCollection($collection);
+
+            $attached++;
+        }
+
+        return $attached;
+    }
+}

--- a/src/Support/AwardCertificateBlueprint.php
+++ b/src/Support/AwardCertificateBlueprint.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tapp\FilamentLms\Support;
+
+final readonly class AwardCertificateBlueprint
+{
+    /**
+     * @param  list<string>  $logoPaths
+     */
+    public function __construct(
+        public string $key,
+        public string $label,
+        public string $templateName,
+        public array $logoPaths,
+        public string $certifyingLine,
+        public string $completedLine,
+        public string $description,
+        public bool $includeCourseName,
+    ) {}
+}

--- a/src/Support/AwardCertificateBlueprint.php
+++ b/src/Support/AwardCertificateBlueprint.php
@@ -8,6 +8,8 @@ final readonly class AwardCertificateBlueprint
 {
     /**
      * @param  list<string>  $logoPaths
+     * @param  array<string, mixed>  $border
+     * @param  array<string, mixed>  $header
      */
     public function __construct(
         public string $key,
@@ -18,5 +20,9 @@ final readonly class AwardCertificateBlueprint
         public string $completedLine,
         public string $description,
         public bool $includeCourseName,
+        public bool $includeSignatures,
+        public array $border,
+        public array $header,
+        public ?string $headerImagePath,
     ) {}
 }

--- a/src/Support/AwardCertificateBlueprintFactory.php
+++ b/src/Support/AwardCertificateBlueprintFactory.php
@@ -1,0 +1,405 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tapp\FilamentLms\Support;
+
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Support\Str;
+use Tapp\FilamentLms\Models\Course;
+use Throwable;
+
+final class AwardCertificateBlueprintFactory
+{
+    /**
+     * @return list<string>
+     */
+    public function awardKeys(?string $only = null): array
+    {
+        if (is_string($only) && $only !== '') {
+            return [$only];
+        }
+
+        $configured = array_keys($this->configuredAwards());
+        $used = $this->courseQuery()
+            ->whereNotNull('award')
+            ->where('award', '!=', '')
+            ->distinct()
+            ->orderBy('award')
+            ->pluck('award')
+            ->all();
+
+        $keys = array_values(array_unique([
+            ...$configured,
+            ...array_map(strval(...), $used),
+        ]));
+
+        sort($keys);
+
+        return $keys;
+    }
+
+    public function make(string $awardKey): AwardCertificateBlueprint
+    {
+        $label = $this->labelFor($awardKey);
+        $source = $this->viewSource($awardKey);
+        $copy = $this->copyFrom($source);
+
+        return new AwardCertificateBlueprint(
+            key: $awardKey,
+            label: $label,
+            templateName: $label.' Certificate',
+            logoPaths: $this->logoPaths($source),
+            certifyingLine: $copy['certifying_line'],
+            completedLine: $copy['completed_line'],
+            description: $copy['description'],
+            includeCourseName: $this->includesCourseName($source),
+        );
+    }
+
+    public function resolveLogoAbsolutePath(string $path): ?string
+    {
+        $parsed = parse_url($path, PHP_URL_PATH);
+        $relative = ltrim(is_string($parsed) && $parsed !== '' ? $parsed : $path, '/');
+
+        if ($relative === '') {
+            return null;
+        }
+
+        $candidates = [
+            public_path($relative),
+            base_path('public/'.$relative),
+        ];
+
+        foreach ($candidates as $candidate) {
+            if (is_file($candidate)) {
+                return $candidate;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    private function configuredAwards(): array
+    {
+        $awards = config('filament-lms.awards', ['default' => 'Default']);
+
+        if (! is_array($awards) || $awards === []) {
+            return ['default' => 'Default'];
+        }
+
+        $normalized = [];
+
+        foreach ($awards as $key => $label) {
+            $normalized[(string) $key] = is_string($label) && $label !== ''
+                ? $label
+                : Str::headline(str_replace(['-', '_'], ' ', (string) $key));
+        }
+
+        return $normalized;
+    }
+
+    private function labelFor(string $awardKey): string
+    {
+        return $this->configuredAwards()[$awardKey]
+            ?? Str::headline(str_replace(['-', '_'], ' ', $awardKey));
+    }
+
+    private function viewSource(string $awardKey): ?string
+    {
+        foreach ([$awardKey, 'default'] as $name) {
+            $contents = $this->contentsFromPath($this->publishedViewPath($name))
+                ?? $this->contentsFromView('filament-lms::certificates.'.$name);
+
+            if ($contents !== null) {
+                return $contents;
+            }
+        }
+
+        return null;
+    }
+
+    private function publishedViewPath(string $awardKey): string
+    {
+        return resource_path('views/vendor/filament-lms/certificates/'.$awardKey.'.blade.php');
+    }
+
+    private function contentsFromPath(string $path): ?string
+    {
+        if (! is_file($path)) {
+            return null;
+        }
+
+        $contents = file_get_contents($path);
+
+        return is_string($contents) ? $contents : null;
+    }
+
+    private function contentsFromView(string $view): ?string
+    {
+        if (! view()->exists($view)) {
+            return null;
+        }
+
+        try {
+            $path = view($view)->getPath();
+        } catch (Throwable) {
+            return null;
+        }
+
+        return $this->contentsFromPath($path);
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function logoPaths(?string $source): array
+    {
+        $paths = [];
+
+        if (is_string($source) && $source !== '') {
+            $backgrounds = $this->backgroundAssetPaths($source);
+
+            foreach ($this->imageAssetPaths($source) as $path) {
+                if (in_array($path, $backgrounds, true) || $this->looksLikeHeaderAsset($path)) {
+                    continue;
+                }
+
+                $paths[] = $path;
+            }
+        }
+
+        if ($paths === []) {
+            $configured = config('filament-lms.certificate_logo') ?: config('filament-lms.brand_logo');
+
+            if (is_string($configured) && $configured !== '') {
+                $paths[] = $configured;
+            }
+        }
+
+        return array_values(array_unique($paths));
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function imageAssetPaths(string $source): array
+    {
+        preg_match_all(
+            '/<img\b[^>]*\bsrc\s*=\s*[\'"]\s*\{\{\s*asset\(\s*[\'"]([^\'"]+)[\'"]/i',
+            $source,
+            $matches,
+        );
+
+        return $this->normalizeAssetPaths($matches[1]);
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function backgroundAssetPaths(string $source): array
+    {
+        preg_match_all(
+            '/background-image\s*:\s*url\(\s*\{\{\s*asset\(\s*[\'"]([^\'"]+)[\'"]/i',
+            $source,
+            $matches,
+        );
+
+        return $this->normalizeAssetPaths($matches[1]);
+    }
+
+    /**
+     * @param  list<string>  $paths
+     * @return list<string>
+     */
+    private function normalizeAssetPaths(array $paths): array
+    {
+        $normalized = [];
+
+        foreach ($paths as $path) {
+            $path = trim($path);
+
+            if ($path === '') {
+                continue;
+            }
+
+            $normalized[] = $path;
+        }
+
+        return $normalized;
+    }
+
+    private function looksLikeHeaderAsset(string $path): bool
+    {
+        return str_contains(Str::lower($path), 'header');
+    }
+
+    /**
+     * @return array{certifying_line: string, completed_line: string, description: string}
+     */
+    private function copyFrom(?string $source): array
+    {
+        $defaults = $this->defaultCopy();
+
+        if (! is_string($source) || $source === '') {
+            return $defaults;
+        }
+
+        $certifying = $defaults['certifying_line'];
+        $completed = $defaults['completed_line'];
+        $description = $defaults['description'];
+        $foundCompleted = false;
+
+        foreach ($this->extractCopyStrings($source) as $string) {
+            if ($this->isTitleCopy($string)) {
+                continue;
+            }
+
+            if ($this->isCertifyingCopy($string)) {
+                $certifying = $string;
+
+                continue;
+            }
+
+            if ($this->isCompletedCopy($string)) {
+                $completed = $this->normalizeCompletedCopy($string);
+                $foundCompleted = true;
+
+                continue;
+            }
+
+            if (Str::length($string) > 40) {
+                $description = $string;
+            }
+        }
+
+        if ($description !== '' && ! $foundCompleted) {
+            $completed = '';
+        }
+
+        return [
+            'certifying_line' => $certifying,
+            'completed_line' => $completed,
+            'description' => $description,
+        ];
+    }
+
+    /**
+     * @return array{certifying_line: string, completed_line: string, description: string}
+     */
+    private function defaultCopy(): array
+    {
+        $tokenSet = CertificateBuilder::tokenSet();
+        $copy = config('certificate-builder.token_sets.'.$tokenSet.'.default_copy', []);
+
+        if (! is_array($copy)) {
+            $copy = [];
+        }
+
+        return [
+            'certifying_line' => is_string($copy['certifying_line'] ?? null) && $copy['certifying_line'] !== ''
+                ? $copy['certifying_line']
+                : 'This certifies that',
+            'completed_line' => is_string($copy['completed_line'] ?? null) && $copy['completed_line'] !== ''
+                ? $copy['completed_line']
+                : 'has successfully completed',
+            'description' => is_string($copy['description'] ?? null) ? $copy['description'] : '',
+        ];
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function extractCopyStrings(string $source): array
+    {
+        $strings = [];
+
+        preg_match_all('/__\(\s*[\'"](.+?)[\'"]\s*\)/s', $source, $matches);
+
+        foreach ($matches[1] as $string) {
+            $decoded = trim(stripcslashes((string) $string));
+
+            if ($decoded !== '') {
+                $strings[] = $decoded;
+            }
+        }
+
+        if (preg_match_all('/<p\b[^>]*>(.*?)<\/p>/si', $source, $matches)) {
+            foreach ($matches[1] as $html) {
+                $text = $this->plainText((string) $html);
+
+                if ($text !== '') {
+                    $strings[] = $text;
+                }
+            }
+        }
+
+        return $strings;
+    }
+
+    private function plainText(string $html): string
+    {
+        $html = preg_replace('/\{\{.*?\}\}/s', '', $html) ?? $html;
+        $html = preg_replace('/\{!!.*?!!\}/s', '', $html) ?? $html;
+        $html = preg_replace('/@\w+(?:\([^)]*\))?/', '', $html) ?? $html;
+        $text = html_entity_decode(strip_tags($html), ENT_QUOTES | ENT_HTML5);
+
+        return trim(preg_replace('/\s+/', ' ', $text) ?? $text);
+    }
+
+    private function isTitleCopy(string $string): bool
+    {
+        $normalized = Str::upper(trim($string));
+
+        return in_array($normalized, [
+            'CERTIFICATE',
+            'CERTIFICATE OF COMPLETION',
+            'OF COMPLETION',
+        ], true);
+    }
+
+    private function isCertifyingCopy(string $string): bool
+    {
+        $normalized = Str::lower($string);
+
+        return str_contains($normalized, 'awarded to')
+            || str_contains($normalized, 'certifies that');
+    }
+
+    private function isCompletedCopy(string $string): bool
+    {
+        $normalized = Str::lower($string);
+
+        return str_contains($normalized, 'successfully completed')
+            || str_contains($normalized, 'has completed');
+    }
+
+    private function normalizeCompletedCopy(string $string): string
+    {
+        $normalized = trim(preg_replace('/\s+on\s*\.?$/i', '', $string) ?? $string);
+        $normalized = trim($normalized, " \t\n\r\0\x0B.");
+
+        return $normalized !== '' ? $normalized : 'has successfully completed';
+    }
+
+    private function includesCourseName(?string $source): bool
+    {
+        if (! is_string($source) || $source === '') {
+            return true;
+        }
+
+        return str_contains($source, '$course->name')
+            || str_contains($source, '$course[\'name\']');
+    }
+
+    /**
+     * @return Builder<Course>
+     */
+    private function courseQuery(): Builder
+    {
+        return Course::query()->withoutTenantScope();
+    }
+}

--- a/src/Support/AwardCertificateBlueprintFactory.php
+++ b/src/Support/AwardCertificateBlueprintFactory.php
@@ -30,6 +30,7 @@ final class AwardCertificateBlueprintFactory
             ->all();
 
         $keys = array_values(array_unique([
+            'default',
             ...$configured,
             ...array_map(strval(...), $used),
         ]));
@@ -54,6 +55,10 @@ final class AwardCertificateBlueprintFactory
             completedLine: $copy['completed_line'],
             description: $copy['description'],
             includeCourseName: $this->includesCourseName($source),
+            includeSignatures: $this->includesSignatures($source),
+            border: $this->borderFrom($source),
+            header: $this->headerFrom($source),
+            headerImagePath: $this->headerImagePath($source),
         );
     }
 
@@ -393,6 +398,145 @@ final class AwardCertificateBlueprintFactory
 
         return str_contains($source, '$course->name')
             || str_contains($source, '$course[\'name\']');
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function borderFrom(?string $source): array
+    {
+        $border = [
+            'style' => 'double',
+            'color' => '#a1a1aa',
+            'width' => 8,
+            'inner_color' => '#d4d4d8',
+            'inner_width' => 4,
+            'inner_inset' => 10,
+            'gradient' => '',
+        ];
+
+        if (! is_string($source) || $source === '') {
+            return $border;
+        }
+
+        if (preg_match('/bg-linear-to-r\s+from-([a-z0-9-]+)\s+via-([a-z0-9-]+)\s+to-([a-z0-9-]+)/', $source, $matches) === 1) {
+            $from = $this->tailwindColor($matches[1]);
+            $via = $this->tailwindColor($matches[2]);
+            $to = $this->tailwindColor($matches[3]);
+
+            if ($from !== null && $via !== null && $to !== null) {
+                return [
+                    ...$border,
+                    'style' => 'gradient',
+                    'width' => 6,
+                    'color' => $from,
+                    'gradient' => 'linear-gradient(to right, '.$from.', '.$via.', '.$to.')',
+                ];
+            }
+        }
+
+        if (preg_match('/\bstyle\s*=\s*[\'"][^\'"]*background:\s*(#[0-9a-fA-F]{3,6})\b/', $source, $matches) === 1) {
+            return [
+                ...$border,
+                'style' => 'solid',
+                'color' => $matches[1],
+                'width' => 6,
+            ];
+        }
+
+        return $border;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function headerFrom(?string $source): array
+    {
+        $header = [
+            'enabled' => false,
+            'height' => 220,
+            'background_color' => '',
+            'background_size' => 'cover',
+            'background_position' => 'center',
+            'title_bind' => '',
+            'title' => '',
+            'title_color' => '#ffffff',
+            'title_size' => 36,
+            'title_transform' => 'none',
+            'subtitle' => '',
+            'subtitle_color' => '#111827',
+            'subtitle_size' => 28,
+        ];
+
+        if (! is_string($source) || $source === '' || $this->headerImagePath($source) === null) {
+            return $header;
+        }
+
+        $header['enabled'] = true;
+
+        if (preg_match('/background-size\s*:\s*([^;]+)/i', $source, $matches) === 1) {
+            $header['background_size'] = trim($matches[1]);
+        }
+
+        if (preg_match('/background-position\s*:\s*([^;]+)/i', $source, $matches) === 1) {
+            $header['background_position'] = trim($matches[1]);
+        }
+
+        if (preg_match('/background-color\s*:\s*(#[0-9a-fA-F]{3,6})/i', $source, $matches) === 1) {
+            $header['background_color'] = $matches[1];
+        }
+
+        if (preg_match('/min-height\s*:\s*(\d+)px/i', $source, $matches) === 1) {
+            $header['height'] = max(40, (int) $matches[1]);
+        }
+
+        if (str_contains($source, '$course->name') || str_contains($source, '$course[\'name\']')) {
+            $header['title_bind'] = 'course_name';
+            $header['title_transform'] = str_contains($source, 'uppercase') ? 'uppercase' : 'none';
+        }
+
+        if (preg_match('/__\(\s*[\'"]CERTIFICATE OF COMPLETION[\'"]\s*\)/', $source) === 1) {
+            $header['subtitle'] = 'CERTIFICATE OF COMPLETION';
+        }
+
+        return $header;
+    }
+
+    private function headerImagePath(?string $source): ?string
+    {
+        if (! is_string($source) || $source === '') {
+            return null;
+        }
+
+        return $this->backgroundAssetPaths($source)[0] ?? null;
+    }
+
+    private function tailwindColor(string $token): ?string
+    {
+        return match ($token) {
+            'lime-400' => '#a3e635',
+            'sky-500' => '#0ea5e9',
+            'cyan-300' => '#67e8f9',
+            'red-400' => '#f87171',
+            'red-500' => '#ef4444',
+            'red-300' => '#fca5a5',
+            'zinc-400' => '#a1a1aa',
+            'zinc-300' => '#d4d4d8',
+            default => null,
+        };
+    }
+
+    private function includesSignatures(?string $source): bool
+    {
+        if (! is_string($source) || $source === '') {
+            return false;
+        }
+
+        if (str_contains($source, 'filament-lms.certificate_show_signatures')) {
+            return (bool) config('filament-lms.certificate_show_signatures', false);
+        }
+
+        return (bool) preg_match('/signature/i', $source);
     }
 
     /**

--- a/src/Support/AwardCertificateLayoutApplier.php
+++ b/src/Support/AwardCertificateLayoutApplier.php
@@ -37,12 +37,162 @@ final class AwardCertificateLayoutApplier
             }
 
             if ($id === 'course_name') {
-                $elements[$index]['visible'] = $blueprint->includeCourseName;
+                $elements[$index]['visible'] = $blueprint->includeCourseName
+                    && ($blueprint->header['title_bind'] ?? '') !== 'course_name';
             }
+
+            if ($id === 'recipient_name_display') {
+                $elements[$index]['visible'] = false;
+            }
+        }
+
+        $elements = $this->placeElementsBelowHeader($elements, $blueprint->header);
+        $elements = $this->separateStackedText($elements, $blueprint->header);
+
+        if (! $blueprint->includeSignatures) {
+            $layout['signature_count'] = 0;
+            $elements = array_values(array_filter(
+                $elements,
+                function (mixed $element): bool {
+                    if (! is_array($element)) {
+                        return true;
+                    }
+
+                    $type = $element['type'] ?? null;
+                    $id = $element['id'] ?? null;
+
+                    return $type !== 'signature'
+                        && ! (is_string($id) && str_starts_with($id, 'signature_'));
+                },
+            ));
         }
 
         $layout['elements'] = array_values($elements);
 
+        if ($blueprint->border !== []) {
+            $layout['border'] = $blueprint->border;
+        }
+
+        if ($blueprint->header !== []) {
+            $layout['header'] = $blueprint->header;
+        }
+
         return $layout;
+    }
+
+    /**
+     * @param  list<array<string, mixed>>  $elements
+     * @param  array<string, mixed>  $header
+     * @return list<array<string, mixed>>
+     */
+    private function placeElementsBelowHeader(array $elements, array $header): array
+    {
+        if (! ($header['enabled'] ?? false)) {
+            return $elements;
+        }
+
+        $headerHeight = (int) ($header['height'] ?? 220);
+        $overlappingYs = [];
+
+        foreach ($elements as $element) {
+            if (! is_array($element)) {
+                continue;
+            }
+
+            $id = isset($element['id']) && is_string($element['id']) ? $element['id'] : null;
+            $y = (int) ($element['y'] ?? 0);
+
+            if (
+                ! ($element['visible'] ?? true)
+                || $y >= $headerHeight
+                || (is_string($id) && str_starts_with($id, 'logo_'))
+            ) {
+                continue;
+            }
+
+            $overlappingYs[] = $y;
+        }
+
+        $minOverlappingY = $overlappingYs === [] ? null : min($overlappingYs);
+        $shift = $minOverlappingY === null
+            ? 0
+            : ($headerHeight + 16) - $minOverlappingY;
+
+        foreach ($elements as $index => $element) {
+            if (! is_array($element)) {
+                continue;
+            }
+
+            $id = isset($element['id']) && is_string($element['id']) ? $element['id'] : null;
+            $y = (int) ($element['y'] ?? 0);
+
+            if (is_string($id) && str_starts_with($id, 'logo_') && $y < $headerHeight) {
+                $elements[$index]['y'] = 560;
+
+                continue;
+            }
+
+            if ($shift > 0 && $minOverlappingY !== null && $y >= $minOverlappingY) {
+                $elements[$index]['y'] = $y + $shift;
+            }
+        }
+
+        return $elements;
+    }
+
+    /**
+     * @param  list<array<string, mixed>>  $elements
+     * @param  array<string, mixed>  $header
+     * @return list<array<string, mixed>>
+     */
+    private function separateStackedText(array $elements, array $header): array
+    {
+        if (! ($header['enabled'] ?? false)) {
+            return $elements;
+        }
+
+        $minGap = 28;
+        $indexes = [];
+
+        foreach ($elements as $index => $element) {
+            if (! is_array($element) || ! ($element['visible'] ?? true)) {
+                continue;
+            }
+
+            $id = isset($element['id']) && is_string($element['id']) ? $element['id'] : '';
+
+            if (($element['type'] ?? 'text') === 'image' || str_starts_with($id, 'logo_')) {
+                continue;
+            }
+
+            $indexes[] = $index;
+        }
+
+        usort($indexes, function (int $left, int $right) use ($elements): int {
+            $leftY = (int) ($elements[$left]['y'] ?? 0);
+            $rightY = (int) ($elements[$right]['y'] ?? 0);
+
+            if ($leftY === $rightY) {
+                return $left <=> $right;
+            }
+
+            return $leftY <=> $rightY;
+        });
+
+        $previousBottom = null;
+
+        foreach ($indexes as $index) {
+            $y = (int) ($elements[$index]['y'] ?? 0);
+            $h = (int) ($elements[$index]['h'] ?? 30);
+
+            if ($previousBottom !== null && $y < $previousBottom + $minGap) {
+                $y = $previousBottom + $minGap;
+                $elements[$index]['y'] = $y;
+            }
+
+            $previousBottom = $y + $h;
+        }
+
+        return $elements;
     }
 }

--- a/src/Support/AwardCertificateLayoutApplier.php
+++ b/src/Support/AwardCertificateLayoutApplier.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tapp\FilamentLms\Support;
+
+final class AwardCertificateLayoutApplier
+{
+    /**
+     * @param  array<string, mixed>  $layout
+     * @return array<string, mixed>
+     */
+    public function apply(array $layout, AwardCertificateBlueprint $blueprint): array
+    {
+        $elements = is_array($layout['elements'] ?? null) ? $layout['elements'] : [];
+
+        foreach ($elements as $index => $element) {
+            if (! is_array($element)) {
+                continue;
+            }
+
+            $id = isset($element['id']) && is_string($element['id']) ? $element['id'] : null;
+
+            if ($id === 'certifying_line') {
+                $elements[$index]['text'] = $blueprint->certifyingLine;
+                $elements[$index]['visible'] = $blueprint->certifyingLine !== '';
+            }
+
+            if ($id === 'completed_line') {
+                $elements[$index]['text'] = $blueprint->completedLine;
+                $elements[$index]['visible'] = $blueprint->completedLine !== '';
+            }
+
+            if ($id === 'description') {
+                $elements[$index]['text'] = $blueprint->description;
+                $elements[$index]['visible'] = $blueprint->description !== '';
+            }
+
+            if ($id === 'course_name') {
+                $elements[$index]['visible'] = $blueprint->includeCourseName;
+            }
+        }
+
+        $layout['elements'] = array_values($elements);
+
+        return $layout;
+    }
+}

--- a/src/Support/CertificateBuilder.php
+++ b/src/Support/CertificateBuilder.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Tapp\FilamentLms\Support;
 
+use Illuminate\Support\Facades\Gate;
 use Tapp\FilamentLms\Models\Course;
 
 final class CertificateBuilder
@@ -35,9 +36,28 @@ final class CertificateBuilder
     public static function canManageTemplates(?object $user, Course $course): bool
     {
         return self::enabled()
-            && $user !== null
-            && method_exists($user, 'can')
-            && $user->can('update', $course) === true;
+            && self::userCanUpdateCourse($user, $course);
+    }
+
+    public static function userCanUpdateCourse(?object $user, Course $course): bool
+    {
+        if ($user === null) {
+            return false;
+        }
+
+        $policy = Gate::getPolicyFor($course);
+
+        if ($policy === null) {
+            return true;
+        }
+
+        $policyClass = is_object($policy) ? $policy::class : $policy;
+
+        if (! method_exists($policyClass, 'update')) {
+            return true;
+        }
+
+        return method_exists($user, 'can') && $user->can('update', $course) === true;
     }
 
     public static function assignedTemplateId(Course $course): ?int

--- a/src/Support/CertificateBuilder.php
+++ b/src/Support/CertificateBuilder.php
@@ -40,7 +40,7 @@ final class CertificateBuilder
             && $user->can('update', $course) === true;
     }
 
-    public static function assignedTemplateId(Course $course): int|string|null
+    public static function assignedTemplateId(Course $course): ?int
     {
         $templateId = $course->certificate_template_id;
 
@@ -50,7 +50,7 @@ final class CertificateBuilder
 
         $exists = self::TEMPLATE_MODEL::query()->whereKey($templateId)->exists();
 
-        return $exists ? $templateId : null;
+        return $exists ? (int) $templateId : null;
     }
 
     public static function templateEditUrl(Course $course): ?string

--- a/src/Support/CertificateBuilder.php
+++ b/src/Support/CertificateBuilder.php
@@ -1,0 +1,88 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tapp\FilamentLms\Support;
+
+use Tapp\FilamentLms\Models\Course;
+
+final class CertificateBuilder
+{
+    public const TEMPLATE_MODEL = 'Tapp\\FilamentCertificateBuilder\\Models\\CertificateTemplate';
+
+    public const LAYOUT_CLASS = 'Tapp\\FilamentCertificateBuilder\\Support\\CertificateLayout';
+
+    public const RESOLVES_TOKENS = 'Tapp\\FilamentCertificateBuilder\\Contracts\\ResolvesCertificateTokens';
+
+    public static function enabled(): bool
+    {
+        return (bool) config('filament-lms.integrations.certificate_builder.enabled', false)
+            && class_exists(self::TEMPLATE_MODEL);
+    }
+
+    public static function canCreateTemplate(?object $user, Course $course): bool
+    {
+        return self::canManageTemplates($user, $course)
+            && self::assignedTemplateId($course) === null;
+    }
+
+    public static function canEditTemplate(?object $user, Course $course): bool
+    {
+        return self::canManageTemplates($user, $course)
+            && self::templateEditUrl($course) !== null;
+    }
+
+    public static function canManageTemplates(?object $user, Course $course): bool
+    {
+        return self::enabled()
+            && $user !== null
+            && method_exists($user, 'can')
+            && $user->can('update', $course) === true;
+    }
+
+    public static function assignedTemplateId(Course $course): int|string|null
+    {
+        $templateId = $course->certificate_template_id;
+
+        if ($templateId === null || ! class_exists(self::TEMPLATE_MODEL)) {
+            return null;
+        }
+
+        $exists = self::TEMPLATE_MODEL::query()->whereKey($templateId)->exists();
+
+        return $exists ? $templateId : null;
+    }
+
+    public static function templateEditUrl(Course $course): ?string
+    {
+        $resource = self::templateResource();
+        $templateId = self::assignedTemplateId($course);
+
+        if ($resource === null || $templateId === null) {
+            return null;
+        }
+
+        return $resource::getUrl('edit', ['record' => $templateId]);
+    }
+
+    public static function tokenSet(): string
+    {
+        $tokenSet = config('filament-lms.integrations.certificate_builder.token_set', 'course');
+
+        return is_string($tokenSet) && $tokenSet !== '' ? $tokenSet : 'course';
+    }
+
+    /**
+     * @return class-string|null
+     */
+    public static function templateResource(): ?string
+    {
+        $resource = config('filament-lms.integrations.certificate_builder.template_resource');
+
+        if (! is_string($resource) || $resource === '' || ! class_exists($resource)) {
+            return null;
+        }
+
+        return $resource;
+    }
+}

--- a/src/Support/CertificateBuilder.php
+++ b/src/Support/CertificateBuilder.php
@@ -17,14 +17,41 @@ final class CertificateBuilder
 
     public static function enabled(): bool
     {
-        return (bool) config('filament-lms.integrations.certificate_builder.enabled', false)
-            && class_exists(self::TEMPLATE_MODEL);
+        return class_exists(self::TEMPLATE_MODEL);
     }
 
     public static function canCreateTemplate(?object $user, Course $course): bool
     {
-        return self::canManageTemplates($user, $course)
-            && self::assignedTemplateId($course) === null;
+        return self::canManageTemplates($user, $course);
+    }
+
+    public static function defaultTemplateId(): ?int
+    {
+        if (! class_exists(self::TEMPLATE_MODEL)) {
+            return null;
+        }
+
+        $tokenSet = self::tokenSet();
+        $query = self::TEMPLATE_MODEL::query()->where('token_set', $tokenSet);
+        $template = (clone $query)->where('name', 'Default Certificate')->first()
+            ?? $query->orderBy('name')->first();
+
+        if ($template !== null) {
+            return (int) $template->getKey();
+        }
+
+        $layoutClass = self::LAYOUT_CLASS;
+        $layout = class_exists($layoutClass) && method_exists($layoutClass, 'default')
+            ? $layoutClass::default($tokenSet)
+            : [];
+
+        $created = self::TEMPLATE_MODEL::query()->create([
+            'name' => 'Default Certificate',
+            'token_set' => $tokenSet,
+            'layout' => is_array($layout) ? $layout : [],
+        ]);
+
+        return (int) $created->getKey();
     }
 
     public static function canEditTemplate(?object $user, Course $course): bool

--- a/tests/Fakes/FakeCertificateLayout.php
+++ b/tests/Fakes/FakeCertificateLayout.php
@@ -17,6 +17,18 @@ final class FakeCertificateLayout
             'signature_count' => 2,
             'elements' => [
                 [
+                    'id' => 'recipient_name_display',
+                    'type' => 'text',
+                    'bind' => 'recipient_name',
+                    'visible' => true,
+                ],
+                [
+                    'id' => 'recipient_name',
+                    'type' => 'text',
+                    'bind' => 'recipient_name',
+                    'visible' => true,
+                ],
+                [
                     'id' => 'certifying_line',
                     'type' => 'text',
                     'text' => 'This certifies that',

--- a/tests/Fakes/FakeCertificateLayout.php
+++ b/tests/Fakes/FakeCertificateLayout.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tapp\FilamentLms\Tests\Fakes;
+
+final class FakeCertificateLayout
+{
+    /**
+     * @return array{width: int, height: int, signature_count: int, elements: list<array<string, mixed>>}
+     */
+    public static function default(?string $tokenSet = null): array
+    {
+        return [
+            'width' => 1050,
+            'height' => 774,
+            'signature_count' => 2,
+            'elements' => [
+                [
+                    'id' => 'certifying_line',
+                    'type' => 'text',
+                    'text' => 'This certifies that',
+                    'visible' => true,
+                ],
+                [
+                    'id' => 'completed_line',
+                    'type' => 'text',
+                    'text' => 'has successfully completed',
+                    'visible' => true,
+                ],
+                [
+                    'id' => 'course_name',
+                    'type' => 'text',
+                    'bind' => 'course_name',
+                    'visible' => true,
+                ],
+                [
+                    'id' => 'description',
+                    'type' => 'text',
+                    'text' => '',
+                    'visible' => false,
+                ],
+            ],
+        ];
+    }
+}

--- a/tests/Fakes/FakeCertificateTemplate.php
+++ b/tests/Fakes/FakeCertificateTemplate.php
@@ -31,5 +31,6 @@ final class FakeCertificateTemplate extends Model implements HasMedia
         $this->addMediaCollection('logo_1')->singleFile();
         $this->addMediaCollection('logo_2')->singleFile();
         $this->addMediaCollection('logo_3')->singleFile();
+        $this->addMediaCollection('header')->singleFile();
     }
 }

--- a/tests/Fakes/FakeCertificateTemplate.php
+++ b/tests/Fakes/FakeCertificateTemplate.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tapp\FilamentLms\Tests\Fakes;
+
+use Illuminate\Database\Eloquent\Model;
+use Spatie\MediaLibrary\HasMedia;
+use Spatie\MediaLibrary\InteractsWithMedia;
+
+final class FakeCertificateTemplate extends Model implements HasMedia
+{
+    use InteractsWithMedia;
+
+    protected $table = 'certificate_templates';
+
+    protected $guarded = [];
+
+    /**
+     * @return array<string, string>
+     */
+    protected function casts(): array
+    {
+        return [
+            'layout' => 'array',
+        ];
+    }
+
+    public function registerMediaCollections(): void
+    {
+        $this->addMediaCollection('logo_1')->singleFile();
+        $this->addMediaCollection('logo_2')->singleFile();
+        $this->addMediaCollection('logo_3')->singleFile();
+    }
+}

--- a/tests/Feature/CertificateControllerTest.php
+++ b/tests/Feature/CertificateControllerTest.php
@@ -3,8 +3,6 @@
 declare(strict_types=1);
 
 use Tapp\FilamentLms\Models\Course;
-use Tapp\FilamentLms\Models\Lesson;
-use Tapp\FilamentLms\Models\Step;
 use Tapp\FilamentLms\Support\CertificateBuilder;
 use Tapp\FilamentLms\Tests\TestUser;
 
@@ -15,29 +13,22 @@ beforeEach(function () {
     ]);
 });
 
-it('renders the default award certificate when no template is assigned', function () {
+it('returns not found when the course has no certificate template', function () {
     $user = TestUser::query()->create([
         'name' => 'Jane Doe',
         'email' => 'jane-cert@example.com',
         'password' => bcrypt('password'),
     ]);
 
-    $course = Course::factory()->create([
+    $course = Course::factory()->withoutCertificateTemplate()->create([
         'name' => 'Intro to CHW',
-        'award' => 'default',
     ]);
-
-    $lesson = Lesson::factory()->create(['course_id' => $course->id]);
-    Step::factory()->create(['lesson_id' => $lesson->id]);
 
     $course->users()->attach($user->id, ['completed_at' => now()]);
 
     $this->actingAs($user)
         ->get(route('filament-lms::certificates.show', ['course' => $course->id, 'user' => $user->id]))
-        ->assertSuccessful()
-        ->assertSee('CERTIFICATE', false)
-        ->assertSee('Intro to CHW', false)
-        ->assertSee('Jane Doe', false);
+        ->assertNotFound();
 });
 
 it('forbids download when the user has not completed the course', function () {
@@ -47,22 +38,20 @@ it('forbids download when the user has not completed the course', function () {
         'password' => bcrypt('password'),
     ]);
 
-    $course = Course::factory()->create(['award' => 'default']);
+    $course = Course::factory()->withoutCertificateTemplate()->create();
 
     $this->actingAs($user)
         ->get(route('filament-lms::certificates.download', $course))
         ->assertForbidden();
 });
 
-it('does not expose the create certificate template action when the builder is disabled', function () {
-    config(['filament-lms.integrations.certificate_builder.enabled' => false]);
-
+it('does not expose template actions when the builder package is missing', function () {
     $user = TestUser::query()->create([
         'name' => 'Pat Admin',
         'email' => 'pat-admin-cert@example.com',
         'password' => bcrypt('password'),
     ]);
-    $course = Course::factory()->create(['award' => 'default']);
+    $course = Course::factory()->withoutCertificateTemplate()->create();
 
     expect(CertificateBuilder::enabled())->toBeFalse()
         ->and(CertificateBuilder::canCreateTemplate($user, $course))->toBeFalse()

--- a/tests/Feature/CertificateControllerTest.php
+++ b/tests/Feature/CertificateControllerTest.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+use Tapp\FilamentLms\Models\Course;
+use Tapp\FilamentLms\Models\Lesson;
+use Tapp\FilamentLms\Models\Step;
+use Tapp\FilamentLms\Support\CertificateBuilder;
+use Tapp\FilamentLms\Tests\TestUser;
+
+beforeEach(function () {
+    config([
+        'filament-lms.user_model' => TestUser::class,
+        'auth.providers.users.model' => TestUser::class,
+    ]);
+});
+
+it('renders the default award certificate when no template is assigned', function () {
+    $user = TestUser::query()->create([
+        'name' => 'Jane Doe',
+        'email' => 'jane-cert@example.com',
+        'password' => bcrypt('password'),
+    ]);
+
+    $course = Course::factory()->create([
+        'name' => 'Intro to CHW',
+        'award' => 'default',
+    ]);
+
+    $lesson = Lesson::factory()->create(['course_id' => $course->id]);
+    Step::factory()->create(['lesson_id' => $lesson->id]);
+
+    $course->users()->attach($user->id, ['completed_at' => now()]);
+
+    $this->actingAs($user)
+        ->get(route('filament-lms::certificates.show', ['course' => $course->id, 'user' => $user->id]))
+        ->assertSuccessful()
+        ->assertSee('CERTIFICATE', false)
+        ->assertSee('Intro to CHW', false)
+        ->assertSee('Jane Doe', false);
+});
+
+it('forbids download when the user has not completed the course', function () {
+    $user = TestUser::query()->create([
+        'name' => 'Pat Learner',
+        'email' => 'pat-cert@example.com',
+        'password' => bcrypt('password'),
+    ]);
+
+    $course = Course::factory()->create(['award' => 'default']);
+
+    $this->actingAs($user)
+        ->get(route('filament-lms::certificates.download', $course))
+        ->assertForbidden();
+});
+
+it('does not expose the create certificate template action when the builder is disabled', function () {
+    config(['filament-lms.integrations.certificate_builder.enabled' => false]);
+
+    $user = TestUser::query()->create([
+        'name' => 'Pat Admin',
+        'email' => 'pat-admin-cert@example.com',
+        'password' => bcrypt('password'),
+    ]);
+    $course = Course::factory()->create(['award' => 'default']);
+
+    expect(CertificateBuilder::enabled())->toBeFalse()
+        ->and(CertificateBuilder::canCreateTemplate($user, $course))->toBeFalse()
+        ->and(CertificateBuilder::canEditTemplate($user, $course))->toBeFalse();
+});

--- a/tests/Feature/MigrateAwardsToCertificateTemplatesCommandTest.php
+++ b/tests/Feature/MigrateAwardsToCertificateTemplatesCommandTest.php
@@ -1,0 +1,201 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Facades\File;
+use Tapp\FilamentLms\Models\Course;
+use Tapp\FilamentLms\Services\MigrateAwardsToCertificateTemplates;
+use Tapp\FilamentLms\Tests\Fakes\FakeCertificateLayout;
+use Tapp\FilamentLms\Tests\Fakes\FakeCertificateTemplate;
+
+function publishAwardFixture(string $award, string $fixture): void
+{
+    $path = resource_path('views/vendor/filament-lms/certificates/'.$award.'.blade.php');
+
+    File::ensureDirectoryExists(dirname($path));
+    File::copy(__DIR__.'/../fixtures/certificates/'.$fixture, $path);
+}
+
+function seedAwardLogo(string $relativePath): string
+{
+    $absolute = public_path(ltrim($relativePath, '/'));
+
+    File::ensureDirectoryExists(dirname($absolute));
+    File::put($absolute, base64_decode('iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg=='));
+
+    return $absolute;
+}
+
+it('fails when the certificate builder is not enabled', function () {
+    $this->artisan('filament-lms:migrate-awards-to-templates')
+        ->expectsOutputToContain('Certificate builder is not enabled')
+        ->assertFailed();
+});
+
+it('creates a template per award and assigns untemplated courses', function () {
+    config([
+        'filament-lms.awards' => [
+            'default' => 'Default',
+            'decan' => 'Delaware Contraceptive Access Network',
+        ],
+    ]);
+
+    publishAwardFixture('decan', 'custom-award.blade.php');
+    seedAwardLogo('img/DE_DHSS-logo-red-wide.png');
+
+    $defaultCourse = Course::factory()->create([
+        'name' => 'Default Award Course',
+        'external_id' => 'default_award_course',
+        'award' => 'default',
+        'certificate_template_id' => null,
+    ]);
+    $decanCourse = Course::factory()->create([
+        'name' => 'Decan Award Course',
+        'external_id' => 'decan_award_course',
+        'award' => 'decan',
+        'certificate_template_id' => null,
+    ]);
+    $alreadyAssigned = Course::factory()->create([
+        'name' => 'Already Assigned Course',
+        'external_id' => 'already_assigned_course',
+        'award' => 'decan',
+        'certificate_template_id' => 99,
+    ]);
+
+    $summary = app(MigrateAwardsToCertificateTemplates::class)->handle(
+        templateClass: FakeCertificateTemplate::class,
+        layoutClass: FakeCertificateLayout::class,
+    );
+
+    $defaultTemplate = FakeCertificateTemplate::query()->where('name', 'Default Certificate')->first();
+    $decanTemplate = FakeCertificateTemplate::query()
+        ->where('name', 'Delaware Contraceptive Access Network Certificate')
+        ->first();
+
+    expect($summary['templates_created'])->toBe(2)
+        ->and($summary['courses_updated'])->toBe(2)
+        ->and($defaultTemplate)->not->toBeNull()
+        ->and($decanTemplate)->not->toBeNull()
+        ->and($decanTemplate->token_set)->toBe('course')
+        ->and($decanTemplate->layout['elements'])->toContain(
+            ['id' => 'certifying_line', 'type' => 'text', 'text' => 'AWARDED TO:', 'visible' => true],
+        )
+        ->and($decanTemplate->getFirstMedia('logo_1'))->not->toBeNull()
+        ->and($defaultCourse->refresh()->certificate_template_id)->toBe($defaultTemplate->id)
+        ->and($decanCourse->refresh()->certificate_template_id)->toBe($decanTemplate->id)
+        ->and($alreadyAssigned->refresh()->certificate_template_id)->toBe(99);
+});
+
+it('is idempotent', function () {
+    config(['filament-lms.awards' => [
+        'decan' => 'Delaware Contraceptive Access Network',
+    ]]);
+
+    publishAwardFixture('decan', 'custom-award.blade.php');
+
+    Course::factory()->create([
+        'name' => 'Decan Course',
+        'external_id' => 'decan_idempotent',
+        'award' => 'decan',
+    ]);
+
+    $migrator = app(MigrateAwardsToCertificateTemplates::class);
+
+    $migrator->handle(
+        templateClass: FakeCertificateTemplate::class,
+        layoutClass: FakeCertificateLayout::class,
+    );
+    $second = $migrator->handle(
+        templateClass: FakeCertificateTemplate::class,
+        layoutClass: FakeCertificateLayout::class,
+    );
+
+    expect(FakeCertificateTemplate::query()->count())->toBe(1)
+        ->and($second['templates_created'])->toBe(0)
+        ->and($second['templates_reused'])->toBe(1)
+        ->and($second['courses_updated'])->toBe(0);
+});
+
+it('does not write during a dry run', function () {
+    config(['filament-lms.awards' => [
+        'decan' => 'Delaware Contraceptive Access Network',
+    ]]);
+
+    $course = Course::factory()->create([
+        'name' => 'Dry Run Course',
+        'external_id' => 'dry_run_course',
+        'award' => 'decan',
+    ]);
+
+    $summary = app(MigrateAwardsToCertificateTemplates::class)->handle(
+        dryRun: true,
+        templateClass: FakeCertificateTemplate::class,
+        layoutClass: FakeCertificateLayout::class,
+    );
+
+    expect($summary['templates_created'])->toBe(1)
+        ->and($summary['courses_updated'])->toBe(1)
+        ->and(FakeCertificateTemplate::query()->count())->toBe(0)
+        ->and($course->refresh()->certificate_template_id)->toBeNull();
+});
+
+it('can migrate a single award key', function () {
+    config(['filament-lms.awards' => [
+        'default' => 'Default',
+        'decan' => 'Delaware Contraceptive Access Network',
+    ]]);
+
+    Course::factory()->create([
+        'name' => 'Default Only Course',
+        'external_id' => 'default_only_course',
+        'award' => 'default',
+    ]);
+    $decanCourse = Course::factory()->create([
+        'name' => 'Decan Only Course',
+        'external_id' => 'decan_only_course',
+        'award' => 'decan',
+    ]);
+
+    $summary = app(MigrateAwardsToCertificateTemplates::class)->handle(
+        award: 'decan',
+        templateClass: FakeCertificateTemplate::class,
+        layoutClass: FakeCertificateLayout::class,
+    );
+
+    expect($summary['awards'])->toHaveCount(1)
+        ->and($summary['awards'][0]['award'])->toBe('decan')
+        ->and(FakeCertificateTemplate::query()->count())->toBe(1)
+        ->and($decanCourse->refresh()->certificate_template_id)->not->toBeNull();
+});
+
+it('reassigns existing templates when forced', function () {
+    config(['filament-lms.awards' => [
+        'decan' => 'Delaware Contraceptive Access Network',
+    ]]);
+
+    publishAwardFixture('decan', 'custom-award.blade.php');
+
+    $existing = FakeCertificateTemplate::query()->create([
+        'name' => 'Delaware Contraceptive Access Network Certificate',
+        'token_set' => 'training',
+        'layout' => ['elements' => []],
+    ]);
+
+    $course = Course::factory()->create([
+        'name' => 'Force Reassign Course',
+        'external_id' => 'force_reassign_course',
+        'award' => 'decan',
+        'certificate_template_id' => 99,
+    ]);
+
+    app(MigrateAwardsToCertificateTemplates::class)->handle(
+        force: true,
+        templateClass: FakeCertificateTemplate::class,
+        layoutClass: FakeCertificateLayout::class,
+    );
+
+    expect(FakeCertificateTemplate::query()->count())->toBe(1)
+        ->and($existing->refresh()->token_set)->toBe('course')
+        ->and($existing->layout['elements'])->not->toBeEmpty()
+        ->and($course->refresh()->certificate_template_id)->toBe($existing->id);
+});

--- a/tests/Feature/MigrateAwardsToCertificateTemplatesCommandTest.php
+++ b/tests/Feature/MigrateAwardsToCertificateTemplatesCommandTest.php
@@ -26,10 +26,10 @@ function seedAwardLogo(string $relativePath): string
     return $absolute;
 }
 
-it('fails when the certificate builder is not enabled', function () {
-    $this->artisan('filament-lms:migrate-awards-to-templates')
-        ->expectsOutputToContain('Certificate builder is not enabled')
-        ->assertFailed();
+it('fails when the certificate builder is not installed', function () {
+    $this->artisan('filament-lms:upgrade-awards')
+        ->expectsOutputToContain('Certificate builder is not installed')
+        ->assertExitCode(1);
 });
 
 it('creates a template per award and assigns untemplated courses', function () {
@@ -42,6 +42,7 @@ it('creates a template per award and assigns untemplated courses', function () {
 
     publishAwardFixture('decan', 'custom-award.blade.php');
     seedAwardLogo('img/DE_DHSS-logo-red-wide.png');
+    seedAwardLogo('img/header-green.jpg');
 
     $defaultCourse = Course::factory()->create([
         'name' => 'Default Award Course',
@@ -55,11 +56,16 @@ it('creates a template per award and assigns untemplated courses', function () {
         'award' => 'decan',
         'certificate_template_id' => null,
     ]);
-    $alreadyAssigned = Course::factory()->create([
+    $customTemplate = FakeCertificateTemplate::query()->create([
+        'name' => 'Hand Built Template',
+        'token_set' => 'course',
+        'layout' => ['elements' => []],
+    ]);
+    $alreadyAssigned = Course::factory()->withoutCertificateTemplate()->create([
         'name' => 'Already Assigned Course',
         'external_id' => 'already_assigned_course',
         'award' => 'decan',
-        'certificate_template_id' => 99,
+        'certificate_template_id' => $customTemplate->id,
     ]);
 
     $summary = app(MigrateAwardsToCertificateTemplates::class)->handle(
@@ -77,13 +83,21 @@ it('creates a template per award and assigns untemplated courses', function () {
         ->and($defaultTemplate)->not->toBeNull()
         ->and($decanTemplate)->not->toBeNull()
         ->and($decanTemplate->token_set)->toBe('course')
-        ->and($decanTemplate->layout['elements'])->toContain(
-            ['id' => 'certifying_line', 'type' => 'text', 'text' => 'AWARDED TO:', 'visible' => true],
-        )
+        ->and($decanTemplate->layout['signature_count'])->toBe(0)
+        ->and($decanTemplate->layout['border']['style'])->toBe('gradient')
+        ->and($decanTemplate->layout['border']['gradient'])->toBe('linear-gradient(to right, #a3e635, #0ea5e9, #67e8f9)')
+        ->and(collect($decanTemplate->layout['elements'])->firstWhere('id', 'certifying_line'))
+        ->toMatchArray(['text' => 'AWARDED TO:', 'visible' => true])
+        ->and(collect($decanTemplate->layout['elements'])->firstWhere('id', 'recipient_name_display'))
+        ->toMatchArray(['bind' => 'recipient_name', 'visible' => false])
+        ->and(collect($decanTemplate->layout['elements'])->pluck('type'))->not->toContain('signature')
+        ->and($decanTemplate->layout['header']['enabled'])->toBeTrue()
+        ->and($decanTemplate->layout['header']['title_bind'])->toBe('course_name')
         ->and($decanTemplate->getFirstMedia('logo_1'))->not->toBeNull()
+        ->and($decanTemplate->getFirstMedia('header'))->not->toBeNull()
         ->and($defaultCourse->refresh()->certificate_template_id)->toBe($defaultTemplate->id)
         ->and($decanCourse->refresh()->certificate_template_id)->toBe($decanTemplate->id)
-        ->and($alreadyAssigned->refresh()->certificate_template_id)->toBe(99);
+        ->and($alreadyAssigned->refresh()->certificate_template_id)->toBe($customTemplate->id);
 });
 
 it('is idempotent', function () {
@@ -110,9 +124,9 @@ it('is idempotent', function () {
         layoutClass: FakeCertificateLayout::class,
     );
 
-    expect(FakeCertificateTemplate::query()->count())->toBe(1)
+    expect(FakeCertificateTemplate::query()->count())->toBe(2)
         ->and($second['templates_created'])->toBe(0)
-        ->and($second['templates_reused'])->toBe(1)
+        ->and($second['templates_reused'])->toBe(2)
         ->and($second['courses_updated'])->toBe(0);
 });
 
@@ -133,7 +147,7 @@ it('does not write during a dry run', function () {
         layoutClass: FakeCertificateLayout::class,
     );
 
-    expect($summary['templates_created'])->toBe(1)
+    expect($summary['templates_created'])->toBe(2)
         ->and($summary['courses_updated'])->toBe(1)
         ->and(FakeCertificateTemplate::query()->count())->toBe(0)
         ->and($course->refresh()->certificate_template_id)->toBeNull();
@@ -181,11 +195,17 @@ it('reassigns existing templates when forced', function () {
         'layout' => ['elements' => []],
     ]);
 
-    $course = Course::factory()->create([
+    $customTemplate = FakeCertificateTemplate::query()->create([
+        'name' => 'Hand Built Template',
+        'token_set' => 'course',
+        'layout' => ['elements' => []],
+    ]);
+
+    $course = Course::factory()->withoutCertificateTemplate()->create([
         'name' => 'Force Reassign Course',
         'external_id' => 'force_reassign_course',
         'award' => 'decan',
-        'certificate_template_id' => 99,
+        'certificate_template_id' => $customTemplate->id,
     ]);
 
     app(MigrateAwardsToCertificateTemplates::class)->handle(
@@ -194,8 +214,31 @@ it('reassigns existing templates when forced', function () {
         layoutClass: FakeCertificateLayout::class,
     );
 
-    expect(FakeCertificateTemplate::query()->count())->toBe(1)
+    expect(FakeCertificateTemplate::query()->count())->toBe(3)
         ->and($existing->refresh()->token_set)->toBe('course')
         ->and($existing->layout['elements'])->not->toBeEmpty()
-        ->and($course->refresh()->certificate_template_id)->toBe($existing->id);
+        ->and($course->refresh()->certificate_template_id)->toBe($customTemplate->id);
+});
+
+it('assigns courses with a null award to the default template', function () {
+    config(['filament-lms.awards' => [
+        'default' => 'Default',
+    ]]);
+
+    $course = Course::factory()->withoutCertificateTemplate()->create([
+        'name' => 'Orphan Award Course',
+        'external_id' => 'orphan_award_course',
+        'award' => null,
+    ]);
+
+    app(MigrateAwardsToCertificateTemplates::class)->handle(
+        templateClass: FakeCertificateTemplate::class,
+        layoutClass: FakeCertificateLayout::class,
+    );
+
+    $template = FakeCertificateTemplate::query()->where('name', 'Default Certificate')->first();
+
+    expect($template)->not->toBeNull()
+        ->and($course->refresh()->certificate_template_id)->toBe($template->id)
+        ->and(app(MigrateAwardsToCertificateTemplates::class)->unverifiedCourseIds(FakeCertificateTemplate::class))->toBe([]);
 });

--- a/tests/Feature/StepRenderedTextTest.php
+++ b/tests/Feature/StepRenderedTextTest.php
@@ -11,7 +11,7 @@ beforeEach(function () {
         'name' => 'Test Course',
         'slug' => 'test-course',
         'external_id' => 'test_course',
-        'award' => 'default',
+        'certificate_template_id' => null,
     ]);
     $this->lesson = Lesson::query()->create([
         'course_id' => $this->course->id,

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -113,6 +113,14 @@ abstract class TestCase extends Orchestra
             $table->softDeletes();
         });
 
+        $app['db']->connection()->getSchemaBuilder()->create('certificate_templates', function (Blueprint $table) {
+            $table->id();
+            $table->string('name');
+            $table->string('token_set')->default('default')->index();
+            $table->json('layout')->nullable();
+            $table->timestamps();
+        });
+
         // Create lms_lessons table
         $app['db']->connection()->getSchemaBuilder()->create('lms_lessons', function (Blueprint $table) {
             $table->id();

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -102,6 +102,7 @@ abstract class TestCase extends Orchestra
             $table->string('external_id')->unique();
             $table->text('image')->nullable();
             $table->string('award')->nullable();
+            $table->unsignedBigInteger('certificate_template_id')->nullable()->index();
             $table->text('description')->nullable();
             $table->unsignedTinyInteger('required_test_percentage')->nullable();
             $table->boolean('is_private')->default(false);

--- a/tests/Unit/AwardCertificateBlueprintFactoryTest.php
+++ b/tests/Unit/AwardCertificateBlueprintFactoryTest.php
@@ -56,7 +56,14 @@ it('extracts logos and copy from a custom award blade', function () {
         ->and($blueprint->certifyingLine)->toBe('AWARDED TO:')
         ->and($blueprint->completedLine)->toBe('')
         ->and($blueprint->description)->toContain('Delaware Contraceptive Access Now')
-        ->and($blueprint->includeCourseName)->toBeTrue();
+        ->and($blueprint->includeCourseName)->toBeTrue()
+        ->and($blueprint->includeSignatures)->toBeFalse()
+        ->and($blueprint->border['style'])->toBe('gradient')
+        ->and($blueprint->border['gradient'])->toBe('linear-gradient(to right, #a3e635, #0ea5e9, #67e8f9)')
+        ->and($blueprint->header['enabled'])->toBeTrue()
+        ->and($blueprint->header['title_bind'])->toBe('course_name')
+        ->and($blueprint->header['subtitle'])->toBe('CERTIFICATE OF COMPLETION')
+        ->and($blueprint->headerImagePath)->toBe('/img/header-green.jpg');
 });
 
 it('hides the course name when the award blade does not print it', function () {
@@ -71,7 +78,30 @@ it('hides the course name when the award blade does not print it', function () {
     expect($blueprint->includeCourseName)->toBeFalse()
         ->and($blueprint->logoPaths)->toBe(['/img/DPH_logo_family.png'])
         ->and($blueprint->certifyingLine)->toBe('AWARDED TO:')
-        ->and($blueprint->description)->toContain('Family Support Specialist');
+        ->and($blueprint->description)->toContain('Family Support Specialist')
+        ->and($blueprint->includeSignatures)->toBeFalse();
+});
+
+it('keeps signatures when the award blade has signature fields', function () {
+    config(['filament-lms.awards' => [
+        'signed' => 'Signed Award',
+    ]]);
+
+    publishAwardView('signed', 'signed-award.blade.php');
+
+    $blueprint = app(AwardCertificateBlueprintFactory::class)->make('signed');
+
+    expect($blueprint->includeSignatures)->toBeTrue();
+});
+
+it('follows the LMS signature config for the default award blade', function () {
+    config(['filament-lms.certificate_show_signatures' => false]);
+
+    expect(app(AwardCertificateBlueprintFactory::class)->make('default')->includeSignatures)->toBeFalse();
+
+    config(['filament-lms.certificate_show_signatures' => true]);
+
+    expect(app(AwardCertificateBlueprintFactory::class)->make('default')->includeSignatures)->toBeTrue();
 });
 
 it('uses the default award copy and configured logo', function () {
@@ -90,7 +120,43 @@ it('uses the default award copy and configured logo', function () {
         ->and($blueprint->logoPaths)->toBe(['images/certificate-logo.png'])
         ->and($blueprint->certifyingLine)->toBe('This certificate is awarded to')
         ->and($blueprint->completedLine)->toBe('successfully completed')
-        ->and($blueprint->includeCourseName)->toBeTrue();
+        ->and($blueprint->includeCourseName)->toBeTrue()
+        ->and($blueprint->border['style'])->toBe('double')
+        ->and($blueprint->border['color'])->toBe('#a1a1aa')
+        ->and($blueprint->header['enabled'])->toBeFalse()
+        ->and($blueprint->headerImagePath)->toBeNull();
+});
+
+it('extracts a solid frame color from an award blade', function () {
+    config(['filament-lms.awards' => [
+        'family-support-specialist' => 'Family Support Specialist Onboarding',
+    ]]);
+
+    publishAwardView('family-support-specialist', 'solid-border-award.blade.php');
+
+    $blueprint = app(AwardCertificateBlueprintFactory::class)->make('family-support-specialist');
+
+    expect($blueprint->border['style'])->toBe('solid')
+        ->and($blueprint->border['color'])->toBe('#B5498F')
+        ->and($blueprint->border['width'])->toBe(6)
+        ->and($blueprint->header['enabled'])->toBeFalse();
+});
+
+it('extracts a banner header from an award blade', function () {
+    config(['filament-lms.awards' => [
+        'family-support-specialist' => 'Family Support Specialist Onboarding',
+    ]]);
+
+    publishAwardView('family-support-specialist', 'header-banner-award.blade.php');
+
+    $blueprint = app(AwardCertificateBlueprintFactory::class)->make('family-support-specialist');
+
+    expect($blueprint->header['enabled'])->toBeTrue()
+        ->and($blueprint->header['height'])->toBe(300)
+        ->and($blueprint->header['background_color'])->toBe('#B5498F')
+        ->and($blueprint->header['background_size'])->toBe('60% auto')
+        ->and($blueprint->header['title_bind'])->toBe('')
+        ->and($blueprint->headerImagePath)->toBe('/img/home-visiting-header-certificate.png');
 });
 
 it('resolves a logo that exists in the public directory', function () {

--- a/tests/Unit/AwardCertificateBlueprintFactoryTest.php
+++ b/tests/Unit/AwardCertificateBlueprintFactoryTest.php
@@ -1,0 +1,107 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Facades\File;
+use Tapp\FilamentLms\Models\Course;
+use Tapp\FilamentLms\Support\AwardCertificateBlueprintFactory;
+
+function publishAwardView(string $award, string $fixture): void
+{
+    $path = resource_path('views/vendor/filament-lms/certificates/'.$award.'.blade.php');
+
+    File::ensureDirectoryExists(dirname($path));
+    File::copy(__DIR__.'/../fixtures/certificates/'.$fixture, $path);
+}
+
+it('discovers configured awards and awards used on courses', function () {
+    config(['filament-lms.awards' => [
+        'default' => 'Default',
+        'safb' => 'Safe Arms For Babies',
+    ]]);
+
+    Course::factory()->create([
+        'name' => 'Used Custom Award Course',
+        'external_id' => 'used_custom_award',
+        'award' => 'decan',
+    ]);
+
+    $keys = app(AwardCertificateBlueprintFactory::class)->awardKeys();
+
+    expect($keys)->toBe(['decan', 'default', 'safb']);
+});
+
+it('limits discovery to an explicit award key', function () {
+    config(['filament-lms.awards' => [
+        'default' => 'Default',
+        'safb' => 'Safe Arms For Babies',
+    ]]);
+
+    expect(app(AwardCertificateBlueprintFactory::class)->awardKeys('safb'))->toBe(['safb']);
+});
+
+it('extracts logos and copy from a custom award blade', function () {
+    config(['filament-lms.awards' => [
+        'decan' => 'Delaware Contraceptive Access Network',
+    ]]);
+
+    publishAwardView('decan', 'custom-award.blade.php');
+
+    $blueprint = app(AwardCertificateBlueprintFactory::class)->make('decan');
+
+    expect($blueprint->key)->toBe('decan')
+        ->and($blueprint->label)->toBe('Delaware Contraceptive Access Network')
+        ->and($blueprint->templateName)->toBe('Delaware Contraceptive Access Network Certificate')
+        ->and($blueprint->logoPaths)->toBe(['/img/DE_DHSS-logo-red-wide.png'])
+        ->and($blueprint->certifyingLine)->toBe('AWARDED TO:')
+        ->and($blueprint->completedLine)->toBe('')
+        ->and($blueprint->description)->toContain('Delaware Contraceptive Access Now')
+        ->and($blueprint->includeCourseName)->toBeTrue();
+});
+
+it('hides the course name when the award blade does not print it', function () {
+    config(['filament-lms.awards' => [
+        'family-support-specialist' => 'Family Support Specialist Onboarding',
+    ]]);
+
+    publishAwardView('family-support-specialist', 'no-course-name.blade.php');
+
+    $blueprint = app(AwardCertificateBlueprintFactory::class)->make('family-support-specialist');
+
+    expect($blueprint->includeCourseName)->toBeFalse()
+        ->and($blueprint->logoPaths)->toBe(['/img/DPH_logo_family.png'])
+        ->and($blueprint->certifyingLine)->toBe('AWARDED TO:')
+        ->and($blueprint->description)->toContain('Family Support Specialist');
+});
+
+it('uses the default award copy and configured logo', function () {
+    config([
+        'filament-lms.certificate_logo' => 'images/certificate-logo.png',
+        'certificate-builder.token_sets.course.default_copy' => [
+            'certifying_line' => 'This certifies that',
+            'completed_line' => 'has successfully completed',
+            'description' => '',
+        ],
+    ]);
+
+    $blueprint = app(AwardCertificateBlueprintFactory::class)->make('default');
+
+    expect($blueprint->templateName)->toBe('Default Certificate')
+        ->and($blueprint->logoPaths)->toBe(['images/certificate-logo.png'])
+        ->and($blueprint->certifyingLine)->toBe('This certificate is awarded to')
+        ->and($blueprint->completedLine)->toBe('successfully completed')
+        ->and($blueprint->includeCourseName)->toBeTrue();
+});
+
+it('resolves a logo that exists in the public directory', function () {
+    $relative = 'img/award-logo.png';
+    $absolute = public_path($relative);
+
+    File::ensureDirectoryExists(dirname($absolute));
+    File::put($absolute, base64_decode('iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg=='));
+
+    expect(app(AwardCertificateBlueprintFactory::class)->resolveLogoAbsolutePath('/'.$relative))
+        ->toBe($absolute)
+        ->and(app(AwardCertificateBlueprintFactory::class)->resolveLogoAbsolutePath('missing/logo.png'))
+        ->toBeNull();
+});

--- a/tests/Unit/AwardCertificateLayoutApplierTest.php
+++ b/tests/Unit/AwardCertificateLayoutApplierTest.php
@@ -16,12 +16,41 @@ it('applies award copy and course-name visibility to a layout', function () {
         completedLine: '',
         description: 'Award-specific description.',
         includeCourseName: false,
+        includeSignatures: false,
+        border: [
+            'style' => 'gradient',
+            'width' => 6,
+            'color' => '#a3e635',
+            'gradient' => 'linear-gradient(to right, #a3e635, #0ea5e9, #67e8f9)',
+        ],
+        header: [
+            'enabled' => true,
+            'height' => 220,
+            'title_bind' => 'course_name',
+            'subtitle' => 'CERTIFICATE OF COMPLETION',
+        ],
+        headerImagePath: '/img/header-green.jpg',
     );
 
-    $layout = app(AwardCertificateLayoutApplier::class)->apply(
-        FakeCertificateLayout::default('course'),
-        $blueprint,
-    );
+    $layout = FakeCertificateLayout::default('course');
+    $layout['elements'][] = [
+        'id' => 'logo_1',
+        'type' => 'image',
+        'y' => 30,
+        'visible' => true,
+    ];
+    $layout['elements'][] = [
+        'id' => 'signature_1',
+        'type' => 'signature',
+        'visible' => true,
+    ];
+    $layout['elements'][] = [
+        'id' => 'signature_2',
+        'type' => 'signature',
+        'visible' => true,
+    ];
+
+    $layout = app(AwardCertificateLayoutApplier::class)->apply($layout, $blueprint);
 
     $byId = collect($layout['elements'])->keyBy('id');
 
@@ -31,5 +60,100 @@ it('applies award copy and course-name visibility to a layout', function () {
         ->and($byId['completed_line']['visible'])->toBeFalse()
         ->and($byId['description']['text'])->toBe('Award-specific description.')
         ->and($byId['description']['visible'])->toBeTrue()
-        ->and($byId['course_name']['visible'])->toBeFalse();
+        ->and($byId['course_name']['visible'])->toBeFalse()
+        ->and($byId['recipient_name_display']['visible'])->toBeFalse()
+        ->and($byId['recipient_name']['visible'])->toBeTrue()
+        ->and($byId['logo_1']['y'])->toBe(560)
+        ->and($layout['signature_count'])->toBe(0)
+        ->and($byId->has('signature_1'))->toBeFalse()
+        ->and($byId->has('signature_2'))->toBeFalse()
+        ->and($layout['border']['style'])->toBe('gradient')
+        ->and($layout['header']['enabled'])->toBeTrue()
+        ->and($layout['header']['title_bind'])->toBe('course_name');
+});
+
+it('keeps awarded-to text from overlapping the recipient name when a header is applied', function () {
+    $blueprint = new AwardCertificateBlueprint(
+        key: 'decan',
+        label: 'Delaware Contraceptive Access Network',
+        templateName: 'Delaware Contraceptive Access Network Certificate',
+        logoPaths: [],
+        certifyingLine: 'AWARDED TO:',
+        completedLine: '',
+        description: 'Award-specific description.',
+        includeCourseName: true,
+        includeSignatures: false,
+        border: [],
+        header: [
+            'enabled' => true,
+            'height' => 220,
+            'title_bind' => 'course_name',
+        ],
+        headerImagePath: '/img/header-green.jpg',
+    );
+
+    $layout = [
+        'elements' => [
+            [
+                'id' => 'certifying_line',
+                'type' => 'text',
+                'text' => 'This certifies that',
+                'y' => 200,
+                'h' => 36,
+                'visible' => true,
+            ],
+            [
+                'id' => 'recipient_name',
+                'type' => 'text',
+                'bind' => 'recipient_name',
+                'y' => 245,
+                'h' => 45,
+                'visible' => true,
+            ],
+            [
+                'id' => 'description',
+                'type' => 'text',
+                'text' => '',
+                'y' => 390,
+                'h' => 80,
+                'visible' => true,
+            ],
+        ],
+    ];
+
+    $layout = app(AwardCertificateLayoutApplier::class)->apply($layout, $blueprint);
+    $byId = collect($layout['elements'])->keyBy('id');
+
+    expect($byId['recipient_name']['y'])
+        ->toBeGreaterThanOrEqual($byId['certifying_line']['y'] + $byId['certifying_line']['h'] + 28)
+        ->and($byId['description']['y'])->toBeGreaterThan($byId['recipient_name']['y'] + $byId['recipient_name']['h']);
+});
+
+it('keeps signature fields when the award includes them', function () {
+    $blueprint = new AwardCertificateBlueprint(
+        key: 'default',
+        label: 'Default',
+        templateName: 'Default Certificate',
+        logoPaths: [],
+        certifyingLine: 'This certifies that',
+        completedLine: 'has successfully completed',
+        description: '',
+        includeCourseName: true,
+        includeSignatures: true,
+        border: [],
+        header: [],
+        headerImagePath: null,
+    );
+
+    $layout = FakeCertificateLayout::default('course');
+    $layout['elements'][] = [
+        'id' => 'signature_1',
+        'type' => 'signature',
+        'visible' => true,
+    ];
+
+    $layout = app(AwardCertificateLayoutApplier::class)->apply($layout, $blueprint);
+
+    expect($layout['signature_count'])->toBe(2)
+        ->and(collect($layout['elements'])->pluck('id'))->toContain('signature_1');
 });

--- a/tests/Unit/AwardCertificateLayoutApplierTest.php
+++ b/tests/Unit/AwardCertificateLayoutApplierTest.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+use Tapp\FilamentLms\Support\AwardCertificateBlueprint;
+use Tapp\FilamentLms\Support\AwardCertificateLayoutApplier;
+use Tapp\FilamentLms\Tests\Fakes\FakeCertificateLayout;
+
+it('applies award copy and course-name visibility to a layout', function () {
+    $blueprint = new AwardCertificateBlueprint(
+        key: 'decan',
+        label: 'Delaware Contraceptive Access Network',
+        templateName: 'Delaware Contraceptive Access Network Certificate',
+        logoPaths: ['/img/logo.png'],
+        certifyingLine: 'AWARDED TO:',
+        completedLine: '',
+        description: 'Award-specific description.',
+        includeCourseName: false,
+    );
+
+    $layout = app(AwardCertificateLayoutApplier::class)->apply(
+        FakeCertificateLayout::default('course'),
+        $blueprint,
+    );
+
+    $byId = collect($layout['elements'])->keyBy('id');
+
+    expect($byId['certifying_line']['text'])->toBe('AWARDED TO:')
+        ->and($byId['certifying_line']['visible'])->toBeTrue()
+        ->and($byId['completed_line']['text'])->toBe('')
+        ->and($byId['completed_line']['visible'])->toBeFalse()
+        ->and($byId['description']['text'])->toBe('Award-specific description.')
+        ->and($byId['description']['visible'])->toBeTrue()
+        ->and($byId['course_name']['visible'])->toBeFalse();
+});

--- a/tests/Unit/CertificateBuilderTest.php
+++ b/tests/Unit/CertificateBuilderTest.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use Illuminate\Support\Facades\Gate;
 use Tapp\FilamentLms\Models\Course;
 use Tapp\FilamentLms\Support\CertificateBuilder;
 use Tapp\FilamentLms\Tests\TestUser;
@@ -30,6 +31,53 @@ it('does not allow creating a template when the builder is disabled', function (
         ->and(CertificateBuilder::canEditTemplate($user, $course))->toBeFalse();
 });
 
+it('allows course updates when no policy is registered', function () {
+    $user = TestUser::query()->create([
+        'name' => 'Admin',
+        'email' => 'admin-no-policy@example.com',
+        'password' => bcrypt('password'),
+    ]);
+
+    $course = Course::factory()->create();
+
+    expect(CertificateBuilder::userCanUpdateCourse(null, $course))->toBeFalse()
+        ->and(CertificateBuilder::userCanUpdateCourse($user, $course))->toBeTrue();
+});
+
+it('defers to a course policy when one exists', function () {
+    Gate::policy(Course::class, CertificateBuilderCourseUpdatePolicy::class);
+
+    $denied = TestUser::query()->create([
+        'name' => 'Denied',
+        'email' => 'denied-course-update@example.com',
+        'password' => bcrypt('password'),
+    ]);
+    $allowed = TestUser::query()->create([
+        'name' => 'Allowed',
+        'email' => 'allowed@example.com',
+        'password' => bcrypt('password'),
+    ]);
+
+    $course = Course::factory()->create();
+
+    expect(CertificateBuilder::userCanUpdateCourse($denied, $course))->toBeFalse()
+        ->and(CertificateBuilder::userCanUpdateCourse($allowed, $course))->toBeTrue();
+});
+
+it('allows course updates when a policy exists without an update method', function () {
+    Gate::policy(Course::class, CertificateBuilderCourseViewPolicy::class);
+
+    $user = TestUser::query()->create([
+        'name' => 'Viewer',
+        'email' => 'viewer-no-update@example.com',
+        'password' => bcrypt('password'),
+    ]);
+
+    $course = Course::factory()->create();
+
+    expect(CertificateBuilder::userCanUpdateCourse($user, $course))->toBeTrue();
+});
+
 it('returns null for the template resource when the configured class is missing', function () {
     expect(CertificateBuilder::templateResource())->toBeNull();
 });
@@ -45,3 +93,19 @@ it('uses the configured token set and falls back to course', function () {
 
     expect(CertificateBuilder::tokenSet())->toBe('course');
 });
+
+class CertificateBuilderCourseUpdatePolicy
+{
+    public function update(object $user, Course $course): bool
+    {
+        return $user->email === 'allowed@example.com';
+    }
+}
+
+class CertificateBuilderCourseViewPolicy
+{
+    public function view(object $user, Course $course): bool
+    {
+        return true;
+    }
+}

--- a/tests/Unit/CertificateBuilderTest.php
+++ b/tests/Unit/CertificateBuilderTest.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+use Tapp\FilamentLms\Models\Course;
+use Tapp\FilamentLms\Support\CertificateBuilder;
+use Tapp\FilamentLms\Tests\TestUser;
+
+it('is disabled by default', function () {
+    expect(CertificateBuilder::enabled())->toBeFalse();
+});
+
+it('is disabled when enabled in config but the builder class is missing', function () {
+    config(['filament-lms.integrations.certificate_builder.enabled' => true]);
+
+    expect(class_exists(CertificateBuilder::TEMPLATE_MODEL))->toBeFalse()
+        ->and(CertificateBuilder::enabled())->toBeFalse();
+});
+
+it('does not allow creating a template when the builder is disabled', function () {
+    $user = TestUser::query()->create([
+        'name' => 'Admin',
+        'email' => 'admin-cert-builder@example.com',
+        'password' => bcrypt('password'),
+    ]);
+
+    $course = Course::factory()->create();
+
+    expect(CertificateBuilder::canCreateTemplate($user, $course))->toBeFalse()
+        ->and(CertificateBuilder::canEditTemplate($user, $course))->toBeFalse();
+});
+
+it('returns null for the template resource when the configured class is missing', function () {
+    expect(CertificateBuilder::templateResource())->toBeNull();
+});
+
+it('uses the configured token set and falls back to course', function () {
+    expect(CertificateBuilder::tokenSet())->toBe('course');
+
+    config(['filament-lms.integrations.certificate_builder.token_set' => 'training']);
+
+    expect(CertificateBuilder::tokenSet())->toBe('training');
+
+    config(['filament-lms.integrations.certificate_builder.token_set' => '']);
+
+    expect(CertificateBuilder::tokenSet())->toBe('course');
+});

--- a/tests/fixtures/certificates/custom-award.blade.php
+++ b/tests/fixtures/certificates/custom-award.blade.php
@@ -1,0 +1,13 @@
+<div style="background-image: url({{ asset('/img/header-green.jpg') }});">
+    <h1>{{ $course->name }}</h1>
+    <h2>{{ __('CERTIFICATE OF COMPLETION') }}</h2>
+    <p>{{ __('AWARDED TO:') }}</p>
+    <h1>{{ $user->name }}</h1>
+    <p>{{ $dateEarned }}</p>
+    <p>
+        This certificate recognizes your commitment to promoting inclusive and accessible reproductive healthcare as a valued participant in the Delaware Contraceptive Access Now training.
+    </p>
+    <p>
+        <img src="{{ asset('/img/DE_DHSS-logo-red-wide.png') }}" />
+    </p>
+</div>

--- a/tests/fixtures/certificates/custom-award.blade.php
+++ b/tests/fixtures/certificates/custom-award.blade.php
@@ -1,3 +1,4 @@
+<div class="pb-1.5 pr-1.5 pl-1.5 mx-auto bg-linear-to-r from-lime-400 via-sky-500 to-cyan-300">
 <div style="background-image: url({{ asset('/img/header-green.jpg') }});">
     <h1>{{ $course->name }}</h1>
     <h2>{{ __('CERTIFICATE OF COMPLETION') }}</h2>
@@ -10,4 +11,5 @@
     <p>
         <img src="{{ asset('/img/DE_DHSS-logo-red-wide.png') }}" />
     </p>
+</div>
 </div>

--- a/tests/fixtures/certificates/header-banner-award.blade.php
+++ b/tests/fixtures/certificates/header-banner-award.blade.php
@@ -1,0 +1,7 @@
+<div class="pb-1.5 pr-1.5 pl-1.5 mx-auto" style="background: #B5498F;">
+    <div style="background-image: url({{ asset('/img/home-visiting-header-certificate.png') }}); background-size: 60% auto; background-repeat: no-repeat; background-position: center center; background-color: #B5498F;">
+        <div style="min-height: 300px;"></div>
+    </div>
+    <p>{{ __('AWARDED TO:') }}</p>
+    <h1>{{ $user->name }}</h1>
+</div>

--- a/tests/fixtures/certificates/no-course-name.blade.php
+++ b/tests/fixtures/certificates/no-course-name.blade.php
@@ -1,0 +1,10 @@
+<div>
+    <p>{{ __('AWARDED TO:') }}</p>
+    <h1>{{ $user->name }}</h1>
+    <p class="text-balance">
+        This certificate recognizes your successful completion of the Family Support Specialist onboarding program.
+    </p>
+    <p>
+        <img src="{{ asset('/img/DPH_logo_family.png') }}" />
+    </p>
+</div>

--- a/tests/fixtures/certificates/signed-award.blade.php
+++ b/tests/fixtures/certificates/signed-award.blade.php
@@ -1,0 +1,8 @@
+<div>
+    <p>{{ __('This certifies that') }}</p>
+    <h1>{{ $user->name }}</h1>
+    <p>{{ __('has successfully completed') }} {{ $course->name }}</p>
+    <div class="signature-line">
+        <p class="signature-label">Authorized Signature</p>
+    </div>
+</div>

--- a/tests/fixtures/certificates/solid-border-award.blade.php
+++ b/tests/fixtures/certificates/solid-border-award.blade.php
@@ -1,0 +1,5 @@
+<div class="pb-1.5 pr-1.5 pl-1.5 mx-auto" style="background: #B5498F;">
+    <p>{{ __('AWARDED TO:') }}</p>
+    <h1>{{ $user->name }}</h1>
+    <p>{{ __('has successfully completed') }} {{ $course->name }}</p>
+</div>

--- a/upgrade.md
+++ b/upgrade.md
@@ -1,0 +1,1 @@
+See [UPGRADING.md](UPGRADING.md).


### PR DESCRIPTION
## Summary
- Course certificates are builder-only. `lms_courses.award` is dropped after every course is assigned a living `certificate_template_id`.
- `php artisan filament-lms:upgrade-awards` (`--dry-run`, `--force`, `--award=`, `--dump=`) converts award Blades to templates. `filament-lms:migrate-awards-to-templates` is a hidden alias.
- `php artisan migrate` runs `drop_award_from_lms_courses_table`: backfill, require the FK (`restrictOnDelete`), drop `award`.
- Courses without a template 404. New courses and SCORM imports default to **Default Certificate**.
- See `UPGRADING.md`.

## Test plan
- [ ] `php artisan filament-lms:upgrade-awards --dry-run`
- [ ] `php artisan migrate`
- [ ] Confirm every course has a template and `award` is gone
- [ ] Edit Course: template select is required; Create stays available
- [ ] Certificate show/download uses the builder view
- [ ] `--force` refreshes `{Label} Certificate` layouts only and does not retarget custom templates

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Breaking schema and certificate rendering path; migrate depends on installing filament-certificate-builder and successful backfill before `award` is dropped.
> 
> **Overview**
> **Breaking change:** course completion certificates no longer use per-course `award` Blade views or `config('filament-lms.awards')`. Courses now require a **`certificate_template_id`** tied to **tapp/filament-certificate-builder**, with new `integrations.certificate_builder` config and **UPGRADING.md** for the migration path.
> 
> **Data & upgrade:** migrations add `certificate_template_id`, then `drop_award_from_lms_courses_table` runs **`MigrateAwardsToCertificateTemplates`** (from legacy award Blades/config), enforces a non-null FK with **`restrictOnDelete`**, and drops **`award`**. **`filament-lms:upgrade-awards`** (`--dry-run`, `--force`, `--award=`, `--dump=`) previews or runs the conversion; a hidden alias remains for the old command name.
> 
> **Runtime & admin:** **`CertificateController`** renders the builder view with course/user token context and returns **404** when no template is assigned; **`CourseResource`** / **Edit Course** use a required template select plus create/edit template actions. New courses, factories, and SCORM imports default to **Default Certificate**. Certificate download on the completed page uses the **`filament-lms::certificates.download`** route.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6b12c0f98c801e12f8c88e3fd7b293589581ffcc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->