### PR TITLE
Course reporting scoped to tenant

### DIFF
--- a/src/Pages/Reporting.php
+++ b/src/Pages/Reporting.php
@@ -15,7 +15,6 @@ use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Auth;
-use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Gate;
 use Maatwebsite\Excel\Facades\Excel;
 use Tapp\FilamentLms\Exports\CourseProgressExport;
@@ -193,9 +192,7 @@ class Reporting extends Page implements HasTable
 
                 SelectFilter::make('user_id')
                     ->label('User')
-                    ->options(function () {
-                        return DB::table('users')->pluck('email', 'id')->toArray();
-                    })
+                    ->options(fn (): array => CourseProgressQueryService::reportUserFilterOptions())
                     ->searchable()
                     ->attribute('user_id'),
             ])

--- a/src/Services/CourseProgressQueryService.php
+++ b/src/Services/CourseProgressQueryService.php
@@ -2,10 +2,12 @@
 
 namespace Tapp\FilamentLms\Services;
 
+use Filament\Facades\Filament;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Query\Builder as QueryBuilder;
 use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\DB;
+use Tapp\FilamentLms\Helpers\TenantHelper;
 
 class CourseProgressQueryService
 {
@@ -46,8 +48,17 @@ class CourseProgressQueryService
             ->select('lms_step_user.user_id')
             ->selectRaw('l.course_id')
             ->join('lms_steps as s', 's.id', '=', 'lms_step_user.step_id')
-            ->join('lms_lessons as l', 'l.id', '=', 's.lesson_id')
-            ->distinct();
+            ->join('lms_lessons as l', 'l.id', '=', 's.lesson_id');
+
+        $tenantKey = self::currentTenantKey();
+
+        if ($tenantKey !== null) {
+            $column = TenantHelper::getTenantColumnName();
+            $participants->join('lms_courses as tenant_courses', 'tenant_courses.id', '=', 'l.course_id')
+                ->where("tenant_courses.{$column}", $tenantKey);
+        }
+
+        $participants->distinct();
 
         $select = array_merge(
             [
@@ -72,7 +83,7 @@ class CourseProgressQueryService
             ['lms_courses.id', 'lms_courses.name']
         );
 
-        return DB::table(DB::raw('('.$participants->toSql().') as participants'))
+        $query = DB::table(DB::raw('('.$participants->toSql().') as participants'))
             ->mergeBindings($participants)
             ->leftJoin('lms_course_user', function ($join): void {
                 $join->on('lms_course_user.user_id', '=', 'participants.user_id')
@@ -90,6 +101,51 @@ class CourseProgressQueryService
             ->groupBy($groupBy)
             ->orderBy('users.id', 'asc')
             ->orderBy('lms_courses.id', 'asc');
+
+        self::constrainCoursesToCurrentTenant($query, 'lms_courses');
+
+        return $query;
+    }
+
+    /**
+     * User emails for the report filter, limited to people who appear in the (tenant-scoped) report.
+     *
+     * @return array<int|string, string>
+     */
+    public static function reportUserFilterOptions(): array
+    {
+        return DB::query()
+            ->fromSub(self::buildQuery(), 'report')
+            ->orderBy('user_email')
+            ->pluck('user_email', 'user_id')
+            ->all();
+    }
+
+    /**
+     * @param  QueryBuilder  $query
+     */
+    private static function constrainCoursesToCurrentTenant($query, string $coursesAlias): void
+    {
+        $tenantKey = self::currentTenantKey();
+
+        if ($tenantKey === null) {
+            return;
+        }
+
+        $column = TenantHelper::getTenantColumnName();
+
+        $query->where("{$coursesAlias}.{$column}", $tenantKey);
+    }
+
+    private static function currentTenantKey(): mixed
+    {
+        if (! Config::get('filament-lms.tenancy.enabled')) {
+            return null;
+        }
+
+        $tenant = Filament::getTenant();
+
+        return $tenant?->getKey();
     }
 
     /**

--- a/tests/Feature/CourseProgressQueryServiceTest.php
+++ b/tests/Feature/CourseProgressQueryServiceTest.php
@@ -4,15 +4,21 @@ declare(strict_types=1);
 
 namespace Tapp\FilamentLms\Tests\Feature;
 
+use Filament\Facades\Filament;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
 use Tapp\FilamentLms\Models\Course;
 use Tapp\FilamentLms\Models\Document;
 use Tapp\FilamentLms\Models\Lesson;
 use Tapp\FilamentLms\Models\Step;
 use Tapp\FilamentLms\Services\CourseProgressQueryService;
+use Tapp\FilamentLms\Tests\TestTeam;
 use Tapp\FilamentLms\Tests\TestUser;
 
 beforeEach(function (): void {
     config(['filament-lms.user_model' => TestUser::class]);
+    config(['filament-lms.tenancy.enabled' => false]);
+    Filament::setTenant(null);
 });
 
 test('course progress query includes in-progress users who are not yet in lms_course_user', function (): void {
@@ -92,3 +98,108 @@ test('course progress query includes completed users with completed_at from pivo
     expect($rows->first()->steps_completed)->toBe(1);
     expect($rows->first()->total_steps)->toBe(1);
 });
+
+test('course progress query excludes other tenants when tenancy is enabled', function (): void {
+    enableLmsTenancyForTests();
+
+    $teamA = TestTeam::query()->create(['name' => 'Team A']);
+    $teamB = TestTeam::query()->create(['name' => 'Team B']);
+
+    $userA = createUserWithCourseProgress('tenant-a@example.com', 'Tenant A Course', $teamA->id);
+    createUserWithCourseProgress('tenant-b@example.com', 'Tenant B Course', $teamB->id);
+
+    $admin = TestUser::create([
+        'name' => 'Admin',
+        'first_name' => 'Admin',
+        'last_name' => 'User',
+        'email' => 'admin@example.com',
+        'password' => bcrypt('password'),
+    ]);
+
+    $this->actingAs($admin);
+    Filament::setTenant($teamA);
+
+    $rows = CourseProgressQueryService::buildQuery()->get();
+
+    expect($rows)->toHaveCount(1)
+        ->and((int) $rows->first()->user_id)->toBe($userA->id)
+        ->and($rows->first()->course_name)->toBe('Tenant A Course');
+
+    $userOptions = CourseProgressQueryService::reportUserFilterOptions();
+
+    expect($userOptions)->toHaveKey($userA->id)
+        ->and($userOptions)->not->toContain('tenant-b@example.com');
+});
+
+test('course progress query is unscoped when tenancy is enabled but no tenant is selected', function (): void {
+    enableLmsTenancyForTests();
+
+    $teamA = TestTeam::query()->create(['name' => 'Team A']);
+    $teamB = TestTeam::query()->create(['name' => 'Team B']);
+
+    createUserWithCourseProgress('open-a@example.com', 'Open A Course', $teamA->id);
+    createUserWithCourseProgress('open-b@example.com', 'Open B Course', $teamB->id);
+
+    $rows = CourseProgressQueryService::buildQuery()->get();
+
+    expect($rows)->toHaveCount(2);
+});
+
+function enableLmsTenancyForTests(): void
+{
+    $schema = Schema::connection((string) config('database.default'));
+
+    if (! $schema->hasTable('teams')) {
+        $schema->create('teams', function (Blueprint $table): void {
+            $table->id();
+            $table->string('name');
+            $table->timestamps();
+        });
+    }
+
+    foreach (['lms_courses', 'lms_lessons', 'lms_steps', 'lms_documents', 'lms_step_user'] as $tableName) {
+        if (! $schema->hasColumn($tableName, 'team_id')) {
+            $schema->table($tableName, function (Blueprint $blueprint): void {
+                $blueprint->unsignedBigInteger('team_id')->nullable();
+            });
+        }
+    }
+
+    config([
+        'filament-lms.tenancy.enabled' => true,
+        'filament-lms.tenancy.model' => TestTeam::class,
+        'filament-lms.tenancy.relationship_name' => 'team',
+        'filament-lms.tenancy.column' => 'team_id',
+    ]);
+}
+
+function createUserWithCourseProgress(string $email, string $courseName, int $teamId): TestUser
+{
+    $user = TestUser::create([
+        'name' => $email,
+        'first_name' => 'Learner',
+        'last_name' => $courseName,
+        'email' => $email,
+        'password' => bcrypt('password'),
+    ]);
+
+    $slug = str_replace(' ', '-', strtolower($courseName));
+    $document = Document::create(['name' => $courseName.' Doc', 'file_path' => '/tmp/doc.pdf']);
+    $course = Course::factory()->create([
+        'name' => $courseName,
+        'slug' => $slug,
+        'external_id' => $slug,
+        'team_id' => $teamId,
+    ]);
+    $lesson = Lesson::factory()->create(['course_id' => $course->id, 'order' => 1]);
+    $step = Step::factory()->create([
+        'lesson_id' => $lesson->id,
+        'order' => 1,
+        'material_type' => 'document',
+        'material_id' => $document->id,
+    ]);
+
+    $step->complete($user);
+
+    return $user;
+}

--- a/tests/TestTeam.php
+++ b/tests/TestTeam.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tapp\FilamentLms\Tests;
+
+use Illuminate\Database\Eloquent\Model;
+
+class TestTeam extends Model
+{
+    protected $table = 'teams';
+
+    protected $guarded = [];
+}


### PR DESCRIPTION
# Details

Course reporting scoped to tenant.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes reporting data boundaries in multi-tenant setups; incorrect scoping could expose other tenants’ progress, though behavior is covered by new tests and reuses existing tenant column helpers.
> 
> **Overview**
> **Course completion reporting** now respects LMS tenancy: when `filament-lms.tenancy.enabled` is on and a Filament tenant is active, `CourseProgressQueryService::buildQuery()` only includes progress for courses belonging to that tenant (via `TenantHelper`’s tenant column). If tenancy is enabled but no tenant is selected, the report stays **unscoped** (all tenants), matching the new test expectation.
> 
> The **User** filter on the Reporting page no longer loads every user from `users`; it uses new `reportUserFilterOptions()`, which lists emails only for learners that appear in the (tenant-scoped) report query—so exports and filters stay aligned with the table.
> 
> Feature tests cover tenant isolation, filter options, and the no-tenant-selected case; a minimal `TestTeam` model supports tenancy in tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b0cee4b32b44cfc7570c98c5cb84967fa1adb72c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->