### PR TITLE
Change unique course fields per tenant

### DIFF
--- a/database/migrations/scope_lms_courses_unique_indexes_to_tenant.php.stub
+++ b/database/migrations/scope_lms_courses_unique_indexes_to_tenant.php.stub
@@ -51,39 +51,9 @@ return new class extends Migration
 
     public function down(): void
     {
-        if (! $this->shouldScopeUniqueIndexes()) {
-            return;
-        }
-
-        $tenantColumn = TenantHelper::getTenantColumnName();
-        $drop = [];
-        $add = [];
-
-        foreach ($this->columns as $column) {
-            if (Schema::hasIndex('lms_courses', [$tenantColumn, $column], 'unique')) {
-                $drop[] = $column;
-            }
-
-            if (! Schema::hasIndex('lms_courses', [$column], 'unique')) {
-                $add[] = $column;
-            }
-        }
-
-        if ($drop !== []) {
-            Schema::table('lms_courses', function (Blueprint $table) use ($drop, $tenantColumn): void {
-                foreach ($drop as $column) {
-                    $table->dropUnique([$tenantColumn, $column]);
-                }
-            });
-        }
-
-        if ($add !== []) {
-            Schema::table('lms_courses', function (Blueprint $table) use ($add): void {
-                foreach ($add as $column) {
-                    $table->unique($column);
-                }
-            });
-        }
+        // Do not restore global unique indexes. After this migration runs,
+        // two tenants may share a name, slug, or external_id; rolling back
+        // would drop tenant-scoped constraints and can fail to recreate globals.
     }
 
     private function shouldScopeUniqueIndexes(): bool

--- a/database/migrations/scope_lms_courses_unique_indexes_to_tenant.php.stub
+++ b/database/migrations/scope_lms_courses_unique_indexes_to_tenant.php.stub
@@ -1,0 +1,100 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+use Tapp\FilamentLms\Helpers\TenantHelper;
+
+return new class extends Migration
+{
+    /**
+     * @var list<string>
+     */
+    private array $columns = ['name', 'slug', 'external_id'];
+
+    public function up(): void
+    {
+        if (! $this->shouldScopeUniqueIndexes()) {
+            return;
+        }
+
+        $tenantColumn = TenantHelper::getTenantColumnName();
+        $drop = [];
+        $add = [];
+
+        foreach ($this->columns as $column) {
+            if (Schema::hasIndex('lms_courses', [$column], 'unique')) {
+                $drop[] = $column;
+            }
+
+            if (! Schema::hasIndex('lms_courses', [$tenantColumn, $column], 'unique')) {
+                $add[] = $column;
+            }
+        }
+
+        if ($drop !== []) {
+            Schema::table('lms_courses', function (Blueprint $table) use ($drop): void {
+                foreach ($drop as $column) {
+                    $table->dropUnique([$column]);
+                }
+            });
+        }
+
+        if ($add !== []) {
+            Schema::table('lms_courses', function (Blueprint $table) use ($add, $tenantColumn): void {
+                foreach ($add as $column) {
+                    $table->unique([$tenantColumn, $column]);
+                }
+            });
+        }
+    }
+
+    public function down(): void
+    {
+        if (! $this->shouldScopeUniqueIndexes()) {
+            return;
+        }
+
+        $tenantColumn = TenantHelper::getTenantColumnName();
+        $drop = [];
+        $add = [];
+
+        foreach ($this->columns as $column) {
+            if (Schema::hasIndex('lms_courses', [$tenantColumn, $column], 'unique')) {
+                $drop[] = $column;
+            }
+
+            if (! Schema::hasIndex('lms_courses', [$column], 'unique')) {
+                $add[] = $column;
+            }
+        }
+
+        if ($drop !== []) {
+            Schema::table('lms_courses', function (Blueprint $table) use ($drop, $tenantColumn): void {
+                foreach ($drop as $column) {
+                    $table->dropUnique([$tenantColumn, $column]);
+                }
+            });
+        }
+
+        if ($add !== []) {
+            Schema::table('lms_courses', function (Blueprint $table) use ($add): void {
+                foreach ($add as $column) {
+                    $table->unique($column);
+                }
+            });
+        }
+    }
+
+    private function shouldScopeUniqueIndexes(): bool
+    {
+        if (! config('filament-lms.tenancy.enabled')) {
+            return false;
+        }
+
+        $tenantColumn = TenantHelper::getTenantColumnName();
+
+        return Schema::hasTable('lms_courses')
+            && Schema::hasColumn('lms_courses', $tenantColumn);
+    }
+};

--- a/src/FilamentLmsServiceProvider.php
+++ b/src/FilamentLmsServiceProvider.php
@@ -72,6 +72,7 @@ class FilamentLmsServiceProvider extends PackageServiceProvider
                 'create_lms_course_user_group_table',
                 'create_lms_user_group_memberships_table',
                 'add_is_explicitly_assigned_to_lms_course_user_table',
+                'scope_lms_courses_unique_indexes_to_tenant',
             ])
             ->hasCommand(BackfillCourseCompletedAt::class)
             ->hasCommand(BackfillEmbeddedPlayerCourses::class)

--- a/src/Resources/CourseResource.php
+++ b/src/Resources/CourseResource.php
@@ -83,13 +83,13 @@ class CourseResource extends Resource
                             $set('external_id', Str::slug($state ?? '', '_'));
                         }
                     })
-                    ->unique(ignoreRecord: true)
+                    ->scopedUnique(ignoreRecord: true)
                     ->required(),
                 TextInput::make('external_id')
                     ->label('External ID')
                     ->helperText('Used for external integrations like HubSpot. Updating this will cause a new property to be added to the integration.')
                     ->required()
-                    ->unique(ignoreRecord: true)
+                    ->scopedUnique(ignoreRecord: true)
                     ->rules([
                         'regex:/^[a-z][a-z0-9_]*$/',
                         'max:100',
@@ -100,7 +100,7 @@ class CourseResource extends Resource
                     ]),
                 TextInput::make('slug')
                     ->helperText('Used for urls.')
-                    ->unique(ignoreRecord: true)
+                    ->scopedUnique(ignoreRecord: true)
                     ->required(),
                 SpatieMediaLibraryFileUpload::make('image')
                     ->helperText('Upload a course image.')

--- a/tests/Feature/ScopeLmsCoursesUniqueIndexesToTenantTest.php
+++ b/tests/Feature/ScopeLmsCoursesUniqueIndexesToTenantTest.php
@@ -3,6 +3,7 @@
 namespace Tapp\FilamentLms\Tests\Feature;
 
 use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
 
 test('scopes course unique indexes to the tenant column', function () {
@@ -41,4 +42,61 @@ test('does not change course unique indexes when tenancy is disabled', function 
     expect(Schema::hasIndex('lms_courses', ['name'], 'unique'))->toBeTrue()
         ->and(Schema::hasIndex('lms_courses', ['slug'], 'unique'))->toBeTrue()
         ->and(Schema::hasIndex('lms_courses', ['external_id'], 'unique'))->toBeTrue();
+});
+
+test('does not replace tenant unique indexes with global uniques on rollback', function () {
+    Schema::create('companies', function (Blueprint $table) {
+        $table->id();
+        $table->timestamps();
+    });
+
+    Schema::table('lms_courses', function (Blueprint $table) {
+        $table->foreignId('company_id')->nullable()->constrained('companies');
+    });
+
+    config([
+        'filament-lms.tenancy.enabled' => true,
+        'filament-lms.tenancy.column' => 'company_id',
+    ]);
+
+    $migration = require dirname(__DIR__, 2).'/database/migrations/scope_lms_courses_unique_indexes_to_tenant.php.stub';
+
+    $migration->up();
+
+    $alphaId = DB::table('companies')->insertGetId([
+        'created_at' => now(),
+        'updated_at' => now(),
+    ]);
+    $betaId = DB::table('companies')->insertGetId([
+        'created_at' => now(),
+        'updated_at' => now(),
+    ]);
+
+    DB::table('lms_courses')->insert([
+        [
+            'company_id' => $alphaId,
+            'name' => 'Shared Course Name',
+            'slug' => 'shared-course-slug',
+            'external_id' => 'shared-external-id',
+            'created_at' => now(),
+            'updated_at' => now(),
+        ],
+        [
+            'company_id' => $betaId,
+            'name' => 'Shared Course Name',
+            'slug' => 'shared-course-slug',
+            'external_id' => 'shared-external-id',
+            'created_at' => now(),
+            'updated_at' => now(),
+        ],
+    ]);
+
+    $migration->down();
+
+    expect(Schema::hasIndex('lms_courses', ['company_id', 'name'], 'unique'))->toBeTrue()
+        ->and(Schema::hasIndex('lms_courses', ['company_id', 'slug'], 'unique'))->toBeTrue()
+        ->and(Schema::hasIndex('lms_courses', ['company_id', 'external_id'], 'unique'))->toBeTrue()
+        ->and(Schema::hasIndex('lms_courses', ['name'], 'unique'))->toBeFalse()
+        ->and(Schema::hasIndex('lms_courses', ['slug'], 'unique'))->toBeFalse()
+        ->and(Schema::hasIndex('lms_courses', ['external_id'], 'unique'))->toBeFalse();
 });

--- a/tests/Feature/ScopeLmsCoursesUniqueIndexesToTenantTest.php
+++ b/tests/Feature/ScopeLmsCoursesUniqueIndexesToTenantTest.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Tapp\FilamentLms\Tests\Feature;
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+test('scopes course unique indexes to the tenant column', function () {
+    Schema::create('companies', function (Blueprint $table) {
+        $table->id();
+        $table->timestamps();
+    });
+
+    Schema::table('lms_courses', function (Blueprint $table) {
+        $table->foreignId('company_id')->nullable()->constrained('companies');
+    });
+
+    config([
+        'filament-lms.tenancy.enabled' => true,
+        'filament-lms.tenancy.column' => 'company_id',
+    ]);
+
+    $migration = require dirname(__DIR__, 2).'/database/migrations/scope_lms_courses_unique_indexes_to_tenant.php.stub';
+
+    $migration->up();
+    $migration->up();
+
+    expect(Schema::hasIndex('lms_courses', ['name'], 'unique'))->toBeFalse()
+        ->and(Schema::hasIndex('lms_courses', ['slug'], 'unique'))->toBeFalse()
+        ->and(Schema::hasIndex('lms_courses', ['external_id'], 'unique'))->toBeFalse()
+        ->and(Schema::hasIndex('lms_courses', ['company_id', 'name'], 'unique'))->toBeTrue()
+        ->and(Schema::hasIndex('lms_courses', ['company_id', 'slug'], 'unique'))->toBeTrue()
+        ->and(Schema::hasIndex('lms_courses', ['company_id', 'external_id'], 'unique'))->toBeTrue();
+});
+
+test('does not change course unique indexes when tenancy is disabled', function () {
+    $migration = require dirname(__DIR__, 2).'/database/migrations/scope_lms_courses_unique_indexes_to_tenant.php.stub';
+
+    $migration->up();
+
+    expect(Schema::hasIndex('lms_courses', ['name'], 'unique'))->toBeTrue()
+        ->and(Schema::hasIndex('lms_courses', ['slug'], 'unique'))->toBeTrue()
+        ->and(Schema::hasIndex('lms_courses', ['external_id'], 'unique'))->toBeTrue();
+});


### PR DESCRIPTION
# Details

Change unique course fields (`name`, `slug`, and `external_id`) per tenant.

```
php artisan vendor:publish --tag=filament-lms-migrations
php artisan migrate
```


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Schema migration changes uniqueness rules on a core table; misconfiguration or partial deploy could affect course creation, but behavior is gated on tenancy config and covered by tests.
> 
> **Overview**
> **Enables separate tenants to reuse the same course `name`, `slug`, and `external_id` without colliding**, aligning DB constraints and admin validation with multi-tenant LMS usage.
> 
> When tenancy is enabled and the tenant column exists on `lms_courses`, a new published migration drops global unique indexes on those three columns and adds composite uniques on `[tenant_column, column]`. The migration is idempotent on re-run, skips work when tenancy is off, and intentionally leaves `down()` empty so rollback does not try to restore global uniques after cross-tenant duplicates may exist.
> 
> **Course admin forms** now use `scopedUnique` instead of `unique` on `name`, `external_id`, and `slug` so Filament validation matches the tenant-scoped indexes. Feature tests cover index shape, no-op when tenancy is disabled, and rollback behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit febf57242c44d1318bd6d447dc4132ea3207380d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->